### PR TITLE
[Chore] Run only relevant tests

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -79,36 +79,15 @@ steps:
     retry: *retry_policy
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
-    label: ":jest: eslint-plugin unit tests"
+    label: ":typescript: Workspace linting"
     env:
-      TEST_TYPE: 'pkg:eslint-plugin:test'
+      TEST_TYPE: 'pkg:lint'
     if: build.branch != "main"
     retry: *retry_policy
 
   - command: .buildkite/scripts/pipelines/pipeline_test.sh
-    label: ":typescript: eui-theme-common linting"
+    label: ":jest: Workspace unit tests"
     env:
-      TEST_TYPE: 'pkg:eui-theme-common:lint'
-    if: build.branch != "main"
-    retry: *retry_policy
-
-  - command: .buildkite/scripts/pipelines/pipeline_test.sh
-    label: ":jest: eui-theme-common unit tests"
-    env:
-      TEST_TYPE: 'pkg:eui-theme-common:test'
-    if: build.branch != "main"
-    retry: *retry_policy
-
-  - command: .buildkite/scripts/pipelines/pipeline_test.sh
-    label: ":typescript: eui-theme-borealis linting"
-    env:
-      TEST_TYPE: 'pkg:eui-theme-borealis:lint'
-    if: build.branch != "main"
-    retry: *retry_policy
-
-  - command: .buildkite/scripts/pipelines/pipeline_test.sh
-    label: ":jest: eui-theme-borealis unit tests"
-    env:
-      TEST_TYPE: 'pkg:eui-theme-borealis:test'
+      TEST_TYPE: 'pkg:unit'
     if: build.branch != "main"
     retry: *retry_policy

--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -77,3 +77,38 @@ steps:
       - "cypress/videos/**/*.mp4"
     timeout_in_minutes: 45
     retry: *retry_policy
