### PR TITLE
[ESLint plugin] Remove auto-fix from tooltip_button_icon_wrap

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -200,18 +200,18 @@ Browser-native tooltips (the `title` prop) are unstyled, have no delay control, 
 
 The rule reports two situations:
 
-- **`title` prop is present** - remove it and use `<EuiToolTip content={…}>` instead. The rule auto-fixes by removing `title` and wrapping the button with `EuiToolTip` (or only removing `title` when the button is already wrapped).
-- **No `EuiToolTip` wrapper** - the button icon has no visible tooltip. The rule auto-fixes by wrapping the button with `<EuiToolTip content={ariaLabel}>` when `aria-label` is a static string or expression.
+- **`title` prop is present** - remove it and use `<EuiToolTip content={…}>` instead.
+- **No `EuiToolTip` wrapper** - the button icon has no visible tooltip. Wrap it with `<EuiToolTip content={ariaLabel}>`.
 
 Buttons with spread props (`{...props}`) are intentionally skipped when no `title` prop is explicitly present because their final prop set cannot be statically determined.
 
 #### Examples
 
 ```tsx
-// ✗ Bad - browser tooltip, not keyboard-accessible
+// ✗ Bad - browser tooltip
 <EuiButtonIcon title="Edit item" aria-label="Edit item" iconType="pencil" />
 
-// ✓ Fixed automatically
+// ✓ Good
 <EuiToolTip content="Edit item">
   <EuiButtonIcon aria-label="Edit item" iconType="pencil" />
 </EuiToolTip>
@@ -221,7 +221,7 @@ Buttons with spread props (`{...props}`) are intentionally skipped when no `titl
 // ✗ Bad - no tooltip for sighted users
 <EuiButtonIcon aria-label="Delete" iconType="trash" />
 
-// ✓ Fixed automatically
+// ✓ Good
 <EuiToolTip content="Delete">
   <EuiButtonIcon aria-label="Delete" iconType="trash" />
 </EuiToolTip>

--- a/packages/eslint-plugin/changelogs/upcoming/9695.md
+++ b/packages/eslint-plugin/changelogs/upcoming/9695.md
@@ -1,0 +1,1 @@
+- Removed auto-fix from `tooltip-button-icon-wrap` rule

