### PR TITLE
[EuiCallOut] Use resize observer instead of container queries

### DIFF
--- a/packages/eui/src/components/call_out/__snapshots__/call_out.test.tsx.snap
+++ b/packages/eui/src/components/call_out/__snapshots__/call_out.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`EuiCallOut is rendered 1`] = `
   style="--euiCallOutTypeColor: #0B64DD;"
 >
   <div
-    class="css-4ee039-wrapper"
+    class="css-1slkmya-wrapper"
   >
     <div
       class="css-wlziyu-body"
@@ -45,7 +45,7 @@ exports[`EuiCallOut props heading h1 is rendered 1`] = `
   style="--euiCallOutTypeColor: #0B64DD;"
 >
   <div
-    class="css-4ee039-wrapper"
+    class="css-1slkmya-wrapper"
   >
     <div
       class="css-wlziyu-body"
@@ -75,7 +75,7 @@ exports[`EuiCallOut props heading h2 is rendered 1`] = `
   style="--euiCallOutTypeColor: #0B64DD;"
 >
   <div
-    class="css-4ee039-wrapper"
+    class="css-1slkmya-wrapper"
   >
     <div
       class="css-wlziyu-body"
@@ -105,7 +105,7 @@ exports[`EuiCallOut props heading h3 is rendered 1`] = `
   style="--euiCallOutTypeColor: #0B64DD;"
 >
   <div
-    class="css-4ee039-wrapper"
+    class="css-1slkmya-wrapper"
   >
     <div
       class="css-wlziyu-body"
@@ -135,7 +135,7 @@ exports[`EuiCallOut props heading h4 is rendered 1`] = `
   style="--euiCallOutTypeColor: #0B64DD;"
 >
   <div
-    class="css-4ee039-wrapper"
+    class="css-1slkmya-wrapper"
   >
     <div
       class="css-wlziyu-body"
@@ -165,7 +165,7 @@ exports[`EuiCallOut props heading h5 is rendered 1`] = `
   style="--euiCallOutTypeColor: #0B64DD;"
 >
   <div
-    class="css-4ee039-wrapper"
+    class="css-1slkmya-wrapper"
   >
     <div
       class="css-wlziyu-body"
@@ -195,7 +195,7 @@ exports[`EuiCallOut props heading h6 is rendered 1`] = `
   style="--euiCallOutTypeColor: #0B64DD;"
 >
   <div
-    class="css-4ee039-wrapper"
+    class="css-1slkmya-wrapper"
   >
     <div
       class="css-wlziyu-body"
@@ -225,7 +225,7 @@ exports[`EuiCallOut props heading p is rendered 1`] = `
   style="--euiCallOutTypeColor: #0B64DD;"
 >
   <div
-    class="css-4ee039-wrapper"
+    class="css-1slkmya-wrapper"
   >
     <div
       class="css-wlziyu-body"

--- a/packages/eui/src/components/call_out/call_out.stories.tsx
+++ b/packages/eui/src/components/call_out/call_out.stories.tsx
@@ -17,14 +17,27 @@ import {
 import { LOKI_SELECTORS } from '../../../.storybook/loki';
 import { EuiButton } from '../button';
 import { EuiCallOut, EuiCallOutProps } from './call_out';
-import { EuiFlexGroup } from '../flex';
+import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiSpacer } from '../spacer';
 import { EuiText } from '../text';
+import { EuiPanel } from '../panel';
+import { EuiPopover } from '../popover';
+import { EuiTitle } from '../title';
 
 const title = 'Callout title';
 const text = 'A short callout text';
 const textLong =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.';