+
+  - command: .buildkite/scripts/pipelines/pipeline_test.sh
+    label: ":jest: eslint-plugin unit tests"
+    env:
+      TEST_TYPE: 'pkg:eslint-plugin:test'
+    if: build.branch != "main"
+    retry: *retry_policy
+
+  - command: .buildkite/scripts/pipelines/pipeline_test.sh
+    label: ":typescript: eui-theme-common linting"
+    env:
+      TEST_TYPE: 'pkg:eui-theme-common:lint'
+    if: build.branch != "main"
+    retry: *retry_policy
+
+  - command: .buildkite/scripts/pipelines/pipeline_test.sh
+    label: ":jest: eui-theme-common unit tests"
+    env:
+      TEST_TYPE: 'pkg:eui-theme-common:test'
+    if: build.branch != "main"
+    retry: *retry_policy
+
+  - command: .buildkite/scripts/pipelines/pipeline_test.sh
+    label: ":typescript: eui-theme-borealis linting"
+    env:
+      TEST_TYPE: 'pkg:eui-theme-borealis:lint'
+    if: build.branch != "main"
+    retry: *retry_policy
+
+  - command: .buildkite/scripts/pipelines/pipeline_test.sh
+    label: ":jest: eui-theme-borealis unit tests"
+    env:
+      TEST_TYPE: 'pkg:eui-theme-borealis:test'
+    if: build.branch != "main"
+    retry: *retry_policy

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -11,7 +11,12 @@
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "set_commit_status": true,
-      "skip_ci_on_only_changed": ["^.github/", "^wiki/"]
+      "skip_ci_on_only_changed": [
+        "^.github/",
+        "^wiki/",
+        "^packages/website/",
+        "^packages/docusaurus-"
+      ]
     },
     {
       "enabled": true,

--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -12,7 +12,7 @@
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "set_commit_status": true,
       "skip_ci_on_only_changed": [
-        "^.github/",
+        "^\\.github/",
         "^wiki/",
         "^packages/website/",
         "^packages/docusaurus-"

--- a/.buildkite/scripts/pipelines/pipeline_test.sh
+++ b/.buildkite/scripts/pipelines/pipeline_test.sh
@@ -112,13 +112,10 @@ case $TEST_TYPE in
 
   pkg:unit)
     echo "[TASK]: Running unit tests for all workspaces except @elastic/eui"
-    # @elastic/eui-test-helpers runs Playwright via its test-unit script and
-    # needs browsers that aren't installed in this image. Belongs in its own step.
     COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui build:workspaces && \
       yarn workspaces foreach -A -pi \
         --exclude '@elastic/eui' \
         --exclude '@elastic/eui-monorepo' \
-        --exclude '@elastic/eui-test-helpers' \
         run test-unit"
     ;;
 

--- a/.buildkite/scripts/pipelines/pipeline_test.sh
+++ b/.buildkite/scripts/pipelines/pipeline_test.sh
@@ -7,6 +7,40 @@ source .buildkite/scripts/common/utils.sh
 
 buildkite_analytics_vault="secret/ci/elastic-eui/buildkite-test-analytics"
 
+# Paths that don't affect the EUI test suite.
+# When a PR's diff is contained entirely within these paths,
+# the heavy EUI jobs (lint, unit:*, cypress:*) exit early below.
+# The lightweight per-package jobs always run.
+NON_EUI_PATHS_REGEXP='^(\.github/|wiki/|packages/(website|docusaurus-[^/]+|eslint-plugin)/)'
+
+is_eui_test_type() {
+  case "$1" in
+    lint|unit:ts|unit:tsx|unit:tsx:17|cypress:17|cypress:18|cypress:a11y) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+should_skip_eui_tests() {
+  local base_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
+  git fetch --no-tags --quiet origin "$base_branch" 2>/dev/null || return 1
+
+  local merge_base
+  merge_base=$(git merge-base "origin/$base_branch" HEAD 2>/dev/null) || return 1
+
+  local changed
+  changed=$(git diff --name-only "$merge_base" HEAD 2>/dev/null) || return 1
+
+  [[ -n "$changed" ]] || return 1
+  echo "$changed" | grep -qvE "$NON_EUI_PATHS_REGEXP" && return 1
+
+  return 0
+}
+
+if is_eui_test_type "$TEST_TYPE" && should_skip_eui_tests; then
+  echo "[SKIP]: Only non-EUI paths changed; skipping ${TEST_TYPE}"
+  exit 0
+fi
+
 DOCKER_OPTIONS=(
   -i --rm
   --env GIT_COMMITTER_NAME=test
@@ -65,6 +99,31 @@ case $TEST_TYPE in
   cypress:a11y)
     echo "[TASK]: Running Cypress accessibility tests against React 18"
     COMMAND="/opt/yarn*/bin/yarn --cwd packages/eui && yarn --cwd packages/eui build:workspaces && yarn --cwd packages/eui cypress install && yarn --cwd packages/eui run test-cypress-a11y --node-options=--max_old_space_size=2048"
+    ;;
+
+  pkg:eslint-plugin:test)
+    echo "[TASK]: Running @elastic/eslint-plugin-eui unit tests"
+    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eslint-plugin-eui test-unit"
+    ;;
+
+  pkg:eui-theme-common:lint)
+    echo "[TASK]: Linting @elastic/eui-theme-common"
+    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui-theme-common lint"
+    ;;
+
+  pkg:eui-theme-common:test)
+    echo "[TASK]: Running @elastic/eui-theme-common unit tests"
+    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui-theme-common test-unit"
+    ;;
+
+  pkg:eui-theme-borealis:lint)
+    echo "[TASK]: Linting @elastic/eui-theme-borealis"
+    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui-theme-borealis build:workspaces && yarn workspace @elastic/eui-theme-borealis lint"
+    ;;
+
+  pkg:eui-theme-borealis:test)
+    echo "[TASK]: Running @elastic/eui-theme-borealis unit tests"
+    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui-theme-borealis build:workspaces && yarn workspace @elastic/eui-theme-borealis test-unit"
     ;;
 
   *)

