### PR TITLE
[AI] Add a CLAUDE.md redirect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,17 @@
 # AGENTS.md
 
+This is a Yarn v4 monorepo; packages live in [`packages/`](./packages/).
+
+## Wiki
+
 All contributor knowledge lives in the [wiki](./wiki/):
 
 - [Contributing to EUI](./wiki/contributing-to-eui/README.md) — start here.
 - [Consuming EUI](./wiki/consuming-eui/README.md) — for downstream projects.
 
-This is a Yarn v4 monorepo; packages live in [`packages/`](./packages/).
-
 If the wiki disagrees with this file, the wiki wins — open a PR to fix it.
+
+## Tools
+
+- Use the [`gh` CLI](https://cli.github.com/) when interacting with GitHub.
+- Use the [`bk` CLI](https://buildkite.com/docs/platform/cli) when interacting with Buildkite.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Claude Code only auto-loads `CLAUDE.md`, not `AGENTS.md` (see [docs](https://code.claude.com/docs/en/features-overview.md)). So we use an `@`-import directive to leverage the auto-load of `CLAUDE.md` but delegate to `AGENTS.md` to be tool-agnostic.

Additionally, we add 2 points about `bk` and `gh` CLI. Usually, agents don't know these exist and don't reach fr them by default. They do require authentication and may be annoying to external contributors. We'll see.