+const defaultActionProps = {
+  primary: {
+    children: 'Primary action',
+    onClick: action('primary onClick'),
+  },
+  secondary: {
+    children: 'Secondary action',
+    onClick: action('secondary onClick'),
+  },
+};
 
 const meta: Meta<EuiCallOutProps> = {
   title: 'Display/EuiCallOut',
@@ -88,16 +101,7 @@ export const WithActions: Story = {
   args: {
     title,
     text,
-    actionProps: {
-      primary: {
-        children: 'Primary action',
-        onClick: action('primary onClick'),
-      },
-      secondary: {
-        children: 'Secondary action',
-        onClick: action('secondary onClick'),
-      },
-    },
+    actionProps: defaultActionProps,
   },
 };
 
@@ -362,6 +366,106 @@ export const KitchenSinkCustomChildren: Story = {
         <br />
         <EuiCallOut {..._args} text="" />
       </>
+    );
+  },
+};
+
+export const WrapperKitchenSink: Story = {
+  tags: ['vrt-only'],
+  render: function Render() {
+    return (
+      <div>
+        <EuiTitle size="s">
+          <p>within EuiPanel</p>
+        </EuiTitle>
+
+        <EuiPanel>
+          <EuiCallOut
+            title={title}
+            text={textLong}
+            actionProps={defaultActionProps}
+          />
+        </EuiPanel>
+
+        <EuiSpacer size="xxl" />
+
+        <EuiTitle size="s">
+          <p>within EuiPopover</p>
+        </EuiTitle>
+
+        <EuiPopover
+          button={<EuiButton>Show popover</EuiButton>}
+          isOpen
+          anchorPosition="downCenter"
+          closePopover={() => {}}
+          aria-label="Popover containing a CallOut"
+        >
+          <EuiCallOut
+            title={title}
+            text={textLong}
+            actionProps={defaultActionProps}
+          />
+          <p>{textLong}</p>
+        </EuiPopover>
+
+        <div style={{ height: 250 }} />
+
+        <EuiPopover
+          button={<EuiButton>Show popover</EuiButton>}
+          isOpen
+          anchorPosition="downCenter"
+          closePopover={() => {}}
+          aria-label="Popover containing a CallOut"
+        >
+          <EuiCallOut
+            title={title}
+            text={textLong}
+            actionProps={defaultActionProps}
+          />
+        </EuiPopover>
+
+        <div style={{ height: 250 }} />
+
+        <EuiTitle size="s">
+          <p>within EuiFlexGroup</p>
+        </EuiTitle>
+
+        <EuiFlexGroup>
+          <EuiFlexItem grow={false}>
+            <EuiCallOut
+              title={title}
+              text={textLong}
+              actionProps={defaultActionProps}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiCallOut
+              title={title}
+              text={textLong}
+              actionProps={defaultActionProps}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+
+        <EuiSpacer size="xxl" />
+
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <EuiCallOut
+              title={title}
+              text={textLong}
+              actionProps={defaultActionProps}
+            />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiCallOut
+              title={title}
+              text={textLong}
+              actionProps={defaultActionProps}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </div>
     );
   },
 };

--- a/packages/eui/src/components/call_out/call_out.styles.ts
+++ b/packages/eui/src/components/call_out/call_out.styles.ts
@@ -14,46 +14,9 @@ import {
   preventForcedColors,
 } from '../../global_styling';
 import { UseEuiTheme } from '../../services';
-import { EuiCallOutSize } from './types';
 
 /** Maximum reading width for `text` and `children` slots. */
 const TEXT_MAX_WIDTH = 1200;
-const CONTAINER_NAME = 'euiCallOut';
-const CQC_LAYOUTS = ['superNarrow', 'wide'] as const;
-type EuiCallOutLayouts = (typeof CQC_LAYOUTS)[number];
-const CQC_BREAKPOINTS: Record<
-  EuiCallOutSize,
-  Record<EuiCallOutLayouts, string>
-> = {
-  s: {
-    superNarrow: '(max-width: 400px)',
-    wide: '(min-width: 800px)',
-  },
-  m: {
-    superNarrow: '(max-width: 600px)',
-    wide: '(min-width: 1000px)',
-  },
-};
-
-const withContainerQuery = ({
-  layout,
-  styles,
-}: {
-  layout: EuiCallOutLayouts;
-  styles: string;
-}) => {
-  return Object.keys(CQC_BREAKPOINTS)
-    .map(
-      (sizeKey) => `
-        @container ${CONTAINER_NAME}--${sizeKey} ${
-        CQC_BREAKPOINTS[sizeKey as EuiCallOutSize][layout]
-      } {
-          ${styles}
-        }
-      `
-    )
-    .join('\n');
-};
 
 export const euiCallOutStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