--- a/.buildkite/scripts/pipelines/pipeline_test.sh
+++ b/.buildkite/scripts/pipelines/pipeline_test.sh
@@ -112,10 +112,13 @@ case $TEST_TYPE in
 
   pkg:unit)
     echo "[TASK]: Running unit tests for all workspaces except @elastic/eui"
+    # @elastic/eui-test-helpers runs Playwright via its test-unit script and
+    # needs browsers that aren't installed in this image. Belongs in its own step.
     COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui build:workspaces && \
       yarn workspaces foreach -A -pi \
         --exclude '@elastic/eui' \
         --exclude '@elastic/eui-monorepo' \
+        --exclude '@elastic/eui-test-helpers' \
         run test-unit"
     ;;
 

--- a/.buildkite/scripts/pipelines/pipeline_test.sh
+++ b/.buildkite/scripts/pipelines/pipeline_test.sh
@@ -101,29 +101,22 @@ case $TEST_TYPE in
     COMMAND="/opt/yarn*/bin/yarn --cwd packages/eui && yarn --cwd packages/eui build:workspaces && yarn --cwd packages/eui cypress install && yarn --cwd packages/eui run test-cypress-a11y --node-options=--max_old_space_size=2048"
     ;;
 
-  pkg:eslint-plugin:test)
-    echo "[TASK]: Running @elastic/eslint-plugin-eui unit tests"
-    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eslint-plugin-eui test-unit"
+  pkg:lint)
+    echo "[TASK]: Linting all workspaces except @elastic/eui"
+    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui build:workspaces && \
+      yarn workspaces foreach -A -pi \
+        --exclude '@elastic/eui' \
+        --exclude '@elastic/eui-monorepo' \
+        run lint"
     ;;
 
-  pkg:eui-theme-common:lint)
-    echo "[TASK]: Linting @elastic/eui-theme-common"
-    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui-theme-common lint"
-    ;;
-
-  pkg:eui-theme-common:test)
-    echo "[TASK]: Running @elastic/eui-theme-common unit tests"
-    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui-theme-common test-unit"
-    ;;
-
-  pkg:eui-theme-borealis:lint)
-    echo "[TASK]: Linting @elastic/eui-theme-borealis"
-    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui-theme-borealis build:workspaces && yarn workspace @elastic/eui-theme-borealis lint"
-    ;;
-
-  pkg:eui-theme-borealis:test)
-    echo "[TASK]: Running @elastic/eui-theme-borealis unit tests"
-    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui-theme-borealis build:workspaces && yarn workspace @elastic/eui-theme-borealis test-unit"
+  pkg:unit)
+    echo "[TASK]: Running unit tests for all workspaces except @elastic/eui"
+    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui build:workspaces && \
+      yarn workspaces foreach -A -pi \
+        --exclude '@elastic/eui' \
+        --exclude '@elastic/eui-monorepo' \
+        run test-unit"
     ;;
 
   *)

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -9,8 +9,8 @@
   "private": true,
   "scripts": {
     "lint": "tsc --noEmit",
-    "test": "yarn lint && yarn test-unit",
-    "test-unit": "playwright test",
+    "test": "yarn lint && yarn test-e2e",
+    "test-e2e": "playwright test",
     "show-report": "playwright show-report"
   },
   "peerDependencies": {


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Closes https://github.com/elastic/eui-private/issues/451

The idea here is to add the missing Jest test suites to the CI and skip all the heavy EUI testing when we know the changes don't affect it (ESLint plugin, website, wiki etc.). Apparently, our CI cost is very low so the argument for this is mostly to save on our time.

The Dream™ would be a job per package (linting, Jest tests, E2E tests) but this requires a bigger CI re-architecture.

### QA instructions for reviewer

- [ ] Change in `.github/`, `wiki/`, `packages/website/`, `packages/docusaurus-theme/` or `packages/docusaurus-preset/` skips the whole test pipeline.
- [ ] Change in `packages/eslint-plugin/` skips the EUI jobs but still runs `Workspace unit tests` and `Workspace linting`.
- [ ] Change in `packages/eui-theme-borealis/` or `packages/eui-theme-common/` still runs the full EUI suite plus the workspace jobs.