--- a/packages/eslint-plugin/src/rules/a11y/tooltip_button_icon_wrap.test.ts
+++ b/packages/eslint-plugin/src/rules/a11y/tooltip_button_icon_wrap.test.ts
@@ -98,80 +98,52 @@ ruleTester.run('tooltip-button-icon-wrap', TooltipButtonIconWrap, {
   ],
   invalid: [
     {
-      name: 'standalone with aria-label — auto-wrap with string literal',
+      name: 'standalone with aria-label',
       code: dedent`
         <EuiButtonIcon aria-label="Edit item" iconType="pencil" />
-      `,
-      output: dedent`
-        <EuiToolTip content="Edit item">
-          <EuiButtonIcon aria-label="Edit item" iconType="pencil" />
-        </EuiToolTip>
       `,
       languageOptions,
       errors: [{ messageId: 'wrapWithEuiToolTip' }],
     },
     {
-      name: 'standalone with aria-label as expression — auto-wrap',
+      name: 'standalone with aria-label as expression',
       code: dedent`
         const label = "Delete";
         <EuiButtonIcon aria-label={label} iconType="trash" />
       `,
-      output: dedent`
-        const label = "Delete";
-        <EuiToolTip content={label}>
-          <EuiButtonIcon aria-label={label} iconType="trash" />
-        </EuiToolTip>
-      `,
       languageOptions,
       errors: [{ messageId: 'wrapWithEuiToolTip' }],
     },
     {
-      name: 'standalone without aria-label — warn only, no fix',
+      name: 'standalone without aria-label',
       code: dedent`
         <EuiButtonIcon iconType="pencil" />
       `,
-      output: null,
       languageOptions,
       errors: [{ messageId: 'wrapWithEuiToolTip' }],
     },
     {
-      name: 'title prop with string — remove title, wrap with EuiToolTip',
+      name: 'title prop with string',
       code: dedent`
         <EuiButtonIcon title="Edit item" aria-label="Edit item" iconType="pencil" />
-      `,
-      output: dedent`
-        <EuiToolTip content="Edit item">
-          <EuiButtonIcon aria-label="Edit item" iconType="pencil" />
-        </EuiToolTip>
       `,
       languageOptions,
       errors: [{ messageId: 'useEuiToolTipInsteadOfTitle' }],
     },
     {
-      name: 'title prop with expression — remove title, wrap with EuiToolTip',
+      name: 'title prop with expression',
       code: dedent`
         const label = "Edit item";
         <EuiButtonIcon title={label} aria-label={label} iconType="pencil" />
       `,
-      output: dedent`
-        const label = "Edit item";
-        <EuiToolTip content={label}>
-          <EuiButtonIcon aria-label={label} iconType="pencil" />
-        </EuiToolTip>
-      `,
       languageOptions,
       errors: [{ messageId: 'useEuiToolTipInsteadOfTitle' }],
     },
     {
-      name: 'title prop already wrapped — only remove title, no double wrap',
+      name: 'title prop already wrapped',
       code: dedent`
         <EuiToolTip content="Edit">
           <EuiButtonIcon title="Edit" aria-label="Edit" iconType="pencil" />
-        </EuiToolTip>
-      `,
-      output: dedent`
-        <EuiToolTip content="Edit">
-          <EuiButtonIcon aria-label="Edit" iconType="pencil" />
         </EuiToolTip>
       `,
       languageOptions,
@@ -182,11 +154,6 @@ ruleTester.run('tooltip-button-icon-wrap', TooltipButtonIconWrap, {
       code: dedent`
         <EuiButtonIcon {...props} title="Edit" iconType="pencil" />
       `,
-      output: dedent`
-        <EuiToolTip content="Edit">
-          <EuiButtonIcon {...props} iconType="pencil" />
-        </EuiToolTip>
-      `,
       languageOptions,
       errors: [{ messageId: 'useEuiToolTipInsteadOfTitle' }],
     },
@@ -194,11 +161,6 @@ ruleTester.run('tooltip-button-icon-wrap', TooltipButtonIconWrap, {
       name: 'title takes priority — does not also report wrapWithEuiToolTip',
       code: dedent`
         <EuiButtonIcon title="Delete" iconType="trash" />
-      `,
-      output: dedent`
-        <EuiToolTip content="Delete">
-          <EuiButtonIcon iconType="trash" />
-        </EuiToolTip>
       `,
       languageOptions,
       errors: [{ messageId: 'useEuiToolTipInsteadOfTitle' }],

--- a/packages/eslint-plugin/src/rules/a11y/tooltip_button_icon_wrap.ts
+++ b/packages/eslint-plugin/src/rules/a11y/tooltip_button_icon_wrap.ts
@@ -7,7 +7,6 @@
  */
 
 import { type TSESTree, ESLintUtils } from '@typescript-eslint/utils';
-import { removeAttribute } from '../../utils/remove_attr';
 import { hasSpread } from '../../utils/has_spread';
 
 const BUTTON_ICON = 'EuiButtonIcon';
@@ -56,7 +55,6 @@ export const TooltipButtonIconWrap = ESLintUtils.RuleCreator.withoutDocs({
         }
 
         let titleAttr: TSESTree.JSXAttribute | undefined;
-        let ariaLabelAttr: TSESTree.JSXAttribute | undefined;
 
         for (const attr of openingElement.attributes) {
           if (
@@ -65,37 +63,12 @@ export const TooltipButtonIconWrap = ESLintUtils.RuleCreator.withoutDocs({
           )
             continue;
           if (attr.name.name === 'title') titleAttr = attr;
-          if (attr.name.name === 'aria-label') ariaLabelAttr = attr;
         }
 
         if (titleAttr) {
-          const alreadyWrapped = isWrappedByTooltip(node);
-
           context.report({
             node: openingElement,
             messageId: 'useEuiToolTipInsteadOfTitle',
-            fix: titleAttr.value
-              ? (fixer) => {
-                  const titleValue = context.sourceCode.getText(
-                    titleAttr!.value as TSESTree.Node
-                  );
-                  const [removeStart, removeEnd] = removeAttribute(
-                    context,
-                    titleAttr!
-                  );
-                  if (alreadyWrapped) {
-                    return fixer.removeRange([removeStart, removeEnd]);
-                  }
-                  return [
-                    fixer.removeRange([removeStart, removeEnd]),
-                    fixer.insertTextBefore(
-                      node,
-                      `<${TOOLTIP} content=${titleValue}>\n  `
-                    ),
-                    fixer.insertTextAfter(node, `\n</${TOOLTIP}>`),
-                  ];
-                }
-              : undefined,
           });
 
           return;
@@ -108,20 +81,6 @@ export const TooltipButtonIconWrap = ESLintUtils.RuleCreator.withoutDocs({
           context.report({
             node: openingElement,
             messageId: 'wrapWithEuiToolTip',
-            fix: ariaLabelAttr?.value
-              ? (fixer) => {
-                  const ariaLabelValue = context.sourceCode.getText(
-                    ariaLabelAttr!.value as TSESTree.Node
-                  );
-                  return [
-                    fixer.insertTextBefore(
-                      node,
-                      `<${TOOLTIP} content=${ariaLabelValue}>\n  `
-                    ),
-                    fixer.insertTextAfter(node, `\n</${TOOLTIP}>`),
-                  ];
-                }
-              : undefined,
           });
         }
       },
@@ -132,17 +91,18 @@ export const TooltipButtonIconWrap = ESLintUtils.RuleCreator.withoutDocs({
     docs: {
       description: `Ensure ${BUTTON_ICON} is wrapped with ${TOOLTIP} for sighted users`,
     },
-    fixable: 'code',
     schema: [],
     messages: {
       useEuiToolTipInsteadOfTitle: [
         `Remove the \`title\` prop from ${BUTTON_ICON} and use ${TOOLTIP} instead.`,
         'Browser-native tooltips are unstyled, have no delay control and are not keyboard-accessible.',
         `Wrap with <${TOOLTIP} content={label}> and use \`aria-label\` for screen readers.`,
+        'If you want to skip the tooltip but are unsure, please ping or contact EUI team.',
       ].join(' '),
       wrapWithEuiToolTip: [
         `${BUTTON_ICON} has no visible tooltip for sighted users.`,
         `Wrap with <${TOOLTIP} content={ariaLabel}> using the button's \`aria-label\` as content.`,
+        'If you want to skip the tooltip but are unsure, please ping or contact EUI team.',
       ].join(' '),
     },
   },


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Kibana CI is automatically applying fixes once linter runs. We want to remove the auto-fix from the rule to avoid broken PRs. I'm addressing all cases myself (see [here](https://github.com/elastic/kibana/pull/268225#issuecomment-4555418140)).

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

- [x] Verify that tests pass locally (after https://github.com/elastic/eui/pull/9687 they will be evaluated in CI)
- [x] Verify that the rule is no longer auto-fixed