@@ -76,11 +39,9 @@ export const euiCallOutStyles = (euiThemeContext: UseEuiTheme) => {
 
   return {
     euiCallOut: css`
-      container-type: inline-size;
-      container-name: ${CONTAINER_NAME};
       position: relative;
       display: flex;
-      inline-size: 100%;
+      max-inline-size: 100%;
       align-items: center;
       border: ${euiTheme.border.width.thin} solid;
       border-radius: ${borderRadius};
@@ -104,14 +65,10 @@ export const euiCallOutStyles = (euiThemeContext: UseEuiTheme) => {
       }
 
       &:where([data-size='s']) {
-        container-name: ${CONTAINER_NAME} ${CONTAINER_NAME}--s;
-
         ${logicalShorthandCSS('padding', `${paddingSizes.s} ${paddingSizes.m}`)}
       }
 
       &:where([data-size='m']) {
-        container-name: ${CONTAINER_NAME} ${CONTAINER_NAME}--m;
-
         padding: ${paddingSizes.m};
       }
     `,
@@ -129,13 +86,10 @@ export const euiCallOutStyles = (euiThemeContext: UseEuiTheme) => {
         gap: ${euiTheme.size.m};
       }
 
-      ${withContainerQuery({
-        layout: 'wide',
-        styles: `
-            flex-direction: row;
-            gap: ${euiTheme.size.xxl};
-          `,
-      })}
+      &:where([data-layout='wide'] &) {
+        flex-direction: row;
+        gap: ${euiTheme.size.xxl};
+      }
     `,
     // handles icon + text layout
     body: css`
@@ -232,8 +186,7 @@ export const euiCallOutStyles = (euiThemeContext: UseEuiTheme) => {
         ${logicalCSS('margin-left', euiTheme.size.xl)}
       }
 
-      /* uses container query directly as it should apply generically independent of size */
-      @container ${CONTAINER_NAME} ${CQC_BREAKPOINTS.s.superNarrow} {
+      &:where([data-layout='superNarrow'] &) {
         flex-wrap: wrap;
 
         /* use full width actions */
@@ -243,15 +196,12 @@ export const euiCallOutStyles = (euiThemeContext: UseEuiTheme) => {
         }
       }
 
-      ${withContainerQuery({
-        layout: 'wide',
-        styles: `
-            ${logicalCSS('margin-left', '0')}
-            align-self: center;
-            flex-shrink: 0;
-            flex-direction: row-reverse;
-          `,
-      })}
+      &:where([data-layout='wide'] &) {
+        ${logicalCSS('margin-left', '0')}
+        align-self: center;
+        flex-shrink: 0;
+        flex-direction: row-reverse;
+      }
     `,
   };
 };

--- a/packages/eui/src/components/call_out/call_out.tsx
+++ b/packages/eui/src/components/call_out/call_out.tsx
@@ -26,6 +26,7 @@ import {
   type EuiNotificationIconType,
 } from '../notification_icon/notification_icon';
 
+import { useLayoutObserver } from './use_layout_observer';
 import {
   EuiCallOutAction,
   EuiCallOutActionPrimaryProps,
@@ -132,6 +133,11 @@ export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
   ) => {
     const { euiTheme } = useEuiTheme();
     const color = getCallOutColor(_color);
+
+    /* Uses resize observer to determine the container width/layout instead of native container queries,
+    because callouts can be placed in containers without defined size (absolute positioned, no-grow flex layout etc.)
+    where container queries would collapse by design instead of adjusting to the content dimensions. */
+    const panelRef = useLayoutObserver(size, ref);
 
     const borderColors = useEuiBorderColorCSS();
     const styles = useEuiMemoizedStyles(euiCallOutStyles);
@@ -307,7 +313,7 @@ export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
         // uses custom padding
         paddingSize="none"
         className={classes}
-        panelRef={ref}
+        panelRef={panelRef}
         grow={false}
         style={{ ...cssVariables, ...style }}
         data-size={size}

--- a/packages/eui/src/components/call_out/call_out.tsx
+++ b/packages/eui/src/components/call_out/call_out.tsx
@@ -10,7 +10,11 @@ import React, { forwardRef, HTMLAttributes, ReactNode, useMemo } from 'react';
 import classNames from 'classnames';
 import { _EuiThemeBorderColors, getTokenName } from '@elastic/eui-theme-common';
 
-import { useEuiMemoizedStyles, useEuiTheme } from '../../services';
+import {
+  useCombinedRefs,
+  useEuiMemoizedStyles,
+  useEuiTheme,
+} from '../../services';
 import { useEuiBorderColorCSS } from '../../global_styling';
 import { CommonProps, DataAttributeProps } from '../common';
 import { EuiIcon, IconType } from '../icon';
@@ -137,7 +141,8 @@ export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
     /* Uses resize observer to determine the container width/layout instead of native container queries,
     because callouts can be placed in containers without defined size (absolute positioned, no-grow flex layout etc.)
     where container queries would collapse by design instead of adjusting to the content dimensions. */
-    const panelRef = useLayoutObserver(size, ref);
+    const layoutRef = useLayoutObserver(size);
+    const panelRef = useCombinedRefs([layoutRef, ref]);
 
     const borderColors = useEuiBorderColorCSS();
     const styles = useEuiMemoizedStyles(euiCallOutStyles);

--- a/packages/eui/src/components/call_out/use_layout_observer.test.tsx
+++ b/packages/eui/src/components/call_out/use_layout_observer.test.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { act } from '@testing-library/react';
+
+import { render } from '../../test/rtl';
+import { createResizeObserverMock } from '../../test/internal';
+import { useLayoutObserver } from './use_layout_observer';
+
+jest.mock('../observer/resize_observer/resize_observer', () => ({
+  hasResizeObserver: true,
+}));
+
+const createMockEntry = (inlineSize: number): ResizeObserverEntry => ({
+  target: document.createElement('div'),
+  contentRect: new DOMRect(),
+  borderBoxSize: [{ inlineSize, blockSize: 100 }],
+  contentBoxSize: [],
+  devicePixelContentBoxSize: [],
+});
+
+const Component = ({ size }: { size: 's' | 'm' }) => {
+  const ref = useLayoutObserver(size);
+  return <div ref={ref} data-test-subj="element" />;
+};
+
+describe('useLayoutObserver', () => {
+  let resizeObserverMock: ReturnType<typeof createResizeObserverMock>;
+
+  beforeEach(() => {
+    resizeObserverMock = createResizeObserverMock();
+    global.ResizeObserver = resizeObserverMock.ResizeObserver;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a ResizeObserver on mount', () => {
+    render(<Component size="m" />);
+
+    expect(resizeObserverMock.ResizeObserver).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects the observer on unmount', () => {
+    const { unmount } = render(<Component size="m" />);
+    const observerInstance =
+      resizeObserverMock.ResizeObserver.mock.results[0]?.value;
+
+    unmount();
+
+    expect(observerInstance?.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-observes when size prop changes', () => {
+    const { rerender } = render(<Component size="s" />);
+    const firstObserver =
+      resizeObserverMock.ResizeObserver.mock.results[0]?.value;
+
+    rerender(<Component size="m" />);
+
+    expect(firstObserver?.disconnect).toHaveBeenCalledTimes(1);
+    expect(resizeObserverMock.ResizeObserver).toHaveBeenCalledTimes(2);
+  });
+
+  describe('data-layout attribute', () => {
+    describe('superNarrow (width <= 400)', () => {
+      it('sets data-layout="superNarrow" at the boundary (400)', () => {
+        const { getByTestSubject } = render(<Component size="m" />);
+        const element = getByTestSubject('element');
+
+        resizeObserverMock.triggerCallback([createMockEntry(400)]);
+
+        expect(element.getAttribute('data-layout')).toBe('superNarrow');
+      });
+
+      it('sets data-layout="superNarrow" below the boundary', () => {
+        const { getByTestSubject } = render(<Component size="m" />);
+        const element = getByTestSubject('element');
+
+        resizeObserverMock.triggerCallback([createMockEntry(200)]);
+
+        expect(element.getAttribute('data-layout')).toBe('superNarrow');
+      });
+    });
+
+    describe('wide breakpoint for size "s" (width >= 800)', () => {
+      it('sets data-layout="wide" at the boundary (800)', () => {
+        const { getByTestSubject } = render(<Component size="s" />);
+        const element = getByTestSubject('element');
+
+        resizeObserverMock.triggerCallback([createMockEntry(800)]);
+
+        expect(element.getAttribute('data-layout')).toBe('wide');
+      });
+
+      it('sets data-layout="wide" above the boundary', () => {
+        const { getByTestSubject } = render(<Component size="s" />);
+        const element = getByTestSubject('element');
+
+        resizeObserverMock.triggerCallback([createMockEntry(1200)]);
+
+        expect(element.getAttribute('data-layout')).toBe('wide');
+      });
+
+      it('removes data-layout for intermediate widths (401–799)', () => {
+        const { getByTestSubject } = render(<Component size="s" />);
+        const element = getByTestSubject('element');
+
+        act(() => {
+          element.setAttribute('data-layout', 'wide');
+        });
+
+        resizeObserverMock.triggerCallback([createMockEntry(600)]);
+
+        expect(element.hasAttribute('data-layout')).toBe(false);
+      });
+    });
+
+    describe('wide breakpoint for size "m" (width >= 1000)', () => {
+      it('sets data-layout="wide" at the boundary (1000)', () => {
+        const { getByTestSubject } = render(<Component size="m" />);
+        const element = getByTestSubject('element');
+
+        resizeObserverMock.triggerCallback([createMockEntry(1000)]);
+
+        expect(element.getAttribute('data-layout')).toBe('wide');
+      });
+
+      it('sets data-layout="wide" above the boundary', () => {
+        const { getByTestSubject } = render(<Component size="m" />);
+        const element = getByTestSubject('element');
+
+        resizeObserverMock.triggerCallback([createMockEntry(1400)]);
+
+        expect(element.getAttribute('data-layout')).toBe('wide');
+      });
+
+      it('removes data-layout for intermediate widths (401–999)', () => {
+        const { getByTestSubject } = render(<Component size="m" />);
+        const element = getByTestSubject('element');
+
+        act(() => {
+          element.setAttribute('data-layout', 'wide');
+        });
+
+        resizeObserverMock.triggerCallback([createMockEntry(700)]);
+
+        expect(element.hasAttribute('data-layout')).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/eui/src/components/call_out/use_layout_observer.ts
+++ b/packages/eui/src/components/call_out/use_layout_observer.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { useCallback, useEffect, useRef } from 'react';
+
+import { hasResizeObserver } from '../observer/resize_observer/resize_observer';
+import { EuiCallOutSize } from './types';
+
+const SUPER_NARROW_WIDTH = 400;
+const WIDE_BREAKPOINTS: Record<EuiCallOutSize, number> = {
+  s: 800,
+  m: 1000,
+};
+
+/**
+ * Observes the rendered width and sets `data-layout` on the root
+ * element so that CSS can respond to size changes.
+ *
+ * This is an alternative to native CSS container queries. Its purpose is to handle cases where
+ * container queries would collapse if the element is placed inside a container without a defined size.
+ */
+export const useLayoutObserver = (
+  size: EuiCallOutSize,
+  ref: React.ForwardedRef<HTMLDivElement>
+): ((node: HTMLDivElement | null) => void) => {
+  const elementRef = useRef<HTMLDivElement | null>(null);
+  const forwardedRefRef = useRef(ref);
+  forwardedRefRef.current = ref;
+
+  const panelRef = useCallback((node: HTMLDivElement | null) => {
+    elementRef.current = node;
+    const fRef = forwardedRefRef.current;
+    if (typeof fRef === 'function') {
+      fRef(node);
+    } else if (fRef) {
+      (fRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    }
+  }, []);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element || !hasResizeObserver) return;
+
+    const wide = WIDE_BREAKPOINTS[size];
+
+    const observer = new ResizeObserver(([entry]) => {
+      const width = entry.borderBoxSize[0].inlineSize;
+
+      if (width <= SUPER_NARROW_WIDTH) {
+        element.setAttribute('data-layout', 'superNarrow');
+      } else if (width >= wide) {
+        element.setAttribute('data-layout', 'wide');
+      } else {
+        element.removeAttribute('data-layout');
+      }
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [size]);
+
+  return panelRef;
+};

--- a/packages/eui/src/components/call_out/use_layout_observer.ts
+++ b/packages/eui/src/components/call_out/use_layout_observer.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useCallback, useEffect, useRef } from 'react';
+import { RefObject, useEffect, useRef } from 'react';
 
 import { hasResizeObserver } from '../observer/resize_observer/resize_observer';
 import { EuiCallOutSize } from './types';
@@ -25,25 +25,13 @@ const WIDE_BREAKPOINTS: Record<EuiCallOutSize, number> = {
  * container queries would collapse if the element is placed inside a container without a defined size.
  */
 export const useLayoutObserver = (
-  size: EuiCallOutSize,
-  ref: React.ForwardedRef<HTMLDivElement>
-): ((node: HTMLDivElement | null) => void) => {
-  const elementRef = useRef<HTMLDivElement | null>(null);
-  const forwardedRefRef = useRef(ref);
-  forwardedRefRef.current = ref;
-
-  const panelRef = useCallback((node: HTMLDivElement | null) => {
-    elementRef.current = node;
-    const fRef = forwardedRefRef.current;
-    if (typeof fRef === 'function') {
-      fRef(node);
-    } else if (fRef) {
-      (fRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
-    }
-  }, []);
+  size: EuiCallOutSize
+): RefObject<HTMLDivElement> => {
+  const elementRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const element = elementRef.current;
+
     if (!element || !hasResizeObserver) return;
 
     const wide = WIDE_BREAKPOINTS[size];
@@ -61,8 +49,9 @@ export const useLayoutObserver = (
     });
 
     observer.observe(element);
+
     return () => observer.disconnect();
   }, [size]);
 
-  return panelRef;
+  return elementRef;
 };

--- a/packages/eui/src/components/form/__snapshots__/form.test.tsx.snap
+++ b/packages/eui/src/components/form/__snapshots__/form.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`EuiForm renders with error callout when isInvalid is "true" 1`] = `
     tabindex="-1"
   >
     <div
-      class="css-4ee039-wrapper"
+      class="css-1slkmya-wrapper"
     >
       <div
         class="css-wlziyu-body"
@@ -73,7 +73,7 @@ exports[`EuiForm renders with error callout when isInvalid is "true" and has mul
     tabindex="-1"
   >
     <div
-      class="css-4ee039-wrapper"
+      class="css-1slkmya-wrapper"
     >
       <div
         class="css-wlziyu-body"
@@ -135,7 +135,7 @@ exports[`EuiForm renders with error callout when isInvalid is "true" and has one
     tabindex="-1"
   >
     <div
-      class="css-4ee039-wrapper"
+      class="css-1slkmya-wrapper"
     >
       <div
         class="css-wlziyu-body"


### PR DESCRIPTION
## Summary

This PR is a follow-up to https://github.com/elastic/eui/pull/9705, which updated `EuiCallOut` to use container queries to handle the responsive behavior of the action elements.

Because `EuiCallOut` is a somewhat general component that can be placed in different layout contexts, it might be placed in containers that have no intrinsic width which would lead the container query to collapse as it has no dimensions to align to (e.g. absolute positioned containers - like `<EuiPopover>` - or flex layouts with no width basis - like `<EuiFlexItem grow={false}>`


To prevent issues because of this, we instead use a minimal resize observer implementation `useLayoutObserver` that sets a `data-layout` attribute which CSS can target accordingly instead of the container query.

### API Changes

⚪ No API changes

## Screenshots

| Before         | After         |
| -------------- | ------------- |
| <img width="334" height="1059" alt="Screenshot 2026-06-19 at 09 17 38" src="https://github.com/user-attachments/assets/7fe3305d-fb1a-4f6d-91fc-17808b6ef767" /> | <img width="1087" height="760" alt="Screenshot 2026-06-19 at 09 19 08" src="https://github.com/user-attachments/assets/abe3e09f-564f-4354-8554-5a5b7ebbe7e0" /> |

For Callouts in general there are no visual changes expected.

| Before         | After         |
| -------------- | ------------- |
| <img width="384" height="197" alt="Screenshot 2026-06-18 at 15 20 36" src="https://github.com/user-attachments/assets/fb973da0-171f-4d74-9acf-0c15ba91f7d6" />| <img width="384" height="197" alt="Screenshot 2026-06-18 at 15 20 22" src="https://github.com/user-attachments/assets/dfd92cf5-bccf-4dab-92b5-dcf380ef5c9e" /> |
| <img width="945" height="151" alt="Screenshot 2026-06-18 at 15 19 29" src="https://github.com/user-attachments/assets/6be2fb11-b848-44a6-a88a-781eb2e97b10" /> | <img width="945" height="151" alt="Screenshot 2026-06-18 at 15 19 33" src="https://github.com/user-attachments/assets/0cb703e5-4881-4f18-b3b8-73ebdbe39199" /> |
| <img width="1090" height="108" alt="Screenshot 2026-06-18 at 15 21 15" src="https://github.com/user-attachments/assets/f1e5169d-ebef-40de-8e91-dde187db12a1" /> | <img width="1090" height="108" alt="Screenshot 2026-06-18 at 15 21 19" src="https://github.com/user-attachments/assets/eb4e894a-4445-42ca-9c15-6112339bd297" /> |

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None - internal change only (pre-rollout)

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [ ] verify that the responsive behavior ([storybook](https://eui.elastic.co/pr_9727/storybook/?path=/story/display-euicallout--playground)) behaves the same as with the previous container-query implementation ([storybook](https://eui.elastic.co/pr_9705/storybook/?path=/story/display-euicallout--with-actions&globals=colorMode:light))

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] ~~**QA:** Tested docs changes~~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] ~~**Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)~~
- [ ] ~~**Breaking changes:** Added `breaking change` label (if applicable)~~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
