### PR TITLE
refactor(copy): migrate EuiCopy from class to function component

### DIFF
--- a/packages/eui/src/components/copy/copy.tsx
+++ b/packages/eui/src/components/copy/copy.tsx
@@ -5,117 +5,78 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
-import React, { Component, createRef, ReactElement, ReactNode } from 'react';
+import React, { useRef, useState, ReactElement, ReactNode } from 'react';
 import { CommonProps } from '../common';
 import { copyToClipboard } from '../../services';
 import { EuiScreenReaderOnly } from '../accessibility';
 import { EuiToolTip, EuiToolTipProps, type EuiToolTipRef } from '../tool_tip';
 
 export interface EuiCopyProps extends CommonProps {
-  /**
-   * Text that will be copied to clipboard when copy function is executed.
-   */
   textToCopy: string;
-  /**
-   * Tooltip message displayed before copy function is called.
-   */
   beforeMessage?: ReactNode;
-  /**
-   * Tooltip message displayed after copy function is called that lets the user know that
-   * 'textToCopy' has been copied to the clipboard.
-   */
   afterMessage?: ReactNode;
-  /**
-   * Function that must return a component. First argument is 'copy' function.
-   * Use your own logic to create the component that users interact with when triggering copy.
-   */
   children(copy: () => void): ReactElement;
-  /**
-   * Optional props to pass to the EuiToolTip component.
-   */
-  tooltipProps?: Partial<
+  tooltipProps?: Partial
     Omit<EuiToolTipProps, 'children' | 'content' | 'onMouseOut'>
   >;
 }
 
-interface EuiCopyState {
-  tooltipText: ReactNode;
-  isCopied: boolean;
-}
+export const EuiCopy = ({
+  textToCopy,
+  beforeMessage,
+  afterMessage = 'Copied',
+  children,
+  tooltipProps,
+}: EuiCopyProps) => {
+  const tooltipRef = useRef<EuiToolTipRef>(null);
+  const [tooltipText, setTooltipText] = useState<ReactNode>(beforeMessage);
+  const [isCopied, setIsCopied] = useState(false);
 
-export class EuiCopy extends Component<EuiCopyProps, EuiCopyState> {
-  static defaultProps = {
-    afterMessage: 'Copied',
-  };
-
-  private tooltipRef = createRef<EuiToolTipRef>();
-
-  constructor(props: EuiCopyProps) {
-    super(props);
-
-    this.state = {
-      tooltipText: this.props.beforeMessage,
-      isCopied: false,
-    };
-  }
-
-  copy = () => {
-    const isCopied = copyToClipboard(this.props.textToCopy);
-    if (isCopied) {
-      this.setState(
-        {
-          tooltipText: this.props.afterMessage,
-          isCopied: true,
-        },
-        // `EuiToolTip` suppresses showing when content is empty, so `EuiCopy`
-        // imperatively shows the tooltip after the post-copy state update.
-        () => {
-          this.tooltipRef.current?.showToolTip();
-        }
-      );
+  const copy = () => {
+    const copied = copyToClipboard(textToCopy);
+    if (copied) {
+      setTooltipText(afterMessage);
+      setIsCopied(true);
+      // `EuiToolTip` suppresses showing when content is empty, so `EuiCopy`
+      // imperatively shows the tooltip after the post-copy state update.
+      setTimeout(() => {
+        tooltipRef.current?.showToolTip();
+      }, 0);
     }
   };
 
-  resetTooltipText = () => {
-    this.setState({
-      tooltipText: this.props.beforeMessage,
-      isCopied: false,
-    });
+  const resetTooltipText = () => {
+    setTooltipText(beforeMessage);
+    setIsCopied(false);
   };
 
-  render() {
-    const { children, tooltipProps, afterMessage } = this.props;
-    const { tooltipText, isCopied } = this.state;
-
-    return (
-      <>
-        {/* See `src/components/tool_tip/tool_tip_anchor.tsx` for explanation of below eslint-disable */}
-        {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}
-        <EuiToolTip
-          ref={this.tooltipRef}
-          content={tooltipText}
-          onMouseOut={this.resetTooltipText}
-          {...tooltipProps}
-          onBlur={() => {
-            tooltipProps?.onBlur?.();
-            if (isCopied) this.resetTooltipText();
-          }}
-          disableScreenReaderOutput={
-            isCopied || !!tooltipProps?.disableScreenReaderOutput
-          }
-        >
-          {children(this.copy)}
-        </EuiToolTip>
-        {/* Stable `aria-live` region so VoiceOver/Safari announces reliably.
+  return (
+    <>
+      {/* See `src/components/tool_tip/tool_tip_anchor.tsx` for explanation of below eslint-disable */}
+      {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}
+      <EuiToolTip
+        ref={tooltipRef}
+        content={tooltipText}
+        onMouseOut={resetTooltipText}
+        {...tooltipProps}
+        onBlur={() => {
+          tooltipProps?.onBlur?.();
+          if (isCopied) resetTooltipText();
+        }}
+        disableScreenReaderOutput={
+          isCopied || !!tooltipProps?.disableScreenReaderOutput
+        }
+      >
+        {children(copy)}
+      </EuiToolTip>
+      {/* Stable `aria-live` region so VoiceOver/Safari announces reliably.
        `EuiScreenReaderLive` alternates `aria-live` between "off" and active which
         Safari ignores when attribute and content change in the same render. */}
-        <EuiScreenReaderOnly>
-          <div aria-live="assertive" aria-atomic="true">
-            {isCopied ? afterMessage : ''}
-          </div>
-        </EuiScreenReaderOnly>
-      </>
-    );
-  }
-}
+      <EuiScreenReaderOnly>
+        <div aria-live="assertive" aria-atomic="true">
+          {isCopied ? afterMessage : ''}
+        </div>
+      </EuiScreenReaderOnly>
+    </>
+  );
+};


### PR DESCRIPTION
Closes #9466

- Convert EuiCopy from class to function component
- Replace createRef with useRef
- Replace this.state with useState
- Replace static defaultProps with default parameter value