### PR TITLE
fix(EuiTable): Use `uuid` to generate unique header cell IDs

### DIFF
--- a/packages/eui/changelogs/upcoming/9698.md
+++ b/packages/eui/changelogs/upcoming/9698.md
@@ -1,3 +1,3 @@
 **Bug fixes**
 
-- Fixed `EuiTableHeaderCell` and `EuiTableHeaderCellCheckbox` throwing an error in jest test environments due to static mocking of `useGeneratedHtmlId`
+- Fixed `EuiTableHeaderCell` and `EuiTableHeaderCellCheckbox` throwing an error in Jest test environments due to static mocking of `useGeneratedHtmlId` by generating a stable, unique key with `uuidv4`

--- a/packages/eui/changelogs/upcoming/9698.md
+++ b/packages/eui/changelogs/upcoming/9698.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiTableHeaderCell` and `EuiTableHeaderCellCheckbox` throwing an error in jest test environments due to static mocking of `useGeneratedHtmlId`

--- a/packages/eui/src/components/table/store/use_unique_column_id.test.tsx
+++ b/packages/eui/src/components/table/store/use_unique_column_id.test.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => {
+    return jest.requireActual('uuid').v4();
+  }),
+}));
+
+import { testOnReactVersion } from '../../../test/internal';
+import { renderHook } from '../../../test/rtl';
+import { useEuiTableStoreUniqueColumnId } from './use_unique_column_id';
+
+describe('useEuiTableStoreUniqueColumnId()', () => {
+  testOnReactVersion(['18'])('returns a unique id', () => {
+    const { result } = renderHook(useEuiTableStoreUniqueColumnId);
+    expect(result.current).toEqual(':r0:');
+  });
+
+  testOnReactVersion(['17'])('returns a unique id', () => {
+    (uuidv4 as jest.MockedFunction<() => string>).mockReturnValue('uuid.v4()');
+
+    const { result } = renderHook(useEuiTableStoreUniqueColumnId);
+    expect(result.current).toEqual('uuid.v4()');
+  });
+});

--- a/packages/eui/src/components/table/store/use_unique_column_id.ts
+++ b/packages/eui/src/components/table/store/use_unique_column_id.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useId, useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+
+const useEuiTableStoreUniqueColumnIdFallback = () => {
+  const ref = useRef(uuidv4());
+  return ref.current;
+};
+
+/**
+ * Returns a stable unique column ID to be used when registering columns.
+ * It uses `React.useId()` when available and falls back to UUID v4 on React 17.
+ *
+ * This is needed so that static `uuid` mocks don't break column registration
+ * (at least in React 18+; in older versions this function would need
+ * to be mocked to return something unique, but stable).
+ * @internal
+ */
+export const useEuiTableStoreUniqueColumnId =
+  'useId' in React ? useId : useEuiTableStoreUniqueColumnIdFallback;

--- a/packages/eui/src/components/table/table.test.tsx
+++ b/packages/eui/src/components/table/table.test.tsx
@@ -6,11 +6,6 @@
  * Side Public License, v 1.
  */
 
-let mockIdCounter = 0;
-jest.mock('../../services/accessibility/html_id_generator', () => ({
-  useGeneratedHtmlId: () => `unique-id-${mockIdCounter++}`,
-}));
-
 import React from 'react';
 import { requiredProps } from '../../test/required_props';
 import { render } from '../../test/rtl';
@@ -25,10 +20,6 @@ import { EuiTableHeaderCell } from './table_header_cell';
 import { EUI_TABLE_CSS_CONTAINER_NAME } from './const';
 
 describe('EuiTable', () => {
-  beforeEach(() => {
-    mockIdCounter = 0;
-  });
-
   it('renders', () => {
     const { container } = render(
       <EuiTable {...requiredProps}>

--- a/packages/eui/src/components/table/table_header_cell.test.tsx
+++ b/packages/eui/src/components/table/table_header_cell.test.tsx
@@ -6,15 +6,18 @@
  * Side Public License, v 1.
  */
 
+import { v4 as uuidv4 } from 'uuid';
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => {
+    return jest.requireActual('uuid').v4();
+  }),
+}));
+
 import {
   createMockResizeObserverEntry,
   createResizeObserverMock,
 } from '../../test/internal';
-
-let mockIdCounter = 0;
-jest.mock('../../services/accessibility/html_id_generator', () => ({
-  useGeneratedHtmlId: () => `unique-id-${mockIdCounter++}`,
-}));
 
 import React, { PropsWithChildren, ReactElement } from 'react';
 import { requiredProps } from '../../test/required_props';
@@ -62,10 +65,6 @@ const renderInTableHeader = (cell: ReactElement) => {
 };
 
 describe('EuiTableHeaderCell', () => {
-  beforeEach(() => {
-    mockIdCounter = 0;
-  });
-
   it('renders', () => {
     const { getByRole } = renderInTableHeader(
       <EuiTableHeaderCell {...requiredProps}>children</EuiTableHeaderCell>
@@ -450,6 +449,10 @@ describe('EuiTableHeaderCell', () => {
     });
 
     it('registers column in the store on mount', () => {
+      (uuidv4 as jest.MockedFunction<() => string>).mockReturnValue(
+        'unique-id'
+      );
+
       const testStore = createEuiTableStore();
       useEuiTableColumnDataStoreMock.mockReturnValue(testStore);
 
@@ -458,7 +461,7 @@ describe('EuiTableHeaderCell', () => {
       renderInTableHeader(<EuiTableHeaderCell>Test</EuiTableHeaderCell>);
 
       expect(registerColumn).toHaveBeenCalledWith(
-        'unique-id-0',
+        'unique-id',
         expect.objectContaining<EuiTableStoreColumnData>({
           renderHeaderCellRef: expect.objectContaining({
             current: expect.any(Function),
@@ -478,9 +481,11 @@ describe('EuiTableHeaderCell', () => {
         <EuiTableHeaderCell>Test</EuiTableHeaderCell>
       );
 
+      const id = registerColumn.mock.lastCall![0];
+
       expect(registerColumn).toHaveBeenCalledTimes(1);
       expect(testStore.getColumns().size).toBe(1);
-      expect(testStore.getColumns().has('unique-id-0')).toBe(true);
+      expect(testStore.getColumns().has(id)).toBe(true);
 
       unmount();
 
@@ -488,7 +493,7 @@ describe('EuiTableHeaderCell', () => {
       // registerColumn() was called, which is tricky to mock, we just assert
       // on the store
       expect(testStore.getColumns().size).toBe(0);
-      expect(testStore.getColumns().has('unique-id-0')).toBe(false);
+      expect(testStore.getColumns().has(id)).toBe(false);
     });
 
     it('does not register or update widths when within sticky header', () => {
@@ -520,31 +525,37 @@ describe('EuiTableHeaderCell', () => {
       const testStore = createEuiTableStore();
       useEuiTableColumnDataStoreMock.mockReturnValue(testStore);
 
+      const registerColumn = jest.spyOn(testStore, 'registerColumn');
       const updateColumnWidth = jest.spyOn(testStore, 'updateColumnWidth');
 
       const { getByRole } = renderInTableHeader(
         <EuiTableHeaderCell>Test</EuiTableHeaderCell>
       );
 
+      const id = registerColumn.mock.lastCall![0];
+
       resizeObserverMock.triggerCallback([
         createMockResizeObserverEntry(getByRole('columnheader')),
       ]);
 
-      expect(updateColumnWidth).toHaveBeenCalledWith('unique-id-0', 500);
+      expect(updateColumnWidth).toHaveBeenCalledWith(id, 500);
     });
 
     it('updates column on every render', () => {
       const testStore = createEuiTableStore();
       useEuiTableColumnDataStoreMock.mockReturnValue(testStore);
 
+      const registerColumn = jest.spyOn(testStore, 'registerColumn');
       const updateColumn = jest.spyOn(testStore, 'updateColumn');
 
       const { rerender } = renderInTableHeader(
         <EuiTableHeaderCell>Test</EuiTableHeaderCell>
       );
 
+      const id = registerColumn.mock.lastCall![0];
+
       expect(updateColumn).toHaveBeenCalledWith(
-        'unique-id-0',
+        id,
         expect.objectContaining<EuiTableStoreColumnData>({
           renderHeaderCellRef: expect.objectContaining({
             current: expect.any(Function),
@@ -559,9 +570,7 @@ describe('EuiTableHeaderCell', () => {
       rerender(<EuiTableHeaderCell>Test</EuiTableHeaderCell>);
 
       expect(updateColumn).toHaveBeenCalledWith(
-        // The ID is stable between rerenders, but the simple number increment
-        // from the used mock shows something different
-        'unique-id-1',
+        id,
         expect.objectContaining<EuiTableStoreColumnData>({
           renderHeaderCellRef,
         })

--- a/packages/eui/src/components/table/table_header_cell.test.tsx
+++ b/packages/eui/src/components/table/table_header_cell.test.tsx
@@ -6,14 +6,6 @@
  * Side Public License, v 1.
  */
 
-import { v4 as uuidv4 } from 'uuid';
-
-jest.mock('uuid', () => ({
-  v4: jest.fn(() => {
-    return jest.requireActual('uuid').v4();
-  }),
-}));
-
 import {
   createMockResizeObserverEntry,
   createResizeObserverMock,
@@ -38,6 +30,7 @@ import { EuiTableWithinStickyHeaderProvider } from './sticky_header/context';
 import { EuiTableHeaderCell } from './table_header_cell';
 import type { EuiTableSharedWidthProps } from './types';
 import * as storeProviderModule from './store/provider';
+import * as useEuiTableStoreUniqueColumnIdModule from './store/use_unique_column_id';
 import {
   createEuiTableStore,
   EuiTableStore,
@@ -65,6 +58,15 @@ const renderInTableHeader = (cell: ReactElement) => {
 };
 
 describe('EuiTableHeaderCell', () => {
+  let useEuiTableStoreUniqueColumnIdSpy: jest.SpyInstance<string>;
+
+  beforeAll(() => {
+    useEuiTableStoreUniqueColumnIdSpy = jest.spyOn(
+      useEuiTableStoreUniqueColumnIdModule,
+      'useEuiTableStoreUniqueColumnId'
+    );
+  });
+
   it('renders', () => {
     const { getByRole } = renderInTableHeader(
       <EuiTableHeaderCell {...requiredProps}>children</EuiTableHeaderCell>
@@ -449,9 +451,7 @@ describe('EuiTableHeaderCell', () => {
     });
 
     it('registers column in the store on mount', () => {
-      (uuidv4 as jest.MockedFunction<() => string>).mockReturnValue(
-        'unique-id'
-      );
+      useEuiTableStoreUniqueColumnIdSpy.mockReturnValue('unique-id');
 
       const testStore = createEuiTableStore();
       useEuiTableColumnDataStoreMock.mockReturnValue(testStore);

--- a/packages/eui/src/components/table/table_header_cell.tsx
+++ b/packages/eui/src/components/table/table_header_cell.tsx
@@ -301,7 +301,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
 
       store.updateColumnWidth(storeCellIdRef.current, entry.contentRect.width);
     },
-    [store, storeCellIdRef]
+    [store]
   );
 
   useEffect(() => {
@@ -338,8 +338,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
 
       resizeObserver?.disconnect();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store, storeCellIdRef, isWithinStickyHeader]);
+  }, [store, isWithinStickyHeader, handleResize]);
 
   // Notify the store on every render so the sticky header stays in sync.
   // React's reconciliation will efficiently handle any duplicate renders.

--- a/packages/eui/src/components/table/table_header_cell.tsx
+++ b/packages/eui/src/components/table/table_header_cell.tsx
@@ -16,13 +16,13 @@ import React, {
   useRef,
 } from 'react';
 import classNames from 'classnames';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   useEuiMemoizedStyles,
   HorizontalAlignment,
   LEFT_ALIGNMENT,
 } from '../../services';
-import { useGeneratedHtmlId } from '../../services/accessibility/html_id_generator';
 import { EuiI18n } from '../i18n';
 import { EuiScreenReaderOnly } from '../accessibility';
 import { CommonProps, NoArgCallback } from '../common';
@@ -206,7 +206,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
 }) => {
   const selfRef = useRef<HTMLTableCellElement>(null);
 
-  const internalCellId = useGeneratedHtmlId();
+  const storeCellIdRef = useRef(uuidv4());
   const store = useEuiTableColumnDataStore();
   const isWithinStickyHeader = useEuiTableWithinStickyHeader();
 
@@ -299,9 +299,9 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
         return;
       }
 
-      store.updateColumnWidth(internalCellId, entry.contentRect.width);
+      store.updateColumnWidth(storeCellIdRef.current, entry.contentRect.width);
     },
-    [store, internalCellId]
+    [store, storeCellIdRef]
   );
 
   useEffect(() => {
@@ -315,7 +315,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       return;
     }
 
-    const unregisterColumn = store.registerColumn(internalCellId, {
+    const unregisterColumn = store.registerColumn(storeCellIdRef.current, {
       renderHeaderCellRef,
       // getBoundingClientRect is not the cheapest, but we call it only once
       currentWidth: selfRef.current.getBoundingClientRect().width,
@@ -339,7 +339,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       resizeObserver?.disconnect();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store, internalCellId, isWithinStickyHeader]);
+  }, [store, storeCellIdRef, isWithinStickyHeader]);
 
   // Notify the store on every render so the sticky header stays in sync.
   // React's reconciliation will efficiently handle any duplicate renders.
@@ -355,7 +355,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       return;
     }
 
-    store.updateColumn(internalCellId, {
+    store.updateColumn(storeCellIdRef.current, {
       renderHeaderCellRef,
     });
   });

--- a/packages/eui/src/components/table/table_header_cell.tsx
+++ b/packages/eui/src/components/table/table_header_cell.tsx
@@ -16,7 +16,6 @@ import React, {
   useRef,
 } from 'react';
 import classNames from 'classnames';
-import { v4 as uuidv4 } from 'uuid';
 
 import {
   useEuiMemoizedStyles,
@@ -47,6 +46,7 @@ import type {
 import { useEuiTableColumnDataStore } from './store/provider';
 import { useEuiTableWithinStickyHeader } from './sticky_header';
 import { EuiTableStoreRenderHeaderCell } from './store/store';
+import { useEuiTableStoreUniqueColumnId } from './store/use_unique_column_id';
 
 export type TableHeaderCellScope = (typeof HEADER_CELL_SCOPE)[number];
 
@@ -206,7 +206,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
 }) => {
   const selfRef = useRef<HTMLTableCellElement>(null);
 
-  const storeCellIdRef = useRef(uuidv4());
+  const storeCellId = useEuiTableStoreUniqueColumnId();
   const store = useEuiTableColumnDataStore();
   const isWithinStickyHeader = useEuiTableWithinStickyHeader();
 
@@ -299,9 +299,9 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
         return;
       }
 
-      store.updateColumnWidth(storeCellIdRef.current, entry.contentRect.width);
+      store.updateColumnWidth(storeCellId, entry.contentRect.width);
     },
-    [store]
+    [store, storeCellId]
   );
 
   useEffect(() => {
@@ -315,7 +315,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       return;
     }
 
-    const unregisterColumn = store.registerColumn(storeCellIdRef.current, {
+    const unregisterColumn = store.registerColumn(storeCellId, {
       renderHeaderCellRef,
       // getBoundingClientRect is not the cheapest, but we call it only once
       currentWidth: selfRef.current.getBoundingClientRect().width,
@@ -338,7 +338,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
 
       resizeObserver?.disconnect();
     };
-  }, [store, isWithinStickyHeader, handleResize]);
+  }, [store, isWithinStickyHeader, handleResize, storeCellId]);
 
   // Notify the store on every render so the sticky header stays in sync.
   // React's reconciliation will efficiently handle any duplicate renders.
@@ -354,7 +354,7 @@ export const EuiTableHeaderCell: FunctionComponent<EuiTableHeaderCellProps> = ({
       return;
     }
 
-    store.updateColumn(storeCellIdRef.current, {
+    store.updateColumn(storeCellId, {
       renderHeaderCellRef,
     });
   });

--- a/packages/eui/src/components/table/table_header_cell_checkbox.test.tsx
+++ b/packages/eui/src/components/table/table_header_cell_checkbox.test.tsx
@@ -6,14 +6,7 @@
  * Side Public License, v 1.
  */
 
-jest.mock('uuid', () => ({
-  v4: jest.fn(() => {
-    return jest.requireActual('uuid').v4();
-  }),
-}));
-
 import React, { PropsWithChildren, ReactElement } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import { requiredProps } from '../../test';
 import { render } from '../../test/rtl';
 
@@ -32,6 +25,7 @@ import {
   EuiTableStoreColumnData,
 } from './store/store';
 import * as storeProviderModule from './store/provider';
+import * as useEuiTableStoreUniqueColumnIdModule from './store/use_unique_column_id';
 import { EuiTableWithinStickyHeaderProvider } from './sticky_header/context';
 
 const renderInTableHeader = (cell: React.ReactElement) => {
@@ -171,6 +165,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
   });
 
   describe('store integration', () => {
+    let useEuiTableStoreUniqueColumnIdSpy: jest.SpyInstance<string>;
     let useEuiTableColumnDataStoreMock: jest.SpyInstance<EuiTableStore>;
 
     beforeEach(() => {
@@ -178,12 +173,15 @@ describe('EuiTableHeaderCellCheckbox', () => {
         storeProviderModule,
         'useEuiTableColumnDataStore'
       );
+
+      useEuiTableStoreUniqueColumnIdSpy = jest.spyOn(
+        useEuiTableStoreUniqueColumnIdModule,
+        'useEuiTableStoreUniqueColumnId'
+      );
     });
 
     it('registers column in the store on mount', () => {
-      (uuidv4 as jest.MockedFunction<() => string>).mockReturnValue(
-        'unique-id'
-      );
+      useEuiTableStoreUniqueColumnIdSpy.mockReturnValue('unique-id');
 
       const testStore = createEuiTableStore();
       useEuiTableColumnDataStoreMock.mockReturnValue(testStore);

--- a/packages/eui/src/components/table/table_header_cell_checkbox.test.tsx
+++ b/packages/eui/src/components/table/table_header_cell_checkbox.test.tsx
@@ -6,12 +6,14 @@
  * Side Public License, v 1.
  */
 
-let mockIdCounter = 0;
-jest.mock('../../services/accessibility/html_id_generator', () => ({
-  useGeneratedHtmlId: () => `unique-id-${mockIdCounter++}`,
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => {
+    return jest.requireActual('uuid').v4();
+  }),
 }));
 
 import React, { PropsWithChildren, ReactElement } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { requiredProps } from '../../test';
 import { render } from '../../test/rtl';
 
@@ -53,10 +55,6 @@ const renderInTableHeader = (cell: React.ReactElement) => {
 };
 
 describe('EuiTableHeaderCellCheckbox', () => {
-  beforeEach(() => {
-    mockIdCounter = 0;
-  });
-
   test('is rendered', () => {
     const { container } = renderInTableHeader(
       <EuiTableHeaderCellCheckbox {...requiredProps} />
@@ -183,6 +181,10 @@ describe('EuiTableHeaderCellCheckbox', () => {
     });
 
     it('registers column in the store on mount', () => {
+      (uuidv4 as jest.MockedFunction<() => string>).mockReturnValue(
+        'unique-id'
+      );
+
       const testStore = createEuiTableStore();
       useEuiTableColumnDataStoreMock.mockReturnValue(testStore);
 
@@ -193,7 +195,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
       );
 
       expect(registerColumn).toHaveBeenCalledWith(
-        'unique-id-0',
+        'unique-id',
         expect.objectContaining<EuiTableStoreColumnData>({
           renderHeaderCellRef: expect.objectContaining({
             current: expect.any(Function),
@@ -213,8 +215,11 @@ describe('EuiTableHeaderCellCheckbox', () => {
       );
 
       expect(registerColumn).toHaveBeenCalledTimes(1);
+
+      const id = registerColumn.mock.lastCall![0];
+
       expect(testStore.getColumns().size).toBe(1);
-      expect(testStore.getColumns().has('unique-id-0')).toBe(true);
+      expect(testStore.getColumns().has(id)).toBe(true);
 
       unmount();
 
@@ -222,7 +227,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
       // registerColumn() was called, which is tricky to mock, we just assert
       // on the store
       expect(testStore.getColumns().size).toBe(0);
-      expect(testStore.getColumns().has('unique-id-0')).toBe(false);
+      expect(testStore.getColumns().has(id)).toBe(false);
     });
 
     it('does not register or update widths when within sticky header', () => {
@@ -254,14 +259,17 @@ describe('EuiTableHeaderCellCheckbox', () => {
       const testStore = createEuiTableStore();
       useEuiTableColumnDataStoreMock.mockReturnValue(testStore);
 
+      const registerColumn = jest.spyOn(testStore, 'registerColumn');
       const updateColumn = jest.spyOn(testStore, 'updateColumn');
 
       const { rerender } = renderInTableHeader(
         <EuiTableHeaderCellCheckbox>Test</EuiTableHeaderCellCheckbox>
       );
 
+      const id = registerColumn.mock.lastCall![0];
+
       expect(updateColumn).toHaveBeenCalledWith(
-        'unique-id-0',
+        id,
         expect.objectContaining<EuiTableStoreColumnData>({
           renderHeaderCellRef: expect.objectContaining({
             current: expect.any(Function),
@@ -276,9 +284,7 @@ describe('EuiTableHeaderCellCheckbox', () => {
       rerender(<EuiTableHeaderCellCheckbox>Test</EuiTableHeaderCellCheckbox>);
 
       expect(updateColumn).toHaveBeenCalledWith(
-        // The ID is stable between rerenders, but the simple number increment
-        // from the used mock shows something different
-        'unique-id-1',
+        id,
         expect.objectContaining<EuiTableStoreColumnData>({
           renderHeaderCellRef,
         })

--- a/packages/eui/src/components/table/table_header_cell_checkbox.tsx
+++ b/packages/eui/src/components/table/table_header_cell_checkbox.tsx
@@ -14,9 +14,9 @@ import React, {
   useRef,
 } from 'react';
 import classNames from 'classnames';
+import { v4 as uuidv4 } from 'uuid';
 
 import { useEuiMemoizedStyles } from '../../services';
-import { useGeneratedHtmlId } from '../../services/accessibility/html_id_generator';
 import { CommonProps } from '../common';
 
 import { resolveWidthPropsAsStyle } from './utils';
@@ -53,7 +53,7 @@ export const EuiTableHeaderCellCheckbox: FunctionComponent<
     ...rest
   } = props;
 
-  const internalCellId = useGeneratedHtmlId();
+  const storeCellIdRef = useRef(uuidv4());
   const store = useEuiTableColumnDataStore();
   const isWithinStickyHeader = useEuiTableWithinStickyHeader();
 
@@ -91,15 +91,14 @@ export const EuiTableHeaderCellCheckbox: FunctionComponent<
       return;
     }
 
-    const unregisterColumn = store.registerColumn(internalCellId, {
+    const unregisterColumn = store.registerColumn(storeCellIdRef.current, {
       renderHeaderCellRef,
     });
 
     return () => {
       unregisterColumn();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [store, internalCellId, isWithinStickyHeader]);
+  }, [store, isWithinStickyHeader]);
 
   useEffect(() => {
     // Notify the store on every render so the sticky header stays in sync.
@@ -108,7 +107,7 @@ export const EuiTableHeaderCellCheckbox: FunctionComponent<
       return;
     }
 
-    store.updateColumn(internalCellId, {
+    store.updateColumn(storeCellIdRef.current, {
       renderHeaderCellRef,
     });
   });

--- a/packages/eui/src/components/table/table_header_cell_checkbox.tsx
+++ b/packages/eui/src/components/table/table_header_cell_checkbox.tsx
@@ -14,7 +14,6 @@ import React, {
   useRef,
 } from 'react';
 import classNames from 'classnames';
-import { v4 as uuidv4 } from 'uuid';
 
 import { useEuiMemoizedStyles } from '../../services';
 import { CommonProps } from '../common';
@@ -26,6 +25,7 @@ import type { EuiTableSharedWidthProps } from './types';
 import { useEuiTableColumnDataStore } from './store/provider';
 import { useEuiTableWithinStickyHeader } from './sticky_header';
 import { EuiTableStoreRenderHeaderCell } from './store/store';
+import { useEuiTableStoreUniqueColumnId } from './store/use_unique_column_id';
 
 export type EuiTableHeaderCellCheckboxScope =
   (typeof HEADER_CELL_SCOPE)[number];
@@ -53,7 +53,7 @@ export const EuiTableHeaderCellCheckbox: FunctionComponent<
     ...rest
   } = props;
 
-  const storeCellIdRef = useRef(uuidv4());
+  const storeCellId = useEuiTableStoreUniqueColumnId();
   const store = useEuiTableColumnDataStore();
   const isWithinStickyHeader = useEuiTableWithinStickyHeader();
 
@@ -91,14 +91,14 @@ export const EuiTableHeaderCellCheckbox: FunctionComponent<
       return;
     }
 
-    const unregisterColumn = store.registerColumn(storeCellIdRef.current, {
+    const unregisterColumn = store.registerColumn(storeCellId, {
       renderHeaderCellRef,
     });
 
     return () => {
       unregisterColumn();
     };
-  }, [store, isWithinStickyHeader]);
+  }, [store, isWithinStickyHeader, storeCellId]);
 
   useEffect(() => {
     // Notify the store on every render so the sticky header stays in sync.
@@ -107,7 +107,7 @@ export const EuiTableHeaderCellCheckbox: FunctionComponent<
       return;
     }
 
-    store.updateColumn(storeCellIdRef.current, {
+    store.updateColumn(storeCellId, {
       renderHeaderCellRef,
     });
   });


### PR DESCRIPTION
## Summary

This PR fixes a test environment issue with the changes introduced in #9682. Because of the way `useGeneratedHtmlId` is globally mocked through the `test-env` build, all rendered table header cells receive the same `unique-id` identifier, which causes EuiTableStore to throw column duplication errors.

This change replaces the usage with a direct `uuid/v4` call, which is preferable in this case. The identifier must be unique in all environments.

### API Changes

N/A

## Screenshots

N/A

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] ~🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ] ~💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [ ] ~🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~**Documentation:** {link to docs page(s)}~
- [ ] ~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->~

### QA instructions for reviewer

- [ ] Confirm the changes make sense and that CI is green

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [ ] ~**QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
