### PR TITLE
[EuiSpacer] Differentiate size l from m (24px instead of 16px)

### DIFF
--- a/packages/eui/changelogs/upcoming/9704.md
+++ b/packages/eui/changelogs/upcoming/9704.md
@@ -1,0 +1,1 @@
+- Updated `EuiSpacer` `l` size to be 24px (previously incorrectly matched the `m` size)


### PR DESCRIPTION
## Summary

Closes #9704.

Both `m` and `l` sizes on `EuiSpacer` were resolving to 16px. Changed `l` to use `calc(base * 1.5)` to ensure it renders at 24px.

### Checklist

- [x] PR has been opened against the correct base branch (main)
- [x] Changelog entry added