### PR TITLE
[HIGH PRIO][Chore] Fix i18ntokens version and format

### DIFF
--- a/packages/eui/i18ntokens_changelog.json
+++ b/packages/eui/i18ntokens_changelog.json
@@ -1,4294 +1,4226 @@
 [
   {
-    version: '116.0.0',
-    changes: [
+    "version": "116.0.0",
+    "changes": [
       {
-        token: 'euiContextMenuPanelTitle.ariaLabel',
-        changeType: 'added',
-        value: 'Close current panel:',
-      },
-    ],
+        "token": "euiContextMenuPanelTitle.ariaLabel",
+        "changeType": "added",
+        "value": "Close current panel:"
+      }
+    ]
   },
   {
-    version: '114.1.0',
-    changes: [
+    "version": "114.1.0",
+    "changes": [
       {
-        token: 'euiSelectable.searchResults',
-        changeType: 'modified',
-        value:
-          "({\n  resultsLength\n}: {\n  resultsLength: number;\n}) => `${resultsLength} result${resultsLength === 1 ? '' : 's'} available`;",
-      },
-    ],
+        "token": "euiSelectable.searchResults",
+        "changeType": "modified",
+        "value": "({\n  resultsLength\n}: {\n  resultsLength: number;\n}) => `${resultsLength} result${resultsLength === 1 ? '' : 's'} available`;"
+      }
+    ]
   },
   {
-    version: '113.3.0',
-    changes: [
+    "version": "113.3.0",
+    "changes": [
       {
-        token: 'euiColorPicker.ariaLabel',
-        changeType: 'added',
-        value: 'Select a color',
-      },
-    ],
+        "token": "euiColorPicker.ariaLabel",
+        "changeType": "added",
+        "value": "Select a color"
+      }
+    ]
   },
   {
-    version: '113.1.0',
-    changes: [
+    "version": "113.1.0",
+    "changes": [
       {
-        token: 'euiFlyout.screenReaderNonModalDialog',
-        changeType: 'deleted',
+        "token": "euiFlyout.screenReaderNonModalDialog",
+        "changeType": "deleted"
       },
       {
-        token: 'euiFlyout.screenReaderNoOverlayMaskDialog',
-        changeType: 'added',
-        value: 'You are in a modal dialog. To close the dialog, press Escape.',
-      },
-    ],
+        "token": "euiFlyout.screenReaderNoOverlayMaskDialog",
+        "changeType": "added",
+        "value": "You are in a modal dialog. To close the dialog, press Escape."
+      }
+    ]
   },
   {
-    version: '112.0.0',
-    changes: [
+    "version": "112.0.0",
+    "changes": [
       {
-        token: 'euiTimeWindowButtons.invalidZoomInLabel',
-        changeType: 'added',
-        value: 'Cannot zoom in invalid time window',
+        "token": "euiTimeWindowButtons.invalidZoomInLabel",
+        "changeType": "added",
+        "value": "Cannot zoom in invalid time window"
       },
       {
-        token: 'euiTimeWindowButtons.cannotZoomInLabel',
-        changeType: 'added',
-        value: 'Cannot zoom in any further',
+        "token": "euiTimeWindowButtons.cannotZoomInLabel",
+        "changeType": "added",
+        "value": "Cannot zoom in any further"
       },
       {
-        token: 'euiTimeWindowButtons.zoomInLabel',
-        changeType: 'added',
-        value: 'Zoom in',
-      },
-    ],
+        "token": "euiTimeWindowButtons.zoomInLabel",
+        "changeType": "added",
+        "value": "Zoom in"
+      }
+    ]
   },
   {
-    version: '111.1.0',
-    changes: [
+    "version": "111.1.0",
+    "changes": [
       {
-        token: 'euiColumnSelector.dragHandleAriaLabel',
-        changeType: 'modified',
-        value: 'drag handle',
-      },
-    ],
+        "token": "euiColumnSelector.dragHandleAriaLabel",
+        "changeType": "modified",
+        "value": "drag handle"
+      }
+    ]
   },
   {
-    version: '111.0.0',
-    changes: [
+    "version": "111.0.0",
+    "changes": [
       {
-        token: 'euiBasicTable.tableCaptionWithPagination',
-        changeType: 'deleted',
+        "token": "euiBasicTable.tableCaptionWithPagination",
+        "changeType": "deleted"
       },
       {
-        token: 'euiBasicTable.tableAutoCaptionWithPagination',
-        changeType: 'deleted',
+        "token": "euiBasicTable.tableAutoCaptionWithPagination",
+        "changeType": "deleted"
       },
       {
-        token: 'euiBasicTable.tableSimpleAutoCaptionWithPagination',
-        changeType: 'deleted',
+        "token": "euiBasicTable.tableSimpleAutoCaptionWithPagination",
+        "changeType": "deleted"
       },
       {
-        token: 'euiBasicTable.tableAutoCaptionWithoutPagination',
-        changeType: 'deleted',
+        "token": "euiBasicTable.tableAutoCaptionWithoutPagination",
+        "changeType": "deleted"
       },
       {
-        token: 'euiBasicTable.caption.itemCountPart.withTotalItemCount',
-        changeType: 'added',
-        value: 'Showing {itemCount} of {totalItemCount} data rows.',
+        "token": "euiBasicTable.caption.itemCountPart.withTotalItemCount",
+        "changeType": "added",
+        "value": "Showing {itemCount} of {totalItemCount} data rows."
       },
       {
-        token: 'euiBasicTable.caption.paginationPart.withPageCount',
-        changeType: 'added',
-        value: 'Page {page} of {pageCount}.',
+        "token": "euiBasicTable.caption.paginationPart.withPageCount",
+        "changeType": "added",
+        "value": "Page {page} of {pageCount}."
       },
       {
-        token: 'euiBasicTable.caption.tableName',
-        changeType: 'added',
-        value: 'Data table',
+        "token": "euiBasicTable.caption.tableName",
+        "changeType": "added",
+        "value": "Data table"
       },
       {
-        token: 'euiBasicTable.caption.emptyState',
-        changeType: 'added',
-        value: '(empty)',
-      },
-    ],
+        "token": "euiBasicTable.caption.emptyState",
+        "changeType": "added",
+        "value": "(empty)"
+      }
+    ]
   },
   {
-    version: '110.0.0',
-    changes: [
+    "version": "110.0.0",
+    "changes": [
       {
-        token: 'euiFlyoutMenu.back',
-        changeType: 'added',
-        value: 'Back',
+        "token": "euiFlyoutMenu.back",
+        "changeType": "added",
+        "value": "Back"
       },
       {
-        token: 'euiFlyoutMenu.history',
-        changeType: 'added',
-        value: 'History',
+        "token": "euiFlyoutMenu.history",
+        "changeType": "added",
+        "value": "History"
       },
       {
-        token: 'euiFlyoutManaged.defaultTitle',
-        changeType: 'added',
-        value: 'Unknown Flyout',
-      },
-    ],
+        "token": "euiFlyoutManaged.defaultTitle",
+        "changeType": "added",
+        "value": "Unknown Flyout"
+      }
+    ]
   },
   {
-    version: '109.1.0',
-    changes: [
+    "version": "109.1.0",
+    "changes": [
       {
-        token: 'euiTimeWindowButtons.invalidShiftLabel',
-        changeType: 'added',
-        value: 'Cannot shift invalid time window',
+        "token": "euiTimeWindowButtons.invalidShiftLabel",
+        "changeType": "added",
+        "value": "Cannot shift invalid time window"
       },
       {
-        token: 'euiTimeWindowButtons.invalidZoomOutLabel',
-        changeType: 'added',
-        value: 'Cannot zoom out invalid time window',
+        "token": "euiTimeWindowButtons.invalidZoomOutLabel",
+        "changeType": "added",
+        "value": "Cannot zoom out invalid time window"
       },
       {
-        token: 'euiTimeWindowButtons.previousLabel',
-        changeType: 'added',
-        value: 'Previous',
+        "token": "euiTimeWindowButtons.previousLabel",
+        "changeType": "added",
+        "value": "Previous"
       },
       {
-        token: 'euiTimeWindowButtons.previousDescription',
-        changeType: 'added',
-        value: 'Previous {displayInterval}',
+        "token": "euiTimeWindowButtons.previousDescription",
+        "changeType": "added",
+        "value": "Previous {displayInterval}"
       },
       {
-        token: 'euiTimeWindowButtons.zoomOutLabel',
-        changeType: 'added',
-        value: 'Zoom out',
+        "token": "euiTimeWindowButtons.zoomOutLabel",
+        "changeType": "added",
+        "value": "Zoom out"
       },
       {
-        token: 'euiTimeWindowButtons.nextLabel',
-        changeType: 'added',
-        value: 'Next',
+        "token": "euiTimeWindowButtons.nextLabel",
+        "changeType": "added",
+        "value": "Next"
       },
       {
-        token: 'euiTimeWindowButtons.nextDescription',
-        changeType: 'added',
-        value: 'Next {displayInterval}',
-      },
-    ],
+        "token": "euiTimeWindowButtons.nextDescription",
+        "changeType": "added",
+        "value": "Next {displayInterval}"
+      }
+    ]
   },
   {
-    version: '106.4.0',
-    changes: [
+    "version": "106.4.0",
+    "changes": [
       {
-        token: 'euiModal.screenReaderModalDialog',
-        changeType: 'added',
-        value:
-          'You are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close.',
-      },
-    ],
+        "token": "euiModal.screenReaderModalDialog",
+        "changeType": "added",
+        "value": "You are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close."
+      }
+    ]
   },
   {
-    version: '106.2.0',
-    changes: [
+    "version": "106.2.0",
+    "changes": [
       {
-        token: 'euiDataGridCell.focusTrapEnteredExitPrompt',
-        changeType: 'added',
-        value: 'Press the Escape key to exit the cell.',
-      },
-    ],
+        "token": "euiDataGridCell.focusTrapEnteredExitPrompt",
+        "changeType": "added",
+        "value": "Press the Escape key to exit the cell."
+      }
+    ]
   },
   {
-    version: '106.1.0',
-    changes: [
+    "version": "106.1.0",
+    "changes": [
       {
-        token: 'euiMarkdownEditorFooter.showMarkdownHelp',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.showMarkdownHelp",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorFooter.syntaxTitle',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.syntaxTitle",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorFooter.mdSyntaxLink',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.mdSyntaxLink",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorFooter.syntaxModalDescriptionPrefix',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.syntaxModalDescriptionPrefix",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorFooter.syntaxModalDescriptionSuffix',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.syntaxModalDescriptionSuffix",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorFooter.closeButton',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.closeButton",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorFooter.syntaxPopoverDescription',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.syntaxPopoverDescription",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorHelpButton.mdSyntaxLink',
-        changeType: 'added',
-        value: 'GitHub flavored markdown',
+        "token": "euiMarkdownEditorHelpButton.mdSyntaxLink",
+        "changeType": "added",
+        "value": "GitHub flavored markdown"
       },
       {
-        token: 'euiMarkdownEditorHelpButton.syntaxTitle',
-        changeType: 'added',
-        value: 'Syntax help',
+        "token": "euiMarkdownEditorHelpButton.syntaxTitle",
+        "changeType": "added",
+        "value": "Syntax help"
       },
       {
-        token: 'euiMarkdownEditorHelpButton.showMarkdownHelp',
-        changeType: 'added',
-        value: 'Show markdown help',
+        "token": "euiMarkdownEditorHelpButton.showMarkdownHelp",
+        "changeType": "added",
+        "value": "Show markdown help"
       },
       {
-        token: 'euiMarkdownEditorHelpButton.syntaxModalDescriptionPrefix',
-        changeType: 'added',
-        value: 'This editor uses',
+        "token": "euiMarkdownEditorHelpButton.syntaxModalDescriptionPrefix",
+        "changeType": "added",
+        "value": "This editor uses"
       },
       {
-        token: 'euiMarkdownEditorHelpButton.syntaxModalDescriptionSuffix',
-        changeType: 'added',
-        value:
-          'You can also utilize these additional syntax plugins to add rich content to your text.',
+        "token": "euiMarkdownEditorHelpButton.syntaxModalDescriptionSuffix",
+        "changeType": "added",
+        "value": "You can also utilize these additional syntax plugins to add rich content to your text."
       },
       {
-        token: 'euiMarkdownEditorHelpButton.closeButton',
-        changeType: 'added',
-        value: 'Close',
+        "token": "euiMarkdownEditorHelpButton.closeButton",
+        "changeType": "added",
+        "value": "Close"
       },
       {
-        token: 'euiMarkdownEditorHelpButton.syntaxPopoverDescription',
-        changeType: 'added',
-        value: 'This editor uses',
-      },
-    ],
+        "token": "euiMarkdownEditorHelpButton.syntaxPopoverDescription",
+        "changeType": "added",
+        "value": "This editor uses"
+      }
+    ]
   },
   {
-    version: '106.0.0',
-    changes: [
+    "version": "106.0.0",
+    "changes": [
       {
-        token: 'euiFlyout.screenReaderFixedHeaders',
-        changeType: 'deleted',
+        "token": "euiFlyout.screenReaderFixedHeaders",
+        "changeType": "deleted"
       },
       {
-        token: 'euiFlyout.screenReaderFocusTrapShards',
-        changeType: 'added',
-        value:
-          'You can still continue tabbing through other global page landmarks.',
-      },
-    ],
+        "token": "euiFlyout.screenReaderFocusTrapShards",
+        "changeType": "added",
+        "value": "You can still continue tabbing through other global page landmarks."
+      }
+    ]
   },
   {
-    version: '104.1.0',
-    changes: [
+    "version": "104.1.0",
+    "changes": [
       {
-        token: 'euiSaturation.ariaLabel',
-        changeType: 'modified',
-        value: 'Select a color',
+        "token": "euiSaturation.ariaLabel",
+        "changeType": "modified",
+        "value": "Select a color"
       },
       {
-        token: 'euiSaturation.roleDescription',
-        changeType: 'added',
-        value: 'HSV color mode saturation and value 2-axis slider.',
+        "token": "euiSaturation.roleDescription",
+        "changeType": "added",
+        "value": "HSV color mode saturation and value 2-axis slider."
       },
       {
-        token: 'euiHue.ariaValueText',
-        changeType: 'added',
-        value: 'Hue',
+        "token": "euiHue.ariaValueText",
+        "changeType": "added",
+        "value": "Hue"
       },
       {
-        token: 'euiHue.ariaRoleDescription',
-        changeType: 'added',
-        value: 'Hue slider',
+        "token": "euiHue.ariaRoleDescription",
+        "changeType": "added",
+        "value": "Hue slider"
       },
       {
-        token: 'euiColorPicker.selectedColorLabel',
-        changeType: 'added',
-        value: 'Selected color',
-      },
-    ],
+        "token": "euiColorPicker.selectedColorLabel",
+        "changeType": "added",
+        "value": "Selected color"
+      }
+    ]
   },
   {
-    version: '98.2.0',
-    changes: [
+    "version": "98.2.0",
+    "changes": [
       {
-        token: 'euiCodeBlockFullScreen.ariaLabel',
-        changeType: 'added',
-        value: 'Expanded code block',
+        "token": "euiCodeBlockFullScreen.ariaLabel",
+        "changeType": "added",
+        "value": "Expanded code block"
       },
       {
-        token: 'euiCodeBlock.label',
-        changeType: 'added',
-        value: '{language} code block:',
-      },
-    ],
+        "token": "euiCodeBlock.label",
+        "changeType": "added",
+        "value": "{language} code block:"
+      }
+    ]
   },
   {
-    version: '98.1.0',
-    changes: [
+    "version": "98.1.0",
+    "changes": [
       {
-        token: 'euiFieldValueSelectionFilter.buttonLabelHint',
-        changeType: 'added',
-        value: 'Selection',
-      },
-    ],
+        "token": "euiFieldValueSelectionFilter.buttonLabelHint",
+        "changeType": "added",
+        "value": "Selection"
+      }
+    ]
   },
   {
-    version: '97.3.0',
-    changes: [
+    "version": "97.3.0",
+    "changes": [
       {
-        token: 'euiDisplaySelector.rowHeightLabel',
-        changeType: 'modified',
-        value: 'Lines per row',
+        "token": "euiDisplaySelector.rowHeightLabel",
+        "changeType": "modified",
+        "value": "Lines per row"
       },
       {
-        token: 'euiDisplaySelector.labelSingle',
-        changeType: 'deleted',
+        "token": "euiDisplaySelector.labelSingle",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDisplaySelector.labelAuto',
-        changeType: 'modified',
-        value: 'Auto',
+        "token": "euiDisplaySelector.labelAuto",
+        "changeType": "modified",
+        "value": "Auto"
       },
       {
-        token: 'euiDisplaySelector.labelCustom',
-        changeType: 'deleted',
+        "token": "euiDisplaySelector.labelCustom",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDisplaySelector.lineCountLabel',
-        changeType: 'deleted',
+        "token": "euiDisplaySelector.lineCountLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDisplaySelector.labelStatic',
-        changeType: 'added',
-        value: 'Static',
+        "token": "euiDisplaySelector.labelStatic",
+        "changeType": "added",
+        "value": "Static"
       },
       {
-        token: 'euiDisplaySelector.labelMax',
-        changeType: 'added',
-        value: 'Max',
-      },
-    ],
+        "token": "euiDisplaySelector.labelMax",
+        "changeType": "added",
+        "value": "Max"
+      }
+    ]
   },
   {
-    version: '97.0.0',
-    changes: [
+    "version": "97.0.0",
+    "changes": [
       {
-        token: 'euiExternalLinkIcon.ariaLabel',
-        changeType: 'deleted',
+        "token": "euiExternalLinkIcon.ariaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiExternalLinkIcon.newTarget.screenReaderOnlyText',
-        changeType: 'modified',
-        value: '(external, opens in a new tab or window)',
+        "token": "euiExternalLinkIcon.newTarget.screenReaderOnlyText",
+        "changeType": "modified",
+        "value": "(external, opens in a new tab or window)"
       },
       {
-        token: 'euiExternalLinkIcon.externalTarget.screenReaderOnlyText',
-        changeType: 'added',
-        value: '(external)',
-      },
-    ],
+        "token": "euiExternalLinkIcon.externalTarget.screenReaderOnlyText",
+        "changeType": "added",
+        "value": "(external)"
+      }
+    ]
   },
   {
-    version: '95.11.0',
-    changes: [
+    "version": "95.11.0",
+    "changes": [
       {
-        token: 'euiCollapsedItemActions.allActions',
-        changeType: 'modified',
-        value: 'All actions, row {index}',
+        "token": "euiCollapsedItemActions.allActions",
+        "changeType": "modified",
+        "value": "All actions, row {index}"
       },
       {
-        token: 'euiDataGridCell.position',
-        changeType: 'modified',
-        value: '{columnName}, column {columnIndex}, row {rowIndex}',
+        "token": "euiDataGridCell.position",
+        "changeType": "modified",
+        "value": "{columnName}, column {columnIndex}, row {rowIndex}"
       },
       {
-        token: 'euiCollapsedItemActions.allActionsTooltip',
-        changeType: 'added',
-        value: 'All actions',
+        "token": "euiCollapsedItemActions.allActionsTooltip",
+        "changeType": "added",
+        "value": "All actions"
       },
       {
-        token: 'euiColumnActions.unsort',
-        changeType: 'added',
-        value: 'Unsort {schemaLabel}',
-      },
-    ],
+        "token": "euiColumnActions.unsort",
+        "changeType": "added",
+        "value": "Unsort {schemaLabel}"
+      }
+    ]
   },
   {
-    version: '95.10.0',
-    changes: [
+    "version": "95.10.0",
+    "changes": [
       {
-        token: 'euiDataGridHeaderCell.headerActions',
-        changeType: 'deleted',
+        "token": "euiDataGridHeaderCell.headerActions",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGridCell.focusTrapExitPrompt',
-        changeType: 'added',
-        value: 'Exited cell content.',
+        "token": "euiDataGridCell.focusTrapExitPrompt",
+        "changeType": "added",
+        "value": "Exited cell content."
       },
       {
-        token: 'euiDataGridHeaderCell.actionsButtonAriaLabel',
-        changeType: 'added',
-        value: '{title}. Click to view column header actions.',
+        "token": "euiDataGridHeaderCell.actionsButtonAriaLabel",
+        "changeType": "added",
+        "value": "{title}. Click to view column header actions."
       },
       {
-        token: 'euiDataGridHeaderCell.actionsEnterKeyInstructions',
-        changeType: 'added',
-        value: "Press the Enter key to view this column's actions",
-      },
-    ],
+        "token": "euiDataGridHeaderCell.actionsEnterKeyInstructions",
+        "changeType": "added",
+        "value": "Press the Enter key to view this column's actions"
+      }
+    ]
   },
   {
-    version: '95.8.0',
-    changes: [
+    "version": "95.8.0",
+    "changes": [
       {
-        token: 'euiFieldSearch.clearSearchButtonLabel',
-        changeType: 'added',
-        value: 'Clear search input',
-      },
-    ],
+        "token": "euiFieldSearch.clearSearchButtonLabel",
+        "changeType": "added",
+        "value": "Clear search input"
+      }
+    ]
   },
   {
-    version: '95.5.0',
-    changes: [
+    "version": "95.5.0",
+    "changes": [
       {
-        token: 'euiRefreshInterval.legend',
-        changeType: 'deleted',
+        "token": "euiRefreshInterval.legend",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDatePopoverContent.nowTabContent',
-        changeType: 'modified',
-        value:
-          'Setting the time to "now" means that on every refresh this time will be set to the time of the refresh.',
+        "token": "euiDatePopoverContent.nowTabContent",
+        "changeType": "modified",
+        "value": "Setting the time to \"now\" means that on every refresh this time will be set to the time of the refresh."
       },
       {
-        token: 'euiQuickSelect.legendText',
-        changeType: 'deleted',
+        "token": "euiQuickSelect.legendText",
+        "changeType": "deleted"
       },
       {
-        token: 'euiRefreshInterval.toggleLabel',
-        changeType: 'added',
-        value: 'Refresh every',
+        "token": "euiRefreshInterval.toggleLabel",
+        "changeType": "added",
+        "value": "Refresh every"
       },
       {
-        token: 'euiRefreshInterval.toggleAriaLabel',
-        changeType: 'added',
-        value: 'Toggle refresh',
+        "token": "euiRefreshInterval.toggleAriaLabel",
+        "changeType": "added",
+        "value": "Toggle refresh"
       },
       {
-        token: 'euiRefreshInterval.valueAriaLabel',
-        changeType: 'added',
-        value: 'Refresh interval value',
+        "token": "euiRefreshInterval.valueAriaLabel",
+        "changeType": "added",
+        "value": "Refresh interval value"
       },
       {
-        token: 'euiRefreshInterval.unitsAriaLabel',
-        changeType: 'added',
-        value: 'Refresh interval units',
-      },
-    ],
+        "token": "euiRefreshInterval.unitsAriaLabel",
+        "changeType": "added",
+        "value": "Refresh interval units"
+      }
+    ]
   },
   {
-    version: '95.3.0',
-    changes: [
+    "version": "95.3.0",
+    "changes": [
       {
-        token: 'euiFilePicker.clearSelectedFiles',
-        changeType: 'deleted',
+        "token": "euiFilePicker.clearSelectedFiles",
+        "changeType": "deleted"
       },
       {
-        token: 'euiFilePicker.removeSelectedAriaLabel',
-        changeType: 'added',
-        value: 'Remove selected files',
-      },
-    ],
+        "token": "euiFilePicker.removeSelectedAriaLabel",
+        "changeType": "added",
+        "value": "Remove selected files"
+      }
+    ]
   },
   {
-    version: '95.0.0',
-    changes: [
+    "version": "95.0.0",
+    "changes": [
       {
-        token: 'euiBasicTable.deselectRows',
-        changeType: 'added',
-        value: 'Deselect rows',
-      },
-    ],
+        "token": "euiBasicTable.deselectRows",
+        "changeType": "added",
+        "value": "Deselect rows"
+      }
+    ]
   },
   {
-    version: '94.4.0',
-    changes: [
+    "version": "94.4.0",
+    "changes": [
       {
-        token: 'euiAbsoluteTab.dateFormatHint',
-        changeType: 'deleted',
+        "token": "euiAbsoluteTab.dateFormatHint",
+        "changeType": "deleted"
       },
       {
-        token: 'euiCollapsedNavButton.ariaLabelButtonIcon',
-        changeType: 'added',
-        value: '{title}, quick navigation menu',
+        "token": "euiCollapsedNavButton.ariaLabelButtonIcon",
+        "changeType": "added",
+        "value": "{title}, quick navigation menu"
       },
       {
-        token: 'euiAbsoluteTab.dateFormatButtonLabel',
-        changeType: 'added',
-        value: 'Parse date',
-      },
-    ],
+        "token": "euiAbsoluteTab.dateFormatButtonLabel",
+        "changeType": "added",
+        "value": "Parse date"
+      }
+    ]
   },
   {
-    version: '94.2.0',
-    changes: [
+    "version": "94.2.0",
+    "changes": [
       {
-        token: 'euiBasicTable.selectThisRow',
-        changeType: 'modified',
-        value: 'Select row {index}',
+        "token": "euiBasicTable.selectThisRow",
+        "changeType": "modified",
+        "value": "Select row {index}"
       },
       {
-        token: 'euiCollapsibleNavKibanaSolution.switcherTitle',
-        changeType: 'added',
-        value: 'Solution view',
+        "token": "euiCollapsibleNavKibanaSolution.switcherTitle",
+        "changeType": "added",
+        "value": "Solution view"
       },
       {
-        token: 'euiCollapsibleNavKibanaSolution.switcherAriaLabel',
-        changeType: 'added',
-        value: ' - click to switch to another solution',
+        "token": "euiCollapsibleNavKibanaSolution.switcherAriaLabel",
+        "changeType": "added",
+        "value": " - click to switch to another solution"
       },
       {
-        token: 'euiCollapsibleNavKibanaSolution.groupLabel',
-        changeType: 'added',
-        value: 'Navigate to solution',
-      },
-    ],
+        "token": "euiCollapsibleNavKibanaSolution.groupLabel",
+        "changeType": "added",
+        "value": "Navigate to solution"
+      }
+    ]
   },
   {
-    version: '93.6.0',
-    changes: [
+    "version": "93.6.0",
+    "changes": [
       {
-        token: 'euiFlyout.closeAriaLabel',
-        changeType: 'deleted',
+        "token": "euiFlyout.closeAriaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiLoadingChart.ariaLabel',
-        changeType: 'deleted',
+        "token": "euiLoadingChart.ariaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiFlyoutCloseButton.ariaLabel',
-        changeType: 'added',
-        value: 'Close this dialog',
-      },
-    ],
+        "token": "euiFlyoutCloseButton.ariaLabel",
+        "changeType": "added",
+        "value": "Close this dialog"
+      }
+    ]
   },
   {
-    version: '93.5.0',
-    changes: [
+    "version": "93.5.0",
+    "changes": [
       {
-        token: 'euiIconTip.defaultAriaLabel',
-        changeType: 'added',
-        value: 'Info',
-      },
-    ],
+        "token": "euiIconTip.defaultAriaLabel",
+        "changeType": "added",
+        "value": "Info"
+      }
+    ]
   },
   {
-    version: '93.2.0',
-    changes: [
+    "version": "93.2.0",
+    "changes": [
       {
-        token: 'euiSideNav.mobileToggleAriaLabel',
-        changeType: 'added',
-        value: 'Toggle navigation',
-      },
-    ],
+        "token": "euiSideNav.mobileToggleAriaLabel",
+        "changeType": "added",
+        "value": "Toggle navigation"
+      }
+    ]
   },
   {
-    version: '93.1.0',
-    changes: [
+    "version": "93.1.0",
+    "changes": [
       {
-        token: 'euiTreeView.ariaLabel',
-        changeType: 'deleted',
-      },
-    ],
+        "token": "euiTreeView.ariaLabel",
+        "changeType": "deleted"
+      }
+    ]
   },
   {
-    version: '93.0.0',
-    changes: [
+    "version": "93.0.0",
+    "changes": [
       {
-        token: 'euiTourStep.endTour',
-        changeType: 'deleted',
+        "token": "euiTourStep.endTour",
+        "changeType": "deleted"
       },
       {
-        token: 'euiTourStep.skipTour',
-        changeType: 'deleted',
+        "token": "euiTourStep.skipTour",
+        "changeType": "deleted"
       },
       {
-        token: 'euiTourStep.closeTour',
-        changeType: 'deleted',
+        "token": "euiTourStep.closeTour",
+        "changeType": "deleted"
       },
       {
-        token: 'euiTourFooter.endTour',
-        changeType: 'added',
-        value: 'End tour',
+        "token": "euiTourFooter.endTour",
+        "changeType": "added",
+        "value": "End tour"
       },
       {
-        token: 'euiTourFooter.skipTour',
-        changeType: 'added',
-        value: 'Skip tour',
+        "token": "euiTourFooter.skipTour",
+        "changeType": "added",
+        "value": "Skip tour"
       },
       {
-        token: 'euiTourFooter.closeTour',
-        changeType: 'added',
-        value: 'Close tour',
-      },
-    ],
+        "token": "euiTourFooter.closeTour",
+        "changeType": "added",
+        "value": "Close tour"
+      }
+    ]
   },
   {
-    version: '92.1.0',
-    changes: [
+    "version": "92.1.0",
+    "changes": [
       {
-        token: 'euiDataGridCell.expansionEnterPrompt',
-        changeType: 'added',
-        value: 'Press the Enter key to expand this cell.',
+        "token": "euiDataGridCell.expansionEnterPrompt",
+        "changeType": "added",
+        "value": "Press the Enter key to expand this cell."
       },
       {
-        token: 'euiDataGridCell.focusTrapEnterPrompt',
-        changeType: 'added',
-        value: "Press the Enter key to interact with this cell's contents.",
-      },
-    ],
+        "token": "euiDataGridCell.focusTrapEnterPrompt",
+        "changeType": "added",
+        "value": "Press the Enter key to interact with this cell's contents."
+      }
+    ]
   },
   {
-    version: '92.0.0',
-    changes: [
+    "version": "92.0.0",
+    "changes": [
       {
-        token: 'euiControlBar.screenReaderHeading',
-        changeType: 'deleted',
+        "token": "euiControlBar.screenReaderHeading",
+        "changeType": "deleted"
       },
       {
-        token: 'euiControlBar.customScreenReaderAnnouncement',
-        changeType: 'deleted',
+        "token": "euiControlBar.customScreenReaderAnnouncement",
+        "changeType": "deleted"
       },
       {
-        token: 'euiControlBar.screenReaderAnnouncement',
-        changeType: 'deleted',
+        "token": "euiControlBar.screenReaderAnnouncement",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventMessages.accordionButtonText',
-        changeType: 'deleted',
+        "token": "euiNotificationEventMessages.accordionButtonText",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventMessages.accordionAriaLabelButtonText',
-        changeType: 'deleted',
+        "token": "euiNotificationEventMessages.accordionAriaLabelButtonText",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventMessages.accordionHideText',
-        changeType: 'deleted',
+        "token": "euiNotificationEventMessages.accordionHideText",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventMeta.contextMenuButton',
-        changeType: 'deleted',
+        "token": "euiNotificationEventMeta.contextMenuButton",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventReadButton.markAsReadAria',
-        changeType: 'deleted',
+        "token": "euiNotificationEventReadButton.markAsReadAria",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventReadButton.markAsUnreadAria',
-        changeType: 'deleted',
+        "token": "euiNotificationEventReadButton.markAsUnreadAria",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventReadButton.markAsRead',
-        changeType: 'deleted',
+        "token": "euiNotificationEventReadButton.markAsRead",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventReadButton.markAsUnread',
-        changeType: 'deleted',
+        "token": "euiNotificationEventReadButton.markAsUnread",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventReadIcon.readAria',
-        changeType: 'deleted',
+        "token": "euiNotificationEventReadIcon.readAria",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventReadIcon.unreadAria',
-        changeType: 'deleted',
+        "token": "euiNotificationEventReadIcon.unreadAria",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventReadIcon.read',
-        changeType: 'deleted',
+        "token": "euiNotificationEventReadIcon.read",
+        "changeType": "deleted"
       },
       {
-        token: 'euiNotificationEventReadIcon.unread',
-        changeType: 'deleted',
-      },
-    ],
+        "token": "euiNotificationEventReadIcon.unread",
+        "changeType": "deleted"
+      }
+    ]
   },
   {
-    version: '91.3.1',
-    changes: [
+    "version": "91.3.1",
+    "changes": [
       {
-        token: 'euiCollapsedItemActions.allActionsDisabled',
-        changeType: 'added',
-        value:
-          'Individual item actions are disabled when rows are being selected.',
-      },
-    ],
+        "token": "euiCollapsedItemActions.allActionsDisabled",
+        "changeType": "added",
+        "value": "Individual item actions are disabled when rows are being selected."
+      }
+    ]
   },
   {
-    version: '91.1.0',
-    changes: [
+    "version": "91.1.0",
+    "changes": [
       {
-        token: 'euiColumnSelector.buttonActiveSingular',
-        changeType: 'deleted',
+        "token": "euiColumnSelector.buttonActiveSingular",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColumnSelector.buttonActivePlural',
-        changeType: 'deleted',
+        "token": "euiColumnSelector.buttonActivePlural",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColumnSorting.buttonActive',
-        changeType: 'deleted',
+        "token": "euiColumnSorting.buttonActive",
+        "changeType": "deleted"
       },
       {
-        token: 'euiLink.newTarget.screenReaderOnlyText',
-        changeType: 'deleted',
+        "token": "euiLink.newTarget.screenReaderOnlyText",
+        "changeType": "deleted"
       },
       {
-        token: 'euiLink.external.ariaLabel',
-        changeType: 'deleted',
+        "token": "euiLink.external.ariaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGridToolbarControl.badgeAriaLabel',
-        changeType: 'added',
-        value: 'Active: {count}',
+        "token": "euiDataGridToolbarControl.badgeAriaLabel",
+        "changeType": "added",
+        "value": "Active: {count}"
       },
       {
-        token: 'euiExternalLinkIcon.ariaLabel',
-        changeType: 'added',
-        value: 'External link',
+        "token": "euiExternalLinkIcon.ariaLabel",
+        "changeType": "added",
+        "value": "External link"
       },
       {
-        token: 'euiExternalLinkIcon.newTarget.screenReaderOnlyText',
-        changeType: 'added',
-        value: '(opens in a new tab or window)',
-      },
-    ],
+        "token": "euiExternalLinkIcon.newTarget.screenReaderOnlyText",
+        "changeType": "added",
+        "value": "(opens in a new tab or window)"
+      }
+    ]
   },
   {
-    version: '91.0.0',
-    changes: [
+    "version": "91.0.0",
+    "changes": [
       {
-        token: 'euiAbsoluteTab.dateFormatError',
-        changeType: 'modified',
-        value:
-          'Allowed formats: {dateFormat}, ISO 8601, RFC 2822, or Unix timestamp.',
+        "token": "euiAbsoluteTab.dateFormatError",
+        "changeType": "modified",
+        "value": "Allowed formats: {dateFormat}, ISO 8601, RFC 2822, or Unix timestamp."
       },
       {
-        token: 'euiAbsoluteTab.dateFormatHint',
-        changeType: 'added',
-        value: 'Press the Enter key to parse as a date.',
-      },
-    ],
+        "token": "euiAbsoluteTab.dateFormatHint",
+        "changeType": "added",
+        "value": "Press the Enter key to parse as a date."
+      }
+    ]
   },
   {
-    version: '90.0.0',
-    changes: [
+    "version": "90.0.0",
+    "changes": [
       {
-        token: 'euiCollapsibleNavButton.ariaLabelOpen',
-        changeType: 'modified',
-        value: 'Open navigation',
+        "token": "euiCollapsibleNavButton.ariaLabelOpen",
+        "changeType": "modified",
+        "value": "Open navigation"
       },
       {
-        token: 'euiCollapsibleNavButton.ariaLabelClose',
-        changeType: 'modified',
-        value: 'Close navigation',
+        "token": "euiCollapsibleNavButton.ariaLabelClose",
+        "changeType": "modified",
+        "value": "Close navigation"
       },
       {
-        token: 'euiCollapsibleNavButton.ariaLabelExpand',
-        changeType: 'added',
-        value: 'Expand navigation',
+        "token": "euiCollapsibleNavButton.ariaLabelExpand",
+        "changeType": "added",
+        "value": "Expand navigation"
       },
       {
-        token: 'euiCollapsibleNavButton.ariaLabelCollapse',
-        changeType: 'added',
-        value: 'Collapse navigation',
-      },
-    ],
+        "token": "euiCollapsibleNavButton.ariaLabelCollapse",
+        "changeType": "added",
+        "value": "Collapse navigation"
+      }
+    ]
   },
   {
-    version: '89.0.0',
-    changes: [
+    "version": "89.0.0",
+    "changes": [
       {
-        token: 'euiColorStopThumb.buttonAriaLabel',
-        changeType: 'deleted',
+        "token": "euiColorStopThumb.buttonAriaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorStopThumb.buttonTitle',
-        changeType: 'deleted',
+        "token": "euiColorStopThumb.buttonTitle",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorStopThumb.screenReaderAnnouncement',
-        changeType: 'deleted',
+        "token": "euiColorStopThumb.screenReaderAnnouncement",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorStopThumb.stopLabel',
-        changeType: 'deleted',
+        "token": "euiColorStopThumb.stopLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorStopThumb.stopErrorMessage',
-        changeType: 'deleted',
+        "token": "euiColorStopThumb.stopErrorMessage",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorStopThumb.removeLabel',
-        changeType: 'deleted',
+        "token": "euiColorStopThumb.removeLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorStops.screenReaderAnnouncement',
-        changeType: 'deleted',
+        "token": "euiColorStops.screenReaderAnnouncement",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSuggest.stateSavedTooltip',
-        changeType: 'deleted',
+        "token": "euiSuggest.stateSavedTooltip",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSuggest.stateUnsavedTooltip',
-        changeType: 'deleted',
+        "token": "euiSuggest.stateUnsavedTooltip",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSuggest.stateLoading',
-        changeType: 'deleted',
+        "token": "euiSuggest.stateLoading",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSuggest.stateSaved',
-        changeType: 'deleted',
+        "token": "euiSuggest.stateSaved",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSuggest.stateUnsaved',
-        changeType: 'deleted',
+        "token": "euiSuggest.stateUnsaved",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSuggest.stateUnchanged',
-        changeType: 'deleted',
-      },
-    ],
+        "token": "euiSuggest.stateUnchanged",
+        "changeType": "deleted"
+      }
+    ]
   },
   {
-    version: '88.5.0',
-    changes: [
+    "version": "88.5.0",
+    "changes": [
       {
-        token: 'euiCallOut.dismissAriaLabel',
-        changeType: 'added',
-        value: 'Dismiss this callout',
-      },
-    ],
+        "token": "euiCallOut.dismissAriaLabel",
+        "changeType": "added",
+        "value": "Dismiss this callout"
+      }
+    ]
   },
   {
-    version: '88.4.0',
-    changes: [
+    "version": "88.4.0",
+    "changes": [
       {
-        token: 'euiSearchBox.placeholder',
-        changeType: 'added',
-        value: 'Search...',
+        "token": "euiSearchBox.placeholder",
+        "changeType": "added",
+        "value": "Search..."
       },
       {
-        token: 'euiSearchBox.incrementalAriaLabel',
-        changeType: 'added',
-        value:
-          'This is a search bar. As you type, the results lower in the page will automatically filter.',
+        "token": "euiSearchBox.incrementalAriaLabel",
+        "changeType": "added",
+        "value": "This is a search bar. As you type, the results lower in the page will automatically filter."
       },
       {
-        token: 'euiSearchBox.ariaLabel',
-        changeType: 'added',
-        value:
-          'This is a search bar. After typing your query, hit enter to filter the results lower in the page.',
-      },
-    ],
+        "token": "euiSearchBox.ariaLabel",
+        "changeType": "added",
+        "value": "This is a search bar. After typing your query, hit enter to filter the results lower in the page."
+      }
+    ]
   },
   {
-    version: '88.3.0',
-    changes: [
+    "version": "88.3.0",
+    "changes": [
       {
-        token: 'euiAccordion.isLoading',
-        changeType: 'deleted',
+        "token": "euiAccordion.isLoading",
+        "changeType": "deleted"
       },
       {
-        token: 'euiAccordionChildrenLoading.message',
-        changeType: 'added',
-        value: 'Loading',
+        "token": "euiAccordionChildrenLoading.message",
+        "changeType": "added",
+        "value": "Loading"
       },
       {
-        token: 'euiGlobalToastList.clearAllToastsButtonAriaLabel',
-        changeType: 'added',
-        value: 'Clear all toast notifications',
+        "token": "euiGlobalToastList.clearAllToastsButtonAriaLabel",
+        "changeType": "added",
+        "value": "Clear all toast notifications"
       },
       {
-        token: 'euiGlobalToastList.clearAllToastsButtonDisplayText',
-        changeType: 'added',
-        value: 'Clear all',
-      },
-    ],
+        "token": "euiGlobalToastList.clearAllToastsButtonDisplayText",
+        "changeType": "added",
+        "value": "Clear all"
+      }
+    ]
   },
   {
-    version: '87.2.0',
-    changes: [
+    "version": "87.2.0",
+    "changes": [
       {
-        token: 'euiResizableButton.horizontalResizerAriaLabel',
-        changeType: 'modified',
-        value: 'Press the left or right arrow keys to adjust panels size',
+        "token": "euiResizableButton.horizontalResizerAriaLabel",
+        "changeType": "modified",
+        "value": "Press the left or right arrow keys to adjust panels size"
       },
       {
-        token: 'euiResizableButton.verticalResizerAriaLabel',
-        changeType: 'modified',
-        value: 'Press the up or down arrow keys to adjust panels size',
-      },
-    ],
+        "token": "euiResizableButton.verticalResizerAriaLabel",
+        "changeType": "modified",
+        "value": "Press the up or down arrow keys to adjust panels size"
+      }
+    ]
   },
   {
-    version: '87.1.0',
-    changes: [
+    "version": "87.1.0",
+    "changes": [
       {
-        token: 'euiCollapsibleNavBeta.ariaLabel',
-        changeType: 'added',
-        value: 'Site menu',
-      },
-    ],
+        "token": "euiCollapsibleNavBeta.ariaLabel",
+        "changeType": "added",
+        "value": "Site menu"
+      }
+    ]
   },
   {
-    version: '87.0.0',
-    changes: [
+    "version": "87.0.0",
+    "changes": [
       {
-        token: 'euiBreadcrumb.popoverAriaLabel',
-        changeType: 'added',
-        value: 'Clicking this button will toggle a popover dialog.',
+        "token": "euiBreadcrumb.popoverAriaLabel",
+        "changeType": "added",
+        "value": "Clicking this button will toggle a popover dialog."
       },
       {
-        token: 'euiCollapsibleNavButton.ariaLabelOpen',
-        changeType: 'added',
-        value: 'Toggle navigation open',
+        "token": "euiCollapsibleNavButton.ariaLabelOpen",
+        "changeType": "added",
+        "value": "Toggle navigation open"
       },
       {
-        token: 'euiCollapsibleNavButton.ariaLabelClose',
-        changeType: 'added',
-        value: 'Toggle navigation closed',
-      },
-    ],
+        "token": "euiCollapsibleNavButton.ariaLabelClose",
+        "changeType": "added",
+        "value": "Toggle navigation closed"
+      }
+    ]
   },
   {
-    version: '81.1.0',
-    changes: [
+    "version": "81.1.0",
+    "changes": [
       {
-        token: 'euiInlineEditForm.saveButtonAriaLabel',
-        changeType: 'added',
-        value: 'Save edit',
+        "token": "euiInlineEditForm.saveButtonAriaLabel",
+        "changeType": "added",
+        "value": "Save edit"
       },
       {
-        token: 'euiInlineEditForm.cancelButtonAriaLabel',
-        changeType: 'added',
-        value: 'Cancel edit',
+        "token": "euiInlineEditForm.cancelButtonAriaLabel",
+        "changeType": "added",
+        "value": "Cancel edit"
       },
       {
-        token: 'euiInlineEditForm.inputKeyboardInstructions',
-        changeType: 'added',
-        value:
-          'Press Enter to save your edited text. Press Escape to cancel your edit.',
+        "token": "euiInlineEditForm.inputKeyboardInstructions",
+        "changeType": "added",
+        "value": "Press Enter to save your edited text. Press Escape to cancel your edit."
       },
       {
-        token: 'euiInlineEditForm.activateEditModeDescription',
-        changeType: 'added',
-        value: 'Click to edit this text inline.',
-      },
-    ],
+        "token": "euiInlineEditForm.activateEditModeDescription",
+        "changeType": "added",
+        "value": "Click to edit this text inline."
+      }
+    ]
   },
   {
-    version: '81.0.0',
-    changes: [
+    "version": "81.0.0",
+    "changes": [
       {
-        token: 'euiSelectableListItem.includedOption',
-        changeType: 'deleted',
+        "token": "euiSelectableListItem.includedOption",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSelectableListItem.includedOptionInstructions',
-        changeType: 'deleted',
+        "token": "euiSelectableListItem.includedOptionInstructions",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSelectableListItem.excludedOptionInstructions',
-        changeType: 'deleted',
+        "token": "euiSelectableListItem.excludedOptionInstructions",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSelectableListItem.unckeckedOptionInstructions',
-        changeType: 'deleted',
+        "token": "euiSelectableListItem.unckeckedOptionInstructions",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSelectableListItem.checkedOptionInstructions',
-        changeType: 'deleted',
+        "token": "euiSelectableListItem.checkedOptionInstructions",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSelectableListItem.checkOptionInstructions',
-        changeType: 'added',
-        value: 'To check this option, press Enter.',
+        "token": "euiSelectableListItem.checkOptionInstructions",
+        "changeType": "added",
+        "value": "To check this option, press Enter."
       },
       {
-        token: 'euiSelectableListItem.uncheckOptionInstructions',
-        changeType: 'added',
-        value: 'To uncheck this option, press Enter.',
+        "token": "euiSelectableListItem.uncheckOptionInstructions",
+        "changeType": "added",
+        "value": "To uncheck this option, press Enter."
       },
       {
-        token: 'euiSelectableListItem.excludeOptionInstructions',
-        changeType: 'added',
-        value: 'To exclude this option, press Enter.',
+        "token": "euiSelectableListItem.excludeOptionInstructions",
+        "changeType": "added",
+        "value": "To exclude this option, press Enter."
       },
       {
-        token: 'euiSelectableListItem.mixedOption',
-        changeType: 'added',
-        value: 'Mixed (indeterminate) option.',
+        "token": "euiSelectableListItem.mixedOption",
+        "changeType": "added",
+        "value": "Mixed (indeterminate) option."
       },
       {
-        token: 'euiSelectableListItem.mixedOptionInstructions',
-        changeType: 'added',
-        value: 'To check this option for all, press Enter once.',
+        "token": "euiSelectableListItem.mixedOptionInstructions",
+        "changeType": "added",
+        "value": "To check this option for all, press Enter once."
       },
       {
-        token: 'euiSelectableListItem.mixedOptionUncheckInstructions',
-        changeType: 'added',
-        value: 'To uncheck this option for all, press Enter twice.',
+        "token": "euiSelectableListItem.mixedOptionUncheckInstructions",
+        "changeType": "added",
+        "value": "To uncheck this option for all, press Enter twice."
       },
       {
-        token: 'euiSelectableListItem.mixedOptionExcludeInstructions',
-        changeType: 'added',
-        value: 'To exclude this option for all, press Enter twice.',
-      },
-    ],
+        "token": "euiSelectableListItem.mixedOptionExcludeInstructions",
+        "changeType": "added",
+        "value": "To exclude this option for all, press Enter twice."
+      }
+    ]
   },
   {
-    version: '77.2.0',
-    changes: [
+    "version": "77.2.0",
+    "changes": [
       {
-        token: 'euiInlineEditForm.saveButtonAriaLabel',
-        changeType: 'deleted',
+        "token": "euiInlineEditForm.saveButtonAriaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiInlineEditForm.cancelButtonAriaLabel',
-        changeType: 'deleted',
+        "token": "euiInlineEditForm.cancelButtonAriaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiFormControlLayoutDelimited.delimiterLabel',
-        changeType: 'added',
-        value: 'to',
-      },
-    ],
+        "token": "euiFormControlLayoutDelimited.delimiterLabel",
+        "changeType": "added",
+        "value": "to"
+      }
+    ]
   },
   {
-    version: '77.1.0',
-    changes: [
+    "version": "77.1.0",
+    "changes": [
       {
-        token: 'euiInlineEditForm.saveButtonAriaLabel',
-        changeType: 'added',
-        value: 'Save edit',
+        "token": "euiInlineEditForm.saveButtonAriaLabel",
+        "changeType": "added",
+        "value": "Save edit"
       },
       {
-        token: 'euiInlineEditForm.cancelButtonAriaLabel',
-        changeType: 'added',
-        value: 'Cancel edit',
-      },
-    ],
+        "token": "euiInlineEditForm.cancelButtonAriaLabel",
+        "changeType": "added",
+        "value": "Cancel edit"
+      }
+    ]
   },
   {
-    version: '76.1.0',
-    changes: [
+    "version": "76.1.0",
+    "changes": [
       {
-        token: 'euiSuperSelectControl.selectAnOption',
-        changeType: 'deleted',
+        "token": "euiSuperSelectControl.selectAnOption",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSelectable.screenReaderInstructions',
-        changeType: 'modified',
-        value:
-          'Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options.',
+        "token": "euiSelectable.screenReaderInstructions",
+        "changeType": "modified",
+        "value": "Use the Up and Down arrow keys to move focus over options. Press Enter to select. Press Escape to collapse options."
       },
       {
-        token: 'euiDualRange.sliderScreenReaderInstructions',
-        changeType: 'added',
-        value:
-          'You are in a custom range slider. Use the Up and Down arrow keys to change the minimum value. Press Tab to interact with the maximum value.',
+        "token": "euiDualRange.sliderScreenReaderInstructions",
+        "changeType": "added",
+        "value": "You are in a custom range slider. Use the Up and Down arrow keys to change the minimum value. Press Tab to interact with the maximum value."
       },
       {
-        token: 'euiRange.sliderScreenReaderInstructions',
-        changeType: 'added',
-        value:
-          'You are in a custom range slider. Use the Up and Down arrow keys to change the value.',
+        "token": "euiRange.sliderScreenReaderInstructions",
+        "changeType": "added",
+        "value": "You are in a custom range slider. Use the Up and Down arrow keys to change the value."
       },
       {
-        token: 'euiSuperSelect.ariaLabel',
-        changeType: 'added',
-        value: 'Select listbox',
-      },
-    ],
+        "token": "euiSuperSelect.ariaLabel",
+        "changeType": "added",
+        "value": "Select listbox"
+      }
+    ]
   },
   {
-    version: '75.1.0',
-    changes: [
+    "version": "75.1.0",
+    "changes": [
       {
-        token: 'euiCodeBlockAnnotations.ariaLabel',
-        changeType: 'added',
-        value: 'Click to view a code annotation for line {lineNumber}',
-      },
-    ],
+        "token": "euiCodeBlockAnnotations.ariaLabel",
+        "changeType": "added",
+        "value": "Click to view a code annotation for line {lineNumber}"
+      }
+    ]
   },
   {
-    version: '75.0.0',
-    changes: [
+    "version": "75.0.0",
+    "changes": [
       {
-        token: 'euiFlyout.screenReaderModalDialog',
-        changeType: 'added',
-        value:
-          'You are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close.',
+        "token": "euiFlyout.screenReaderModalDialog",
+        "changeType": "added",
+        "value": "You are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close."
       },
       {
-        token: 'euiFlyout.screenReaderNonModalDialog',
-        changeType: 'added',
-        value:
-          'You are in a non-modal dialog. To close the dialog, press Escape.',
+        "token": "euiFlyout.screenReaderNonModalDialog",
+        "changeType": "added",
+        "value": "You are in a non-modal dialog. To close the dialog, press Escape."
       },
       {
-        token: 'euiFlyout.screenReaderFixedHeaders',
-        changeType: 'added',
-        value:
-          'You can still continue tabbing through the page headers in addition to the dialog.',
-      },
-    ],
+        "token": "euiFlyout.screenReaderFixedHeaders",
+        "changeType": "added",
+        "value": "You can still continue tabbing through the page headers in addition to the dialog."
+      }
+    ]
   },
   {
-    version: '74.1.0',
-    changes: [
+    "version": "74.1.0",
+    "changes": [
       {
-        token: 'euiSuperSelect.screenReaderAnnouncement',
-        changeType: 'modified',
-        value:
-          'You are in a form selector and must select a single option.\n              Use the Up and Down arrow keys to navigate or Escape to close.',
+        "token": "euiSuperSelect.screenReaderAnnouncement",
+        "changeType": "modified",
+        "value": "You are in a form selector and must select a single option.\n              Use the Up and Down arrow keys to navigate or Escape to close."
       },
       {
-        token: 'euiPopover.screenReaderAnnouncement',
-        changeType: 'modified',
-        value:
-          'You are in a dialog. Press Escape, or tap/click outside the dialog to close.',
+        "token": "euiPopover.screenReaderAnnouncement",
+        "changeType": "modified",
+        "value": "You are in a dialog. Press Escape, or tap/click outside the dialog to close."
       },
       {
-        token: 'euiSkeletonLoading.loadingAriaText',
-        changeType: 'added',
-        value: 'Loading {contentAriaLabel}',
+        "token": "euiSkeletonLoading.loadingAriaText",
+        "changeType": "added",
+        "value": "Loading {contentAriaLabel}"
       },
       {
-        token: 'euiSkeletonLoading.loadedAriaText',
-        changeType: 'added',
-        value: 'Loaded {contentAriaLabel}',
-      },
-    ],
+        "token": "euiSkeletonLoading.loadedAriaText",
+        "changeType": "added",
+        "value": "Loaded {contentAriaLabel}"
+      }
+    ]
   },
   {
-    version: '73.0.0',
-    changes: [
+    "version": "73.0.0",
+    "changes": [
       {
-        token: 'euiColumnSelector.dragHandleAriaLabel',
-        changeType: 'added',
-        value: 'Drag handle',
-      },
-    ],
+        "token": "euiColumnSelector.dragHandleAriaLabel",
+        "changeType": "added",
+        "value": "Drag handle"
+      }
+    ]
   },
   {
-    version: '72.0.0',
-    changes: [
+    "version": "72.0.0",
+    "changes": [
       {
-        token: 'euiQuickSelectPopover.buttonLabel',
-        changeType: 'added',
-        value: 'Date quick select',
-      },
-    ],
+        "token": "euiQuickSelectPopover.buttonLabel",
+        "changeType": "added",
+        "value": "Date quick select"
+      }
+    ]
   },
   {
-    version: '70.2.0',
-    changes: [
+    "version": "70.2.0",
+    "changes": [
       {
-        token: 'euiKeyboardShortcuts.title',
-        changeType: 'added',
-        value: 'Keyboard shortcuts',
+        "token": "euiKeyboardShortcuts.title",
+        "changeType": "added",
+        "value": "Keyboard shortcuts"
       },
       {
-        token: 'euiKeyboardShortcuts.upArrowTitle',
-        changeType: 'added',
-        value: 'Up arrow',
+        "token": "euiKeyboardShortcuts.upArrowTitle",
+        "changeType": "added",
+        "value": "Up arrow"
       },
       {
-        token: 'euiKeyboardShortcuts.upArrowDescription',
-        changeType: 'added',
-        value: 'Move one cell up',
+        "token": "euiKeyboardShortcuts.upArrowDescription",
+        "changeType": "added",
+        "value": "Move one cell up"
       },
       {
-        token: 'euiKeyboardShortcuts.downArrowTitle',
-        changeType: 'added',
-        value: 'Down arrow',
+        "token": "euiKeyboardShortcuts.downArrowTitle",
+        "changeType": "added",
+        "value": "Down arrow"
       },
       {
-        token: 'euiKeyboardShortcuts.downArrowDescription',
-        changeType: 'added',
-        value: 'Move one cell down',
+        "token": "euiKeyboardShortcuts.downArrowDescription",
+        "changeType": "added",
+        "value": "Move one cell down"
       },
       {
-        token: 'euiKeyboardShortcuts.rightArrowTitle',
-        changeType: 'added',
-        value: 'Right arrow',
+        "token": "euiKeyboardShortcuts.rightArrowTitle",
+        "changeType": "added",
+        "value": "Right arrow"
       },
       {
-        token: 'euiKeyboardShortcuts.rightArrowDescription',
-        changeType: 'added',
-        value: 'Move one cell right',
+        "token": "euiKeyboardShortcuts.rightArrowDescription",
+        "changeType": "added",
+        "value": "Move one cell right"
       },
       {
-        token: 'euiKeyboardShortcuts.leftArrowTitle',
-        changeType: 'added',
-        value: 'Left arrow',
+        "token": "euiKeyboardShortcuts.leftArrowTitle",
+        "changeType": "added",
+        "value": "Left arrow"
       },
       {
-        token: 'euiKeyboardShortcuts.leftArrowDescription',
-        changeType: 'added',
-        value: 'Move one cell left',
+        "token": "euiKeyboardShortcuts.leftArrowDescription",
+        "changeType": "added",
+        "value": "Move one cell left"
       },
       {
-        token: 'euiKeyboardShortcuts.homeTitle',
-        changeType: 'added',
-        value: 'Home',
+        "token": "euiKeyboardShortcuts.homeTitle",
+        "changeType": "added",
+        "value": "Home"
       },
       {
-        token: 'euiKeyboardShortcuts.homeDescription',
-        changeType: 'added',
-        value: 'Move to the first cell of the current row',
+        "token": "euiKeyboardShortcuts.homeDescription",
+        "changeType": "added",
+        "value": "Move to the first cell of the current row"
       },
       {
-        token: 'euiKeyboardShortcuts.endTitle',
-        changeType: 'added',
-        value: 'End',
+        "token": "euiKeyboardShortcuts.endTitle",
+        "changeType": "added",
+        "value": "End"
       },
       {
-        token: 'euiKeyboardShortcuts.endDescription',
-        changeType: 'added',
-        value: 'Move to the last cell of the current row',
+        "token": "euiKeyboardShortcuts.endDescription",
+        "changeType": "added",
+        "value": "Move to the last cell of the current row"
       },
       {
-        token: 'euiKeyboardShortcuts.ctrl',
-        changeType: 'added',
-        value: 'Ctrl',
+        "token": "euiKeyboardShortcuts.ctrl",
+        "changeType": "added",
+        "value": "Ctrl"
       },
       {
-        token: 'euiKeyboardShortcuts.ctrlHomeDescription',
-        changeType: 'added',
-        value: 'Move to the first cell of the current page',
+        "token": "euiKeyboardShortcuts.ctrlHomeDescription",
+        "changeType": "added",
+        "value": "Move to the first cell of the current page"
       },
       {
-        token: 'euiKeyboardShortcuts.ctrlEndDescription',
-        changeType: 'added',
-        value: 'Move to the last cell of the current page',
+        "token": "euiKeyboardShortcuts.ctrlEndDescription",
+        "changeType": "added",
+        "value": "Move to the last cell of the current page"
       },
       {
-        token: 'euiKeyboardShortcuts.pageUpTitle',
-        changeType: 'added',
-        value: 'Page Up',
+        "token": "euiKeyboardShortcuts.pageUpTitle",
+        "changeType": "added",
+        "value": "Page Up"
       },
       {
-        token: 'euiKeyboardShortcuts.pageUpDescription',
-        changeType: 'added',
-        value: 'Go to the last row of the previous page',
+        "token": "euiKeyboardShortcuts.pageUpDescription",
+        "changeType": "added",
+        "value": "Go to the last row of the previous page"
       },
       {
-        token: 'euiKeyboardShortcuts.pageDownTitle',
-        changeType: 'added',
-        value: 'Page Down',
+        "token": "euiKeyboardShortcuts.pageDownTitle",
+        "changeType": "added",
+        "value": "Page Down"
       },
       {
-        token: 'euiKeyboardShortcuts.pageDownDescription',
-        changeType: 'added',
-        value: 'Go to the first row of the next page',
+        "token": "euiKeyboardShortcuts.pageDownDescription",
+        "changeType": "added",
+        "value": "Go to the first row of the next page"
       },
       {
-        token: 'euiKeyboardShortcuts.enterTitle',
-        changeType: 'added',
-        value: 'Enter',
+        "token": "euiKeyboardShortcuts.enterTitle",
+        "changeType": "added",
+        "value": "Enter"
       },
       {
-        token: 'euiKeyboardShortcuts.enterDescription',
-        changeType: 'added',
-        value: 'Open cell details and actions',
+        "token": "euiKeyboardShortcuts.enterDescription",
+        "changeType": "added",
+        "value": "Open cell details and actions"
       },
       {
-        token: 'euiKeyboardShortcuts.escapeTitle',
-        changeType: 'added',
-        value: 'Escape',
+        "token": "euiKeyboardShortcuts.escapeTitle",
+        "changeType": "added",
+        "value": "Escape"
       },
       {
-        token: 'euiKeyboardShortcuts.escapeDescription',
-        changeType: 'added',
-        value: 'Close cell details and actions',
-      },
-    ],
+        "token": "euiKeyboardShortcuts.escapeDescription",
+        "changeType": "added",
+        "value": "Close cell details and actions"
+      }
+    ]
   },
   {
-    version: '70.0.0',
-    changes: [
+    "version": "70.0.0",
+    "changes": [
       {
-        token: 'euiCodeBlock.copyButton',
-        changeType: 'deleted',
+        "token": "euiCodeBlock.copyButton",
+        "changeType": "deleted"
       },
       {
-        token: 'euiCodeBlock.fullscreenCollapse',
-        changeType: 'deleted',
+        "token": "euiCodeBlock.fullscreenCollapse",
+        "changeType": "deleted"
       },
       {
-        token: 'euiCodeBlock.fullscreenExpand',
-        changeType: 'deleted',
+        "token": "euiCodeBlock.fullscreenExpand",
+        "changeType": "deleted"
       },
       {
-        token: 'euiCodeBlockCopy.copy',
-        changeType: 'added',
-        value: 'Copy',
+        "token": "euiCodeBlockCopy.copy",
+        "changeType": "added",
+        "value": "Copy"
       },
       {
-        token: 'euiCodeBlockFullScreen.fullscreenCollapse',
-        changeType: 'added',
-        value: 'Collapse',
+        "token": "euiCodeBlockFullScreen.fullscreenCollapse",
+        "changeType": "added",
+        "value": "Collapse"
       },
       {
-        token: 'euiCodeBlockFullScreen.fullscreenExpand',
-        changeType: 'added',
-        value: 'Expand',
-      },
-    ],
+        "token": "euiCodeBlockFullScreen.fullscreenExpand",
+        "changeType": "added",
+        "value": "Expand"
+      }
+    ]
   },
   {
-    version: '62.1.0',
-    changes: [
+    "version": "62.1.0",
+    "changes": [
       {
-        token: 'euiBreadcrumbs.collapsedBadge.ariaLabel',
-        changeType: 'deleted',
+        "token": "euiBreadcrumbs.collapsedBadge.ariaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiBreadcrumb.collapsedBadge.ariaLabel',
-        changeType: 'added',
-        value: 'See collapsed breadcrumbs',
-      },
-    ],
+        "token": "euiBreadcrumb.collapsedBadge.ariaLabel",
+        "changeType": "added",
+        "value": "See collapsed breadcrumbs"
+      }
+    ]
   },
   {
-    version: '62.0.0',
-    changes: [
+    "version": "62.0.0",
+    "changes": [
       {
-        token: 'euiDataGridHeaderCell.headerActions',
-        changeType: 'modified',
-        value: 'Click to view column header actions',
+        "token": "euiDataGridHeaderCell.headerActions",
+        "changeType": "modified",
+        "value": "Click to view column header actions"
       },
       {
-        token: 'euiImage.closeImage',
-        changeType: 'deleted',
+        "token": "euiImage.closeImage",
+        "changeType": "deleted"
       },
       {
-        token: 'euiImage.openImage',
-        changeType: 'deleted',
+        "token": "euiImage.openImage",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGridHeaderCell.sortedByAscendingSingle',
-        changeType: 'added',
-        value: 'Sorted ascending',
+        "token": "euiDataGridHeaderCell.sortedByAscendingSingle",
+        "changeType": "added",
+        "value": "Sorted ascending"
       },
       {
-        token: 'euiDataGridHeaderCell.sortedByDescendingSingle',
-        changeType: 'added',
-        value: 'Sorted descending',
+        "token": "euiDataGridHeaderCell.sortedByDescendingSingle",
+        "changeType": "added",
+        "value": "Sorted descending"
       },
       {
-        token: 'euiDataGridHeaderCell.sortedByAscendingFirst',
-        changeType: 'added',
-        value: 'Sorted by {columnId}, ascending',
+        "token": "euiDataGridHeaderCell.sortedByAscendingFirst",
+        "changeType": "added",
+        "value": "Sorted by {columnId}, ascending"
       },
       {
-        token: 'euiDataGridHeaderCell.sortedByDescendingFirst',
-        changeType: 'added',
-        value: 'Sorted by {columnId}, descending',
+        "token": "euiDataGridHeaderCell.sortedByDescendingFirst",
+        "changeType": "added",
+        "value": "Sorted by {columnId}, descending"
       },
       {
-        token: 'euiDataGridHeaderCell.sortedByAscendingMultiple',
-        changeType: 'added',
-        value: ', then sorted by {columnId}, ascending',
+        "token": "euiDataGridHeaderCell.sortedByAscendingMultiple",
+        "changeType": "added",
+        "value": ", then sorted by {columnId}, ascending"
       },
       {
-        token: 'euiDataGridHeaderCell.sortedByDescendingMultiple',
-        changeType: 'added',
-        value: ', then sorted by {columnId}, descending',
+        "token": "euiDataGridHeaderCell.sortedByDescendingMultiple",
+        "changeType": "added",
+        "value": ", then sorted by {columnId}, descending"
       },
       {
-        token: 'euiImageButton.openFullScreen',
-        changeType: 'added',
-        value: 'Click to open this image in fullscreen mode',
+        "token": "euiImageButton.openFullScreen",
+        "changeType": "added",
+        "value": "Click to open this image in fullscreen mode"
       },
       {
-        token: 'euiImageButton.closeFullScreen',
-        changeType: 'added',
-        value: 'Press Escape or click to close image fullscreen mode',
-      },
-    ],
+        "token": "euiImageButton.closeFullScreen",
+        "changeType": "added",
+        "value": "Press Escape or click to close image fullscreen mode"
+      }
+    ]
   },
   {
-    version: '60.3.0',
-    changes: [
+    "version": "60.3.0",
+    "changes": [
       {
-        token: 'euiDataGridCell.position',
-        changeType: 'modified',
-        value: '{columnId}, column {col}, row {row}',
-      },
-    ],
+        "token": "euiDataGridCell.position",
+        "changeType": "modified",
+        "value": "{columnId}, column {col}, row {row}"
+      }
+    ]
   },
   {
-    version: '60.2.0',
-    changes: [
+    "version": "60.2.0",
+    "changes": [
       {
-        token: 'euiDataGridHeaderCell.actionsPopoverScreenReaderText',
-        changeType: 'added',
-        value:
-          'To navigate through the list of column actions, press the Tab or Up and Down arrow keys.',
-      },
-    ],
+        "token": "euiDataGridHeaderCell.actionsPopoverScreenReaderText",
+        "changeType": "added",
+        "value": "To navigate through the list of column actions, press the Tab or Up and Down arrow keys."
+      }
+    ]
   },
   {
-    version: '58.1.0',
-    changes: [
+    "version": "58.1.0",
+    "changes": [
       {
-        token: 'euiColumnSortingDraggable.dragHandleAriaLabel',
-        changeType: 'added',
-        value: 'Drag handle',
-      },
-    ],
+        "token": "euiColumnSortingDraggable.dragHandleAriaLabel",
+        "changeType": "added",
+        "value": "Drag handle"
+      }
+    ]
   },
   {
-    version: '56.0.0',
-    changes: [
+    "version": "56.0.0",
+    "changes": [
       {
-        token: 'euiLoadingStrings.ariaLabel',
-        changeType: 'added',
-        value: 'Loading',
-      },
-    ],
+        "token": "euiLoadingStrings.ariaLabel",
+        "changeType": "added",
+        "value": "Loading"
+      }
+    ]
   },
   {
-    version: '55.1.0',
-    changes: [
+    "version": "55.1.0",
+    "changes": [
       {
-        token: 'euiLoadingChart.ariaLabel',
-        changeType: 'added',
-        value: 'Loading',
-      },
-    ],
+        "token": "euiLoadingChart.ariaLabel",
+        "changeType": "added",
+        "value": "Loading"
+      }
+    ]
   },
   {
-    version: '54.1.0',
-    changes: [
+    "version": "54.1.0",
+    "changes": [
       {
-        token: 'euiMark.highlightStart',
-        changeType: 'added',
-        value: 'highlight start',
+        "token": "euiMark.highlightStart",
+        "changeType": "added",
+        "value": "highlight start"
       },
       {
-        token: 'euiMark.highlightEnd',
-        changeType: 'added',
-        value: 'highlight end',
-      },
-    ],
+        "token": "euiMark.highlightEnd",
+        "changeType": "added",
+        "value": "highlight end"
+      }
+    ]
   },
   {
-    version: '53.0.0',
-    changes: [
+    "version": "53.0.0",
+    "changes": [
       {
-        token: 'euiRelativeTab.relativeDate',
-        changeType: 'deleted',
+        "token": "euiRelativeTab.relativeDate",
+        "changeType": "deleted"
       },
       {
-        token: 'euiRelativeTab.roundingLabel',
-        changeType: 'deleted',
+        "token": "euiRelativeTab.roundingLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiAbsoluteTab.dateFormatError',
-        changeType: 'added',
-        value: 'Expected format: {dateFormat}',
+        "token": "euiAbsoluteTab.dateFormatError",
+        "changeType": "added",
+        "value": "Expected format: {dateFormat}"
       },
       {
-        token: 'euiDatePopoverContent.startDateLabel',
-        changeType: 'added',
-        value: 'Start date',
+        "token": "euiDatePopoverContent.startDateLabel",
+        "changeType": "added",
+        "value": "Start date"
       },
       {
-        token: 'euiDatePopoverContent.endDateLabel',
-        changeType: 'added',
-        value: 'End date',
+        "token": "euiDatePopoverContent.endDateLabel",
+        "changeType": "added",
+        "value": "End date"
       },
       {
-        token: 'euiDatePopoverContent.absoluteTabLabel',
-        changeType: 'added',
-        value: 'Absolute',
+        "token": "euiDatePopoverContent.absoluteTabLabel",
+        "changeType": "added",
+        "value": "Absolute"
       },
       {
-        token: 'euiDatePopoverContent.relativeTabLabel',
-        changeType: 'added',
-        value: 'Relative',
+        "token": "euiDatePopoverContent.relativeTabLabel",
+        "changeType": "added",
+        "value": "Relative"
       },
       {
-        token: 'euiDatePopoverContent.nowTabLabel',
-        changeType: 'added',
-        value: 'Now',
+        "token": "euiDatePopoverContent.nowTabLabel",
+        "changeType": "added",
+        "value": "Now"
       },
       {
-        token: 'euiDatePopoverContent.nowTabContent',
-        changeType: 'added',
-        value:
-          'Setting the time to "now" means that on every refresh this\n            time will be set to the time of the refresh.',
+        "token": "euiDatePopoverContent.nowTabContent",
+        "changeType": "added",
+        "value": "Setting the time to \"now\" means that on every refresh this\n            time will be set to the time of the refresh."
       },
       {
-        token: 'euiDatePopoverContent.nowTabButtonStart',
-        changeType: 'added',
-        value: 'Set start date and time to now',
+        "token": "euiDatePopoverContent.nowTabButtonStart",
+        "changeType": "added",
+        "value": "Set start date and time to now"
       },
       {
-        token: 'euiDatePopoverContent.nowTabButtonEnd',
-        changeType: 'added',
-        value: 'Set end date and time to now',
+        "token": "euiDatePopoverContent.nowTabButtonEnd",
+        "changeType": "added",
+        "value": "Set end date and time to now"
       },
       {
-        token: 'euiPrettyDuration.lastDurationSeconds',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Last ${duration} second${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.lastDurationSeconds",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Last ${duration} second${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.nextDurationSeconds',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Next ${duration} second${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.nextDurationSeconds",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Next ${duration} second${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.lastDurationMinutes',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Last ${duration} minute${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.lastDurationMinutes",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Last ${duration} minute${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.nextDurationMinutes',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Next ${duration} minute${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.nextDurationMinutes",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Next ${duration} minute${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.lastDurationHours',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Last ${duration} hour${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.lastDurationHours",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Last ${duration} hour${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.nextDurationHours',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Next ${duration} hour${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.nextDurationHours",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Next ${duration} hour${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.lastDurationDays',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Last ${duration} day${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.lastDurationDays",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Last ${duration} day${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.nexttDurationDays',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Next ${duration} day${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.nexttDurationDays",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Next ${duration} day${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.lastDurationWeeks',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Last ${duration} week${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.lastDurationWeeks",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Last ${duration} week${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.nextDurationWeeks',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Next ${duration} week${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.nextDurationWeeks",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Next ${duration} week${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.lastDurationMonths',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Last ${duration} month${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.lastDurationMonths",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Last ${duration} month${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.nextDurationMonths',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Next ${duration} month${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.nextDurationMonths",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Next ${duration} month${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.lastDurationYears',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Last ${duration} year${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.lastDurationYears",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Last ${duration} year${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.nextDurationYears',
-        changeType: 'added',
-        value:
-          "({\n  duration\n}) => `Next ${duration} year${duration === 1 ? '' : 's'}`;",
+        "token": "euiPrettyDuration.nextDurationYears",
+        "changeType": "added",
+        "value": "({\n  duration\n}) => `Next ${duration} year${duration === 1 ? '' : 's'}`;"
       },
       {
-        token: 'euiPrettyDuration.durationRoundedToSecond',
-        changeType: 'added',
-        value: '{prettyDuration} rounded to the second',
+        "token": "euiPrettyDuration.durationRoundedToSecond",
+        "changeType": "added",
+        "value": "{prettyDuration} rounded to the second"
       },
       {
-        token: 'euiPrettyDuration.durationRoundedToMinute',
-        changeType: 'added',
-        value: '{prettyDuration} rounded to the minute',
+        "token": "euiPrettyDuration.durationRoundedToMinute",
+        "changeType": "added",
+        "value": "{prettyDuration} rounded to the minute"
       },
       {
-        token: 'euiPrettyDuration.durationRoundedToHour',
-        changeType: 'added',
-        value: '{prettyDuration} rounded to the hour',
+        "token": "euiPrettyDuration.durationRoundedToHour",
+        "changeType": "added",
+        "value": "{prettyDuration} rounded to the hour"
       },
       {
-        token: 'euiPrettyDuration.durationRoundedToDay',
-        changeType: 'added',
-        value: '{prettyDuration} rounded to the day',
+        "token": "euiPrettyDuration.durationRoundedToDay",
+        "changeType": "added",
+        "value": "{prettyDuration} rounded to the day"
       },
       {
-        token: 'euiPrettyDuration.durationRoundedToWeek',
-        changeType: 'added',
-        value: '{prettyDuration} rounded to the week',
+        "token": "euiPrettyDuration.durationRoundedToWeek",
+        "changeType": "added",
+        "value": "{prettyDuration} rounded to the week"
       },
       {
-        token: 'euiPrettyDuration.durationRoundedToMonth',
-        changeType: 'added',
-        value: '{prettyDuration} rounded to the month',
+        "token": "euiPrettyDuration.durationRoundedToMonth",
+        "changeType": "added",
+        "value": "{prettyDuration} rounded to the month"
       },
       {
-        token: 'euiPrettyDuration.durationRoundedToYear',
-        changeType: 'added',
-        value: '{prettyDuration} rounded to the year',
+        "token": "euiPrettyDuration.durationRoundedToYear",
+        "changeType": "added",
+        "value": "{prettyDuration} rounded to the year"
       },
       {
-        token: 'euiPrettyDuration.now',
-        changeType: 'added',
-        value: 'now',
+        "token": "euiPrettyDuration.now",
+        "changeType": "added",
+        "value": "now"
       },
       {
-        token: 'euiPrettyDuration.invalid',
-        changeType: 'added',
-        value: 'Invalid date',
+        "token": "euiPrettyDuration.invalid",
+        "changeType": "added",
+        "value": "Invalid date"
       },
       {
-        token: 'euiPrettyDuration.fallbackDuration',
-        changeType: 'added',
-        value: '{displayFrom} to {displayTo}',
+        "token": "euiPrettyDuration.fallbackDuration",
+        "changeType": "added",
+        "value": "{displayFrom} to {displayTo}"
       },
       {
-        token: 'euiPrettyInterval.seconds',
-        changeType: 'added',
-        value:
-          "({\n  interval\n}) => `${interval} second${interval > 1 ? 's' : ''}`;",
+        "token": "euiPrettyInterval.seconds",
+        "changeType": "added",
+        "value": "({\n  interval\n}) => `${interval} second${interval > 1 ? 's' : ''}`;"
       },
       {
-        token: 'euiPrettyInterval.minutes',
-        changeType: 'added',
-        value:
-          "({\n  interval\n}) => `${interval} minute${interval > 1 ? 's' : ''}`;",
+        "token": "euiPrettyInterval.minutes",
+        "changeType": "added",
+        "value": "({\n  interval\n}) => `${interval} minute${interval > 1 ? 's' : ''}`;"
       },
       {
-        token: 'euiPrettyInterval.hours',
-        changeType: 'added',
-        value:
-          "({\n  interval\n}) => `${interval} hour${interval > 1 ? 's' : ''}`;",
+        "token": "euiPrettyInterval.hours",
+        "changeType": "added",
+        "value": "({\n  interval\n}) => `${interval} hour${interval > 1 ? 's' : ''}`;"
       },
       {
-        token: 'euiPrettyInterval.days',
-        changeType: 'added',
-        value:
-          "({\n  interval\n}) => `${interval} day${interval > 1 ? 's' : ''}`;",
+        "token": "euiPrettyInterval.days",
+        "changeType": "added",
+        "value": "({\n  interval\n}) => `${interval} day${interval > 1 ? 's' : ''}`;"
       },
       {
-        token: 'euiPrettyInterval.secondsShorthand',
-        changeType: 'added',
-        value: '{interval} s',
+        "token": "euiPrettyInterval.secondsShorthand",
+        "changeType": "added",
+        "value": "{interval} s"
       },
       {
-        token: 'euiPrettyInterval.minutesShorthand',
-        changeType: 'added',
-        value: '{interval} m',
+        "token": "euiPrettyInterval.minutesShorthand",
+        "changeType": "added",
+        "value": "{interval} m"
       },
       {
-        token: 'euiPrettyInterval.hoursShorthand',
-        changeType: 'added',
-        value: '{interval} h',
+        "token": "euiPrettyInterval.hoursShorthand",
+        "changeType": "added",
+        "value": "{interval} h"
       },
       {
-        token: 'euiPrettyInterval.daysShorthand',
-        changeType: 'added',
-        value: '{interval} d',
+        "token": "euiPrettyInterval.daysShorthand",
+        "changeType": "added",
+        "value": "{interval} d"
       },
       {
-        token: 'euiPrettyInterval.off',
-        changeType: 'added',
-        value: 'Off',
+        "token": "euiPrettyInterval.off",
+        "changeType": "added",
+        "value": "Off"
       },
       {
-        token: 'euiTimeOptions.last',
-        changeType: 'added',
-        value: 'Last',
+        "token": "euiTimeOptions.last",
+        "changeType": "added",
+        "value": "Last"
       },
       {
-        token: 'euiTimeOptions.next',
-        changeType: 'added',
-        value: 'Next',
+        "token": "euiTimeOptions.next",
+        "changeType": "added",
+        "value": "Next"
       },
       {
-        token: 'euiTimeOptions.seconds',
-        changeType: 'added',
-        value: 'Seconds',
+        "token": "euiTimeOptions.seconds",
+        "changeType": "added",
+        "value": "Seconds"
       },
       {
-        token: 'euiTimeOptions.minutes',
-        changeType: 'added',
-        value: 'Minutes',
+        "token": "euiTimeOptions.minutes",
+        "changeType": "added",
+        "value": "Minutes"
       },
       {
-        token: 'euiTimeOptions.hours',
-        changeType: 'added',
-        value: 'Hours',
+        "token": "euiTimeOptions.hours",
+        "changeType": "added",
+        "value": "Hours"
       },
       {
-        token: 'euiTimeOptions.days',
-        changeType: 'added',
-        value: 'Days',
+        "token": "euiTimeOptions.days",
+        "changeType": "added",
+        "value": "Days"
       },
       {
-        token: 'euiTimeOptions.weeks',
-        changeType: 'added',
-        value: 'Weeks',
+        "token": "euiTimeOptions.weeks",
+        "changeType": "added",
+        "value": "Weeks"
       },
       {
-        token: 'euiTimeOptions.months',
-        changeType: 'added',
-        value: 'Months',
+        "token": "euiTimeOptions.months",
+        "changeType": "added",
+        "value": "Months"
       },
       {
-        token: 'euiTimeOptions.years',
-        changeType: 'added',
-        value: 'Years',
+        "token": "euiTimeOptions.years",
+        "changeType": "added",
+        "value": "Years"
       },
       {
-        token: 'euiTimeOptions.secondsAgo',
-        changeType: 'added',
-        value: 'Seconds ago',
+        "token": "euiTimeOptions.secondsAgo",
+        "changeType": "added",
+        "value": "Seconds ago"
       },
       {
-        token: 'euiTimeOptions.minutesAgo',
-        changeType: 'added',
-        value: 'Minutes ago',
+        "token": "euiTimeOptions.minutesAgo",
+        "changeType": "added",
+        "value": "Minutes ago"
       },
       {
-        token: 'euiTimeOptions.hoursAgo',
-        changeType: 'added',
-        value: 'Hours ago',
+        "token": "euiTimeOptions.hoursAgo",
+        "changeType": "added",
+        "value": "Hours ago"
       },
       {
-        token: 'euiTimeOptions.daysAgo',
-        changeType: 'added',
-        value: 'Days ago',
+        "token": "euiTimeOptions.daysAgo",
+        "changeType": "added",
+        "value": "Days ago"
       },
       {
-        token: 'euiTimeOptions.weeksAgo',
-        changeType: 'added',
-        value: 'Weeks ago',
+        "token": "euiTimeOptions.weeksAgo",
+        "changeType": "added",
+        "value": "Weeks ago"
       },
       {
-        token: 'euiTimeOptions.monthsAgo',
-        changeType: 'added',
-        value: 'Months ago',
+        "token": "euiTimeOptions.monthsAgo",
+        "changeType": "added",
+        "value": "Months ago"
       },
       {
-        token: 'euiTimeOptions.yearsAgo',
-        changeType: 'added',
-        value: 'Years ago',
+        "token": "euiTimeOptions.yearsAgo",
+        "changeType": "added",
+        "value": "Years ago"
       },
       {
-        token: 'euiTimeOptions.secondsFromNow',
-        changeType: 'added',
-        value: 'Seconds from now',
+        "token": "euiTimeOptions.secondsFromNow",
+        "changeType": "added",
+        "value": "Seconds from now"
       },
       {
-        token: 'euiTimeOptions.minutesFromNow',
-        changeType: 'added',
-        value: 'Minutes from now',
+        "token": "euiTimeOptions.minutesFromNow",
+        "changeType": "added",
+        "value": "Minutes from now"
       },
       {
-        token: 'euiTimeOptions.hoursFromNow',
-        changeType: 'added',
-        value: 'Hours from now',
+        "token": "euiTimeOptions.hoursFromNow",
+        "changeType": "added",
+        "value": "Hours from now"
       },
       {
-        token: 'euiTimeOptions.daysFromNow',
-        changeType: 'added',
-        value: 'Days from now',
+        "token": "euiTimeOptions.daysFromNow",
+        "changeType": "added",
+        "value": "Days from now"
       },
       {
-        token: 'euiTimeOptions.weeksFromNow',
-        changeType: 'added',
-        value: 'Weeks from now',
+        "token": "euiTimeOptions.weeksFromNow",
+        "changeType": "added",
+        "value": "Weeks from now"
       },
       {
-        token: 'euiTimeOptions.monthsFromNow',
-        changeType: 'added',
-        value: 'Months from now',
+        "token": "euiTimeOptions.monthsFromNow",
+        "changeType": "added",
+        "value": "Months from now"
       },
       {
-        token: 'euiTimeOptions.yearsFromNow',
-        changeType: 'added',
-        value: 'Years from now',
+        "token": "euiTimeOptions.yearsFromNow",
+        "changeType": "added",
+        "value": "Years from now"
       },
       {
-        token: 'euiTimeOptions.roundToSecond',
-        changeType: 'added',
-        value: 'Round to the second',
+        "token": "euiTimeOptions.roundToSecond",
+        "changeType": "added",
+        "value": "Round to the second"
       },
       {
-        token: 'euiTimeOptions.roundToMinute',
-        changeType: 'added',
-        value: 'Round to the minute',
+        "token": "euiTimeOptions.roundToMinute",
+        "changeType": "added",
+        "value": "Round to the minute"
       },
       {
-        token: 'euiTimeOptions.roundToHour',
-        changeType: 'added',
-        value: 'Round to the hour',
+        "token": "euiTimeOptions.roundToHour",
+        "changeType": "added",
+        "value": "Round to the hour"
       },
       {
-        token: 'euiTimeOptions.roundToDay',
-        changeType: 'added',
-        value: 'Round to the day',
+        "token": "euiTimeOptions.roundToDay",
+        "changeType": "added",
+        "value": "Round to the day"
       },
       {
-        token: 'euiTimeOptions.roundToWeek',
-        changeType: 'added',
-        value: 'Round to the week',
+        "token": "euiTimeOptions.roundToWeek",
+        "changeType": "added",
+        "value": "Round to the week"
       },
       {
-        token: 'euiTimeOptions.roundToMonth',
-        changeType: 'added',
-        value: 'Round to the month',
+        "token": "euiTimeOptions.roundToMonth",
+        "changeType": "added",
+        "value": "Round to the month"
       },
       {
-        token: 'euiTimeOptions.roundToYear',
-        changeType: 'added',
-        value: 'Round to the year',
+        "token": "euiTimeOptions.roundToYear",
+        "changeType": "added",
+        "value": "Round to the year"
       },
       {
-        token: 'euiTimeOptions.today',
-        changeType: 'added',
-        value: 'Today',
+        "token": "euiTimeOptions.today",
+        "changeType": "added",
+        "value": "Today"
       },
       {
-        token: 'euiTimeOptions.thisWeek',
-        changeType: 'added',
-        value: 'This week',
+        "token": "euiTimeOptions.thisWeek",
+        "changeType": "added",
+        "value": "This week"
       },
       {
-        token: 'euiTimeOptions.thisMonth',
-        changeType: 'added',
-        value: 'This month',
+        "token": "euiTimeOptions.thisMonth",
+        "changeType": "added",
+        "value": "This month"
       },
       {
-        token: 'euiTimeOptions.thisYear',
-        changeType: 'added',
-        value: 'This year',
+        "token": "euiTimeOptions.thisYear",
+        "changeType": "added",
+        "value": "This year"
       },
       {
-        token: 'euiTimeOptions.yesterday',
-        changeType: 'added',
-        value: 'Yesterday',
+        "token": "euiTimeOptions.yesterday",
+        "changeType": "added",
+        "value": "Yesterday"
       },
       {
-        token: 'euiTimeOptions.weekToDate',
-        changeType: 'added',
-        value: 'Week to date',
+        "token": "euiTimeOptions.weekToDate",
+        "changeType": "added",
+        "value": "Week to date"
       },
       {
-        token: 'euiTimeOptions.monthToDate',
-        changeType: 'added',
-        value: 'Month to date',
+        "token": "euiTimeOptions.monthToDate",
+        "changeType": "added",
+        "value": "Month to date"
       },
       {
-        token: 'euiTimeOptions.yearToDate',
-        changeType: 'added',
-        value: 'Year to date',
-      },
-    ],
+        "token": "euiTimeOptions.yearToDate",
+        "changeType": "added",
+        "value": "Year to date"
+      }
+    ]
   },
   {
-    version: '51.1.0',
-    changes: [
+    "version": "51.1.0",
+    "changes": [
       {
-        token: 'euiDataGridToolbar.fullScreenButton',
-        changeType: 'deleted',
+        "token": "euiDataGridToolbar.fullScreenButton",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGridToolbar.fullScreenButtonActive',
-        changeType: 'deleted',
+        "token": "euiDataGridToolbar.fullScreenButtonActive",
+        "changeType": "deleted"
       },
       {
-        token: 'euiImage.closeImage',
-        changeType: 'modified',
-        value: 'Close fullscreen {alt} image',
+        "token": "euiImage.closeImage",
+        "changeType": "modified",
+        "value": "Close fullscreen {alt} image"
       },
       {
-        token: 'euiImage.openImage',
-        changeType: 'modified',
-        value: 'Open fullscreen {alt} image',
+        "token": "euiImage.openImage",
+        "changeType": "modified",
+        "value": "Open fullscreen {alt} image"
       },
       {
-        token: 'euiFullscreenSelector.fullscreenButton',
-        changeType: 'added',
-        value: 'Enter fullscreen',
+        "token": "euiFullscreenSelector.fullscreenButton",
+        "changeType": "added",
+        "value": "Enter fullscreen"
       },
       {
-        token: 'euiFullscreenSelector.fullscreenButtonActive',
-        changeType: 'added',
-        value: 'Exit fullscreen',
-      },
-    ],
+        "token": "euiFullscreenSelector.fullscreenButtonActive",
+        "changeType": "added",
+        "value": "Exit fullscreen"
+      }
+    ]
   },
   {
-    version: '50.0.0',
-    changes: [
+    "version": "50.0.0",
+    "changes": [
       {
-        token: 'euiComboBox.listboxAriaLabel',
-        changeType: 'added',
-        value: 'Choose from the following options',
-      },
-    ],
+        "token": "euiComboBox.listboxAriaLabel",
+        "changeType": "added",
+        "value": "Choose from the following options"
+      }
+    ]
   },
   {
-    version: '49.0.0',
-    changes: [
+    "version": "49.0.0",
+    "changes": [
       {
-        token: 'euiTablePagination.allRows',
-        changeType: 'added',
-        value: 'Showing all rows',
+        "token": "euiTablePagination.allRows",
+        "changeType": "added",
+        "value": "Showing all rows"
       },
       {
-        token: 'euiTablePagination.rowsPerPageOptionShowAllRows',
-        changeType: 'added',
-        value: 'Show all rows',
-      },
-    ],
+        "token": "euiTablePagination.rowsPerPageOptionShowAllRows",
+        "changeType": "added",
+        "value": "Show all rows"
+      }
+    ]
   },
   {
-    version: '48.0.0',
-    changes: [
+    "version": "48.0.0",
+    "changes": [
       {
-        token: 'euiDataGridCellButtons.expandButtonTitle',
-        changeType: 'deleted',
+        "token": "euiDataGridCellButtons.expandButtonTitle",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGridCellActions.expandButtonTitle',
-        changeType: 'added',
-        value: 'Click or hit enter to interact with cell content',
+        "token": "euiDataGridCellActions.expandButtonTitle",
+        "changeType": "added",
+        "value": "Click or hit enter to interact with cell content"
       },
       {
-        token: 'euiSuggest.stateSavedTooltip',
-        changeType: 'added',
-        value: 'Saved.',
+        "token": "euiSuggest.stateSavedTooltip",
+        "changeType": "added",
+        "value": "Saved."
       },
       {
-        token: 'euiSuggest.stateUnsavedTooltip',
-        changeType: 'added',
-        value: 'Changes have not been saved.',
+        "token": "euiSuggest.stateUnsavedTooltip",
+        "changeType": "added",
+        "value": "Changes have not been saved."
       },
       {
-        token: 'euiSuggest.stateLoading',
-        changeType: 'added',
-        value: 'State: loading.',
+        "token": "euiSuggest.stateLoading",
+        "changeType": "added",
+        "value": "State: loading."
       },
       {
-        token: 'euiSuggest.stateSaved',
-        changeType: 'added',
-        value: 'State: saved.',
+        "token": "euiSuggest.stateSaved",
+        "changeType": "added",
+        "value": "State: saved."
       },
       {
-        token: 'euiSuggest.stateUnsaved',
-        changeType: 'added',
-        value: 'State: unsaved.',
+        "token": "euiSuggest.stateUnsaved",
+        "changeType": "added",
+        "value": "State: unsaved."
       },
       {
-        token: 'euiSuggest.stateUnchanged',
-        changeType: 'added',
-        value: 'State: unchanged.',
-      },
-    ],
+        "token": "euiSuggest.stateUnchanged",
+        "changeType": "added",
+        "value": "State: unchanged."
+      }
+    ]
   },
   {
-    version: '47.0.0',
-    changes: [
+    "version": "47.0.0",
+    "changes": [
       {
-        token: 'euiSelectableListItem.includedOption',
-        changeType: 'modified',
-        value: 'Selected option.',
+        "token": "euiSelectableListItem.includedOption",
+        "changeType": "modified",
+        "value": "Selected option."
       },
       {
-        token: 'euiSelectableListItem.excludedOptionInstructions',
-        changeType: 'modified',
-        value: 'To uncheck this option, press enter.',
+        "token": "euiSelectableListItem.excludedOptionInstructions",
+        "changeType": "modified",
+        "value": "To uncheck this option, press enter."
       },
       {
-        token: 'euiSelectableListItem.unckeckedOptionInstructions',
-        changeType: 'added',
-        value: 'To select this option, press enter.',
+        "token": "euiSelectableListItem.unckeckedOptionInstructions",
+        "changeType": "added",
+        "value": "To select this option, press enter."
       },
       {
-        token: 'euiSelectableListItem.checkedOption',
-        changeType: 'added',
-        value: 'Checked option.',
+        "token": "euiSelectableListItem.checkedOption",
+        "changeType": "added",
+        "value": "Checked option."
       },
       {
-        token: 'euiSelectableListItem.checkedOptionInstructions',
-        changeType: 'added',
-        value: 'To uncheck this option, press enter.',
+        "token": "euiSelectableListItem.checkedOptionInstructions",
+        "changeType": "added",
+        "value": "To uncheck this option, press enter."
       },
       {
-        token: 'euiSelectable.searchResults',
-        changeType: 'added',
-        value:
-          "({\n  resultsLength\n}) => `${resultsLength} result${resultsLength === 1 ? '' : 's'} available`;",
+        "token": "euiSelectable.searchResults",
+        "changeType": "added",
+        "value": "({\n  resultsLength\n}) => `${resultsLength} result${resultsLength === 1 ? '' : 's'} available`;"
       },
       {
-        token: 'euiSelectable.screenReaderInstructions',
-        changeType: 'added',
-        value:
-          'Use up and down arrows to move focus over options. Enter to select. Escape to collapse options.',
-      },
-    ],
+        "token": "euiSelectable.screenReaderInstructions",
+        "changeType": "added",
+        "value": "Use up and down arrows to move focus over options. Enter to select. Escape to collapse options."
+      }
+    ]
   },
   {
-    version: '43.0.0',
-    changes: [
+    "version": "43.0.0",
+    "changes": [
       {
-        token: 'euiStyleSelector.buttonText',
-        changeType: 'deleted',
+        "token": "euiStyleSelector.buttonText",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStyleSelector.buttonLegend',
-        changeType: 'deleted',
+        "token": "euiStyleSelector.buttonLegend",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStyleSelector.labelExpanded',
-        changeType: 'deleted',
+        "token": "euiStyleSelector.labelExpanded",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStyleSelector.labelNormal',
-        changeType: 'deleted',
+        "token": "euiStyleSelector.labelNormal",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStyleSelector.labelCompact',
-        changeType: 'deleted',
+        "token": "euiStyleSelector.labelCompact",
+        "changeType": "deleted"
       },
       {
-        token: 'euiRefreshInterval.start',
-        changeType: 'deleted',
+        "token": "euiRefreshInterval.start",
+        "changeType": "deleted"
       },
       {
-        token: 'euiRefreshInterval.stop',
-        changeType: 'deleted',
+        "token": "euiRefreshInterval.stop",
+        "changeType": "deleted"
       },
       {
-        token: 'euiRefreshInterval.fullDescription',
-        changeType: 'deleted',
+        "token": "euiRefreshInterval.fullDescription",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSuperDatePicker.showDatesButtonLabel',
-        changeType: 'deleted',
+        "token": "euiSuperDatePicker.showDatesButtonLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDisplaySelector.buttonText',
-        changeType: 'added',
-        value: 'Display options',
+        "token": "euiDisplaySelector.buttonText",
+        "changeType": "added",
+        "value": "Display options"
       },
       {
-        token: 'euiDisplaySelector.resetButtonText',
-        changeType: 'added',
-        value: 'Reset to default',
+        "token": "euiDisplaySelector.resetButtonText",
+        "changeType": "added",
+        "value": "Reset to default"
       },
       {
-        token: 'euiDisplaySelector.densityLabel',
-        changeType: 'added',
-        value: 'Density',
+        "token": "euiDisplaySelector.densityLabel",
+        "changeType": "added",
+        "value": "Density"
       },
       {
-        token: 'euiDisplaySelector.labelCompact',
-        changeType: 'added',
-        value: 'Compact',
+        "token": "euiDisplaySelector.labelCompact",
+        "changeType": "added",
+        "value": "Compact"
       },
       {
-        token: 'euiDisplaySelector.labelNormal',
-        changeType: 'added',
-        value: 'Normal',
+        "token": "euiDisplaySelector.labelNormal",
+        "changeType": "added",
+        "value": "Normal"
       },
       {
-        token: 'euiDisplaySelector.labelExpanded',
-        changeType: 'added',
-        value: 'Expanded',
+        "token": "euiDisplaySelector.labelExpanded",
+        "changeType": "added",
+        "value": "Expanded"
       },
       {
-        token: 'euiDisplaySelector.rowHeightLabel',
-        changeType: 'added',
-        value: 'Row height',
+        "token": "euiDisplaySelector.rowHeightLabel",
+        "changeType": "added",
+        "value": "Row height"
       },
       {
-        token: 'euiDisplaySelector.labelSingle',
-        changeType: 'added',
-        value: 'Single',
+        "token": "euiDisplaySelector.labelSingle",
+        "changeType": "added",
+        "value": "Single"
       },
       {
-        token: 'euiDisplaySelector.labelAuto',
-        changeType: 'added',
-        value: 'Auto fit',
+        "token": "euiDisplaySelector.labelAuto",
+        "changeType": "added",
+        "value": "Auto fit"
       },
       {
-        token: 'euiDisplaySelector.labelCustom',
-        changeType: 'added',
-        value: 'Custom',
+        "token": "euiDisplaySelector.labelCustom",
+        "changeType": "added",
+        "value": "Custom"
       },
       {
-        token: 'euiDisplaySelector.lineCountLabel',
-        changeType: 'added',
-        value: 'Lines per row',
+        "token": "euiDisplaySelector.lineCountLabel",
+        "changeType": "added",
+        "value": "Lines per row"
       },
       {
-        token: 'euiAutoRefresh.autoRefreshLabel',
-        changeType: 'added',
-        value: 'Auto refresh',
+        "token": "euiAutoRefresh.autoRefreshLabel",
+        "changeType": "added",
+        "value": "Auto refresh"
       },
       {
-        token: 'euiAutoRefresh.buttonLabelOff',
-        changeType: 'added',
-        value: 'Auto refresh is off',
+        "token": "euiAutoRefresh.buttonLabelOff",
+        "changeType": "added",
+        "value": "Auto refresh is off"
       },
       {
-        token: 'euiAutoRefresh.buttonLabelOn',
-        changeType: 'added',
-        value: 'Auto refresh is on and set to {prettyInterval}',
+        "token": "euiAutoRefresh.buttonLabelOn",
+        "changeType": "added",
+        "value": "Auto refresh is on and set to {prettyInterval}"
       },
       {
-        token: 'euiRefreshInterval.fullDescriptionOff',
-        changeType: 'added',
-        value: 'Refresh is off, interval set to {optionValue} {optionText}.',
+        "token": "euiRefreshInterval.fullDescriptionOff",
+        "changeType": "added",
+        "value": "Refresh is off, interval set to {optionValue} {optionText}."
       },
       {
-        token: 'euiRefreshInterval.fullDescriptionOn',
-        changeType: 'added',
-        value: 'Refresh is on, interval set to {optionValue} {optionText}.',
-      },
-    ],
+        "token": "euiRefreshInterval.fullDescriptionOn",
+        "changeType": "added",
+        "value": "Refresh is on, interval set to {optionValue} {optionText}."
+      }
+    ]
   },
   {
-    version: '42.1.0',
-    changes: [
+    "version": "42.1.0",
+    "changes": [
       {
-        token: 'euiPagination.previousPage',
-        changeType: 'deleted',
+        "token": "euiPagination.previousPage",
+        "changeType": "deleted"
       },
       {
-        token: 'euiPagination.disabledPreviousPage',
-        changeType: 'deleted',
+        "token": "euiPagination.disabledPreviousPage",
+        "changeType": "deleted"
       },
       {
-        token: 'euiPagination.nextPage',
-        changeType: 'deleted',
+        "token": "euiPagination.nextPage",
+        "changeType": "deleted"
       },
       {
-        token: 'euiPagination.disabledNextPage',
-        changeType: 'deleted',
+        "token": "euiPagination.disabledNextPage",
+        "changeType": "deleted"
       },
       {
-        token: 'euiPaginationButtonArrow.firstPage',
-        changeType: 'added',
-        value: 'First page',
+        "token": "euiPaginationButtonArrow.firstPage",
+        "changeType": "added",
+        "value": "First page"
       },
       {
-        token: 'euiPaginationButtonArrow.previousPage',
-        changeType: 'added',
-        value: 'Previous page',
+        "token": "euiPaginationButtonArrow.previousPage",
+        "changeType": "added",
+        "value": "Previous page"
       },
       {
-        token: 'euiPaginationButtonArrow.nextPage',
-        changeType: 'added',
-        value: 'Next page',
+        "token": "euiPaginationButtonArrow.nextPage",
+        "changeType": "added",
+        "value": "Next page"
       },
       {
-        token: 'euiPaginationButtonArrow.lastPage',
-        changeType: 'added',
-        value: 'Last page',
+        "token": "euiPaginationButtonArrow.lastPage",
+        "changeType": "added",
+        "value": "Last page"
       },
       {
-        token: 'euiPagination.last',
-        changeType: 'added',
-        value: 'Last',
+        "token": "euiPagination.last",
+        "changeType": "added",
+        "value": "Last"
       },
       {
-        token: 'euiPagination.page',
-        changeType: 'added',
-        value: 'Page',
+        "token": "euiPagination.page",
+        "changeType": "added",
+        "value": "Page"
       },
       {
-        token: 'euiPagination.of',
-        changeType: 'added',
-        value: 'of',
+        "token": "euiPagination.of",
+        "changeType": "added",
+        "value": "of"
       },
       {
-        token: 'euiPagination.collection',
-        changeType: 'added',
-        value: 'collection',
+        "token": "euiPagination.collection",
+        "changeType": "added",
+        "value": "collection"
       },
       {
-        token: 'euiPagination.fromEndLabel',
-        changeType: 'added',
-        value: 'from end',
-      },
-    ],
+        "token": "euiPagination.fromEndLabel",
+        "changeType": "added",
+        "value": "from end"
+      }
+    ]
   },
   {
-    version: '41.2.0',
-    changes: [
+    "version": "41.2.0",
+    "changes": [
       {
-        token: 'euiSuperSelect.screenReaderAnnouncement',
-        changeType: 'modified',
-        value:
-          'You are in a form selector and must select a single option.\n              Use the up and down keys to navigate or escape to close.',
-      },
-    ],
+        "token": "euiSuperSelect.screenReaderAnnouncement",
+        "changeType": "modified",
+        "value": "You are in a form selector and must select a single option.\n              Use the up and down keys to navigate or escape to close."
+      }
+    ]
   },
   {
-    version: '41.1.0',
-    changes: [
+    "version": "41.1.0",
+    "changes": [
       {
-        token: 'euiErrorBoundary.error',
-        changeType: 'added',
-        value: 'Error',
-      },
-    ],
+        "token": "euiErrorBoundary.error",
+        "changeType": "added",
+        "value": "Error"
+      }
+    ]
   },
   {
-    version: '41.0.0',
-    changes: [
+    "version": "41.0.0",
+    "changes": [
       {
-        token: 'euiCodeEditor.startInteracting',
-        changeType: 'deleted',
+        "token": "euiCodeEditor.startInteracting",
+        "changeType": "deleted"
       },
       {
-        token: 'euiCodeEditor.startEditing',
-        changeType: 'deleted',
+        "token": "euiCodeEditor.startEditing",
+        "changeType": "deleted"
       },
       {
-        token: 'euiCodeEditor.stopInteracting',
-        changeType: 'deleted',
+        "token": "euiCodeEditor.stopInteracting",
+        "changeType": "deleted"
       },
       {
-        token: 'euiCodeEditor.stopEditing',
-        changeType: 'deleted',
-      },
-    ],
+        "token": "euiCodeEditor.stopEditing",
+        "changeType": "deleted"
+      }
+    ]
   },
   {
-    version: '39.1.1',
-    changes: [
+    "version": "39.1.1",
+    "changes": [
       {
-        token: 'euiRelativeTab.dateInputError',
-        changeType: 'added',
-        value: 'Must be a valid range',
-      },
-    ],
+        "token": "euiRelativeTab.dateInputError",
+        "changeType": "added",
+        "value": "Must be a valid range"
+      }
+    ]
   },
   {
-    version: '39.1.0',
-    changes: [
+    "version": "39.1.0",
+    "changes": [
       {
-        token: 'euiBasicTable.tablePagination',
-        changeType: 'modified',
-        value: 'Pagination for table: {tableCaption}',
-      },
-    ],
+        "token": "euiBasicTable.tablePagination",
+        "changeType": "modified",
+        "value": "Pagination for table: {tableCaption}"
+      }
+    ]
   },
   {
-    version: '39.0.0',
-    changes: [
+    "version": "39.0.0",
+    "changes": [
       {
-        token: 'euiBasicTable.noItemsMessage',
-        changeType: 'added',
-        value: 'No items found',
-      },
-    ],
+        "token": "euiBasicTable.noItemsMessage",
+        "changeType": "added",
+        "value": "No items found"
+      }
+    ]
   },
   {
-    version: '38.1.0',
-    changes: [
+    "version": "38.1.0",
+    "changes": [
       {
-        token: 'euiMarkdownEditorFooter.descriptionPrefix',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.descriptionPrefix",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorFooter.descriptionSuffix',
-        changeType: 'deleted',
+        "token": "euiMarkdownEditorFooter.descriptionSuffix",
+        "changeType": "deleted"
       },
       {
-        token: 'euiMarkdownEditorFooter.mdSyntaxLink',
-        changeType: 'added',
-        value: 'GitHub flavored markdown',
+        "token": "euiMarkdownEditorFooter.mdSyntaxLink",
+        "changeType": "added",
+        "value": "GitHub flavored markdown"
       },
       {
-        token: 'euiMarkdownEditorFooter.syntaxModalDescriptionPrefix',
-        changeType: 'added',
-        value: 'This editor uses',
+        "token": "euiMarkdownEditorFooter.syntaxModalDescriptionPrefix",
+        "changeType": "added",
+        "value": "This editor uses"
       },
       {
-        token: 'euiMarkdownEditorFooter.syntaxModalDescriptionSuffix',
-        changeType: 'added',
-        value:
-          'You can also utilize these additional syntax plugins to add rich content to your text.',
+        "token": "euiMarkdownEditorFooter.syntaxModalDescriptionSuffix",
+        "changeType": "added",
+        "value": "You can also utilize these additional syntax plugins to add rich content to your text."
       },
       {
-        token: 'euiMarkdownEditorFooter.syntaxPopoverDescription',
-        changeType: 'added',
-        value: 'This editor uses',
-      },
-    ],
+        "token": "euiMarkdownEditorFooter.syntaxPopoverDescription",
+        "changeType": "added",
+        "value": "This editor uses"
+      }
+    ]
   },
   {
-    version: '37.3.1',
-    changes: [
+    "version": "37.3.1",
+    "changes": [
       {
-        token: 'euiColumnSorting.buttonActive',
-        changeType: 'modified',
-        value:
-          "({\n  numberOfSortedFields\n}) => `${numberOfSortedFields} field${numberOfSortedFields === 1 ? '' : 's'} sorted`;",
+        "token": "euiColumnSorting.buttonActive",
+        "changeType": "modified",
+        "value": "({\n  numberOfSortedFields\n}) => `${numberOfSortedFields} field${numberOfSortedFields === 1 ? '' : 's'} sorted`;"
       },
       {
-        token: 'euiFilterButton.filterBadge',
-        changeType: 'deleted',
+        "token": "euiFilterButton.filterBadge",
+        "changeType": "deleted"
       },
       {
-        token: 'euiFilePicker.filesSelected',
-        changeType: 'modified',
-        value: '{fileCount} files selected',
+        "token": "euiFilePicker.filesSelected",
+        "changeType": "modified",
+        "value": "{fileCount} files selected"
       },
       {
-        token: 'euiFilterButton.filterBadgeActiveAriaLabel',
-        changeType: 'added',
-        value: '{count} active filters',
+        "token": "euiFilterButton.filterBadgeActiveAriaLabel",
+        "changeType": "added",
+        "value": "{count} active filters"
       },
       {
-        token: 'euiFilterButton.filterBadgeAvailableAriaLabel',
-        changeType: 'added',
-        value: '{count} available filters',
+        "token": "euiFilterButton.filterBadgeAvailableAriaLabel",
+        "changeType": "added",
+        "value": "{count} available filters"
       },
       {
-        token: 'euiFilePicker.promptText',
-        changeType: 'added',
-        value: 'Select or drag and drop a file',
-      },
-    ],
+        "token": "euiFilePicker.promptText",
+        "changeType": "added",
+        "value": "Select or drag and drop a file"
+      }
+    ]
   },
   {
-    version: '37.3.0',
-    changes: [
+    "version": "37.3.0",
+    "changes": [
       {
-        token: 'euiColumnSortingDraggable.activeSortLabel',
-        changeType: 'modified',
-        value: '{display} is sorting this data grid',
+        "token": "euiColumnSortingDraggable.activeSortLabel",
+        "changeType": "modified",
+        "value": "{display} is sorting this data grid"
       },
       {
-        token: 'euiColumnSortingDraggable.removeSortLabel',
-        changeType: 'modified',
-        value: 'Remove {display} from data grid sort',
+        "token": "euiColumnSortingDraggable.removeSortLabel",
+        "changeType": "modified",
+        "value": "Remove {display} from data grid sort"
       },
       {
-        token: 'euiColumnSortingDraggable.toggleLegend',
-        changeType: 'modified',
-        value: 'Select sorting method for {display}',
+        "token": "euiColumnSortingDraggable.toggleLegend",
+        "changeType": "modified",
+        "value": "Select sorting method for {display}"
       },
       {
-        token: 'euiDataGridCell.row',
-        changeType: 'deleted',
+        "token": "euiDataGridCell.row",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGridCell.column',
-        changeType: 'deleted',
+        "token": "euiDataGridCell.column",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGrid.ariaLabelGridPagination',
-        changeType: 'deleted',
+        "token": "euiDataGrid.ariaLabelGridPagination",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGrid.ariaLabelledByGridPagination',
-        changeType: 'deleted',
+        "token": "euiDataGrid.ariaLabelledByGridPagination",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGrid.fullScreenButton',
-        changeType: 'deleted',
+        "token": "euiDataGrid.fullScreenButton",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGrid.fullScreenButtonActive',
-        changeType: 'deleted',
+        "token": "euiDataGrid.fullScreenButtonActive",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGridCell.position',
-        changeType: 'added',
-        value: 'Row: {row}; Column: {col}',
+        "token": "euiDataGridCell.position",
+        "changeType": "added",
+        "value": "Row: {row}; Column: {col}"
       },
       {
-        token: 'euiDataGridPagination.detailedPaginationLabel',
-        changeType: 'added',
-        value: 'Pagination for preceding grid: {label}',
+        "token": "euiDataGridPagination.detailedPaginationLabel",
+        "changeType": "added",
+        "value": "Pagination for preceding grid: {label}"
       },
       {
-        token: 'euiDataGridPagination.paginationLabel',
-        changeType: 'added',
-        value: 'Pagination for preceding grid',
+        "token": "euiDataGridPagination.paginationLabel",
+        "changeType": "added",
+        "value": "Pagination for preceding grid"
       },
       {
-        token: 'euiDataGridToolbar.fullScreenButton',
-        changeType: 'added',
-        value: 'Full screen',
+        "token": "euiDataGridToolbar.fullScreenButton",
+        "changeType": "added",
+        "value": "Full screen"
       },
       {
-        token: 'euiDataGridToolbar.fullScreenButtonActive',
-        changeType: 'added',
-        value: 'Exit full screen',
-      },
-    ],
+        "token": "euiDataGridToolbar.fullScreenButtonActive",
+        "changeType": "added",
+        "value": "Exit full screen"
+      }
+    ]
   },
   {
-    version: '37.0.0',
-    changes: [
+    "version": "37.0.0",
+    "changes": [
       {
-        token: 'euiDatePopoverButton.invalidTitle',
-        changeType: 'added',
-        value: 'Invalid date: {title}',
+        "token": "euiDatePopoverButton.invalidTitle",
+        "changeType": "added",
+        "value": "Invalid date: {title}"
       },
       {
-        token: 'euiDatePopoverButton.outdatedTitle',
-        changeType: 'added',
-        value: 'Update needed: {title}',
-      },
-    ],
+        "token": "euiDatePopoverButton.outdatedTitle",
+        "changeType": "added",
+        "value": "Update needed: {title}"
+      }
+    ]
   },
   {
-    version: '36.1.0',
-    changes: [
+    "version": "36.1.0",
+    "changes": [
       {
-        token: 'euiBreadcrumbs.collapsedBadge.ariaLabel',
-        changeType: 'modified',
-        value: 'See collapsed breadcrumbs',
+        "token": "euiBreadcrumbs.collapsedBadge.ariaLabel",
+        "changeType": "modified",
+        "value": "See collapsed breadcrumbs"
       },
       {
-        token: 'euiBreadcrumbs.nav.ariaLabel',
-        changeType: 'added',
-        value: 'Breadcrumbs',
+        "token": "euiBreadcrumbs.nav.ariaLabel",
+        "changeType": "added",
+        "value": "Breadcrumbs"
       },
       {
-        token: 'euiStepStrings.current',
-        changeType: 'added',
-        value: 'Current step {number}: {title}',
+        "token": "euiStepStrings.current",
+        "changeType": "added",
+        "value": "Current step {number}: {title}"
       },
       {
-        token: 'euiStepStrings.simpleCurrent',
-        changeType: 'added',
-        value: 'Current step is {number}',
-      },
-    ],
+        "token": "euiStepStrings.simpleCurrent",
+        "changeType": "added",
+        "value": "Current step is {number}"
+      }
+    ]
   },
   {
-    version: '35.1.0',
-    changes: [
+    "version": "35.1.0",
+    "changes": [
       {
-        token: 'euiColorPicker.swatchAriaLabel',
-        changeType: 'deleted',
+        "token": "euiColorPicker.swatchAriaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorPicker.screenReaderAnnouncement',
-        changeType: 'deleted',
+        "token": "euiColorPicker.screenReaderAnnouncement",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSaturation.roleDescription',
-        changeType: 'deleted',
+        "token": "euiSaturation.roleDescription",
+        "changeType": "deleted"
       },
       {
-        token: 'euiSaturation.screenReaderAnnouncement',
-        changeType: 'deleted',
+        "token": "euiSaturation.screenReaderAnnouncement",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorPickerSwatch.ariaLabel',
-        changeType: 'added',
-        value: 'Select {color} as the color',
+        "token": "euiColorPickerSwatch.ariaLabel",
+        "changeType": "added",
+        "value": "Select {color} as the color"
       },
       {
-        token: 'euiColorPicker.popoverLabel',
-        changeType: 'added',
-        value: 'Color selection dialog',
+        "token": "euiColorPicker.popoverLabel",
+        "changeType": "added",
+        "value": "Color selection dialog"
       },
       {
-        token: 'euiSaturation.ariaLabel',
-        changeType: 'added',
-        value: 'HSV color mode saturation and value 2-axis slider',
+        "token": "euiSaturation.ariaLabel",
+        "changeType": "added",
+        "value": "HSV color mode saturation and value 2-axis slider"
       },
       {
-        token: 'euiSaturation.screenReaderInstructions',
-        changeType: 'added',
-        value:
-          "Arrow keys to navigate the square color gradient. Coordinates will be used to calculate HSV color mode 'saturation' and 'value' numbers, in the range of 0 to 1. Left and right to change the saturation. Up and down change the value.",
-      },
-    ],
+        "token": "euiSaturation.screenReaderInstructions",
+        "changeType": "added",
+        "value": "Arrow keys to navigate the square color gradient. Coordinates will be used to calculate HSV color mode 'saturation' and 'value' numbers, in the range of 0 to 1. Left and right to change the saturation. Up and down change the value."
+      }
+    ]
   },
   {
-    version: '34.5.0',
-    changes: [
+    "version": "34.5.0",
+    "changes": [
       {
-        token: 'euiNotificationEventReadIcon.readAria',
-        changeType: 'added',
-        value: '{eventName} is read',
+        "token": "euiNotificationEventReadIcon.readAria",
+        "changeType": "added",
+        "value": "{eventName} is read"
       },
       {
-        token: 'euiNotificationEventReadIcon.unreadAria',
-        changeType: 'added',
-        value: '{eventName} is unread',
+        "token": "euiNotificationEventReadIcon.unreadAria",
+        "changeType": "added",
+        "value": "{eventName} is unread"
       },
       {
-        token: 'euiNotificationEventReadIcon.read',
-        changeType: 'added',
-        value: 'Read',
+        "token": "euiNotificationEventReadIcon.read",
+        "changeType": "added",
+        "value": "Read"
       },
       {
-        token: 'euiNotificationEventReadIcon.unread',
-        changeType: 'added',
-        value: 'Unread',
-      },
-    ],
+        "token": "euiNotificationEventReadIcon.unread",
+        "changeType": "added",
+        "value": "Unread"
+      }
+    ]
   },
   {
-    version: '34.0.0',
-    changes: [
+    "version": "34.0.0",
+    "changes": [
       {
-        token: 'euiCollapsibleNav.closeButtonLabel',
-        changeType: 'deleted',
+        "token": "euiCollapsibleNav.closeButtonLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiTourStepIndicator.ariaLabel',
-        changeType: 'modified',
-        value: 'Step {number} {status}',
+        "token": "euiTourStepIndicator.ariaLabel",
+        "changeType": "modified",
+        "value": "Step {number} {status}"
       },
       {
-        token: 'euiTourStep.closeTour',
-        changeType: 'modified',
-        value: 'Close tour',
-      },
-    ],
+        "token": "euiTourStep.closeTour",
+        "changeType": "modified",
+        "value": "Close tour"
+      }
+    ]
   },
   {
-    version: '33.0.0',
-    changes: [
+    "version": "33.0.0",
+    "changes": [
       {
-        token: 'euiTableHeaderCell.clickForDescending',
-        changeType: 'deleted',
+        "token": "euiTableHeaderCell.clickForDescending",
+        "changeType": "deleted"
       },
       {
-        token: 'euiTableHeaderCell.clickForUnsort',
-        changeType: 'deleted',
+        "token": "euiTableHeaderCell.clickForUnsort",
+        "changeType": "deleted"
       },
       {
-        token: 'euiTableHeaderCell.clickForAscending',
-        changeType: 'deleted',
+        "token": "euiTableHeaderCell.clickForAscending",
+        "changeType": "deleted"
       },
       {
-        token: 'euiTableHeaderCell.titleTextWithSort',
-        changeType: 'deleted',
+        "token": "euiTableHeaderCell.titleTextWithSort",
+        "changeType": "deleted"
       },
       {
-        token: 'euiTableHeaderCell.titleTextWithDesc',
-        changeType: 'added',
-        value: '{innerText}; {description}',
-      },
-    ],
+        "token": "euiTableHeaderCell.titleTextWithDesc",
+        "changeType": "added",
+        "value": "{innerText}; {description}"
+      }
+    ]
   },
   {
-    version: '32.3.0',
-    changes: [
+    "version": "32.3.0",
+    "changes": [
       {
-        token: 'euiFilePicker.removeSelected',
-        changeType: 'added',
-        value: 'Remove',
-      },
-    ],
+        "token": "euiFilePicker.removeSelected",
+        "changeType": "added",
+        "value": "Remove"
+      }
+    ]
   },
   {
-    version: '32.2.0',
-    changes: [
+    "version": "32.2.0",
+    "changes": [
       {
-        token: 'euiDataGridSchema.dateSortTextAsc',
-        changeType: 'modified',
-        value: 'Old-New',
+        "token": "euiDataGridSchema.dateSortTextAsc",
+        "changeType": "modified",
+        "value": "Old-New"
       },
       {
-        token: 'euiDataGridSchema.dateSortTextDesc',
-        changeType: 'modified',
-        value: 'New-Old',
-      },
-    ],
+        "token": "euiDataGridSchema.dateSortTextDesc",
+        "changeType": "modified",
+        "value": "New-Old"
+      }
+    ]
   },
   {
-    version: '32.1.0',
-    changes: [
+    "version": "32.1.0",
+    "changes": [
       {
-        token: 'euiTableHeaderCell.sortedAriaLabel',
-        changeType: 'deleted',
-      },
-    ],
+        "token": "euiTableHeaderCell.sortedAriaLabel",
+        "changeType": "deleted"
+      }
+    ]
   },
   {
-    version: '31.11.0',
-    changes: [
+    "version": "31.11.0",
+    "changes": [
       {
-        token: 'euiNotificationEventMessages.accordionButtonText',
-        changeType: 'added',
-        value: '+ {messagesLength} more',
+        "token": "euiNotificationEventMessages.accordionButtonText",
+        "changeType": "added",
+        "value": "+ {messagesLength} more"
       },
       {
-        token: 'euiNotificationEventMessages.accordionAriaLabelButtonText',
-        changeType: 'added',
-        value: '+ {messagesLength} messages for {eventName}',
+        "token": "euiNotificationEventMessages.accordionAriaLabelButtonText",
+        "changeType": "added",
+        "value": "+ {messagesLength} messages for {eventName}"
       },
       {
-        token: 'euiNotificationEventMessages.accordionHideText',
-        changeType: 'added',
-        value: 'hide',
+        "token": "euiNotificationEventMessages.accordionHideText",
+        "changeType": "added",
+        "value": "hide"
       },
       {
-        token: 'euiNotificationEventMeta.contextMenuButton',
-        changeType: 'added',
-        value: 'Menu for {eventName}',
+        "token": "euiNotificationEventMeta.contextMenuButton",
+        "changeType": "added",
+        "value": "Menu for {eventName}"
       },
       {
-        token: 'euiNotificationEventReadButton.markAsReadAria',
-        changeType: 'added',
-        value: 'Mark {eventName} as read',
+        "token": "euiNotificationEventReadButton.markAsReadAria",
+        "changeType": "added",
+        "value": "Mark {eventName} as read"
       },
       {
-        token: 'euiNotificationEventReadButton.markAsUnreadAria',
-        changeType: 'added',
-        value: 'Mark {eventName} as unread',
+        "token": "euiNotificationEventReadButton.markAsUnreadAria",
+        "changeType": "added",
+        "value": "Mark {eventName} as unread"
       },
       {
-        token: 'euiNotificationEventReadButton.markAsRead',
-        changeType: 'added',
-        value: 'Mark as read',
+        "token": "euiNotificationEventReadButton.markAsRead",
+        "changeType": "added",
+        "value": "Mark as read"
       },
       {
-        token: 'euiNotificationEventReadButton.markAsUnread',
-        changeType: 'added',
-        value: 'Mark as unread',
-      },
-    ],
+        "token": "euiNotificationEventReadButton.markAsUnread",
+        "changeType": "added",
+        "value": "Mark as unread"
+      }
+    ]
   },
   {
-    version: '31.9.0',
-    changes: [
+    "version": "31.9.0",
+    "changes": [
       {
-        token: 'euiDataGridSchema.booleanSortTextAsc',
-        changeType: 'modified',
-        value: 'False-True',
+        "token": "euiDataGridSchema.booleanSortTextAsc",
+        "changeType": "modified",
+        "value": "False-True"
       },
       {
-        token: 'euiDataGridSchema.booleanSortTextDesc',
-        changeType: 'modified',
-        value: 'True-False',
+        "token": "euiDataGridSchema.booleanSortTextDesc",
+        "changeType": "modified",
+        "value": "True-False"
       },
       {
-        token: 'euiCodeBlock.fullscreenCollapse',
-        changeType: 'added',
-        value: 'Collapse',
+        "token": "euiCodeBlock.fullscreenCollapse",
+        "changeType": "added",
+        "value": "Collapse"
       },
       {
-        token: 'euiCodeBlock.fullscreenExpand',
-        changeType: 'added',
-        value: 'Expand',
+        "token": "euiCodeBlock.fullscreenExpand",
+        "changeType": "added",
+        "value": "Expand"
       },
       {
-        token: 'euiColorPicker.colorLabel',
-        changeType: 'added',
-        value: 'Color value',
+        "token": "euiColorPicker.colorLabel",
+        "changeType": "added",
+        "value": "Color value"
       },
       {
-        token: 'euiColorPicker.colorErrorMessage',
-        changeType: 'added',
-        value: 'Invalid color value',
+        "token": "euiColorPicker.colorErrorMessage",
+        "changeType": "added",
+        "value": "Invalid color value"
       },
       {
-        token: 'euiColorPicker.transparent',
-        changeType: 'added',
-        value: 'Transparent',
+        "token": "euiColorPicker.transparent",
+        "changeType": "added",
+        "value": "Transparent"
       },
       {
-        token: 'euiColorPicker.openLabel',
-        changeType: 'added',
-        value: 'Press the escape key to close the popover',
+        "token": "euiColorPicker.openLabel",
+        "changeType": "added",
+        "value": "Press the escape key to close the popover"
       },
       {
-        token: 'euiColorPicker.closeLabel',
-        changeType: 'added',
-        value: 'Press the down key to open a popover containing color options',
+        "token": "euiColorPicker.closeLabel",
+        "changeType": "added",
+        "value": "Press the down key to open a popover containing color options"
       },
       {
-        token: 'euiColorStopThumb.buttonAriaLabel',
-        changeType: 'added',
-        value:
-          'Press the Enter key to modify this stop. Press Escape to focus the group',
+        "token": "euiColorStopThumb.buttonAriaLabel",
+        "changeType": "added",
+        "value": "Press the Enter key to modify this stop. Press Escape to focus the group"
       },
       {
-        token: 'euiColorStopThumb.buttonTitle',
-        changeType: 'added',
-        value: 'Click to edit, drag to reposition',
+        "token": "euiColorStopThumb.buttonTitle",
+        "changeType": "added",
+        "value": "Click to edit, drag to reposition"
       },
       {
-        token: 'euiColorStopThumb.stopLabel',
-        changeType: 'added',
-        value: 'Stop value',
+        "token": "euiColorStopThumb.stopLabel",
+        "changeType": "added",
+        "value": "Stop value"
       },
       {
-        token: 'euiColorStopThumb.stopErrorMessage',
-        changeType: 'added',
-        value: 'Value is out of range',
+        "token": "euiColorStopThumb.stopErrorMessage",
+        "changeType": "added",
+        "value": "Value is out of range"
       },
       {
-        token: 'euiColumnSelector.search',
-        changeType: 'added',
-        value: 'Search',
+        "token": "euiColumnSelector.search",
+        "changeType": "added",
+        "value": "Search"
       },
       {
-        token: 'euiColumnSelector.searchcolumns',
-        changeType: 'added',
-        value: 'Search columns',
+        "token": "euiColumnSelector.searchcolumns",
+        "changeType": "added",
+        "value": "Search columns"
       },
       {
-        token: 'euiColumnSorting.button',
-        changeType: 'added',
-        value: 'Sort fields',
+        "token": "euiColumnSorting.button",
+        "changeType": "added",
+        "value": "Sort fields"
       },
       {
-        token: 'euiColumnSorting.buttonActive',
-        changeType: 'added',
-        value: 'fields sorted',
+        "token": "euiColumnSorting.buttonActive",
+        "changeType": "added",
+        "value": "fields sorted"
       },
       {
-        token: 'euiDataGridCell.row',
-        changeType: 'added',
-        value: 'Row',
+        "token": "euiDataGridCell.row",
+        "changeType": "added",
+        "value": "Row"
       },
       {
-        token: 'euiDataGridCell.column',
-        changeType: 'added',
-        value: 'Column',
+        "token": "euiDataGridCell.column",
+        "changeType": "added",
+        "value": "Column"
       },
       {
-        token: 'euiDataGrid.fullScreenButton',
-        changeType: 'added',
-        value: 'Full screen',
+        "token": "euiDataGrid.fullScreenButton",
+        "changeType": "added",
+        "value": "Full screen"
       },
       {
-        token: 'euiDataGrid.fullScreenButtonActive',
-        changeType: 'added',
-        value: 'Exit full screen',
+        "token": "euiDataGrid.fullScreenButtonActive",
+        "changeType": "added",
+        "value": "Exit full screen"
       },
       {
-        token: 'euiStyleSelector.buttonLegend',
-        changeType: 'added',
-        value: 'Select the display density for the data grid',
+        "token": "euiStyleSelector.buttonLegend",
+        "changeType": "added",
+        "value": "Select the display density for the data grid"
       },
       {
-        token: 'euiStyleSelector.labelExpanded',
-        changeType: 'added',
-        value: 'Expanded density',
+        "token": "euiStyleSelector.labelExpanded",
+        "changeType": "added",
+        "value": "Expanded density"
       },
       {
-        token: 'euiStyleSelector.labelNormal',
-        changeType: 'added',
-        value: 'Normal density',
+        "token": "euiStyleSelector.labelNormal",
+        "changeType": "added",
+        "value": "Normal density"
       },
       {
-        token: 'euiStyleSelector.labelCompact',
-        changeType: 'added',
-        value: 'Compact density',
+        "token": "euiStyleSelector.labelCompact",
+        "changeType": "added",
+        "value": "Compact density"
       },
       {
-        token: 'euiRelativeTab.numberInputError',
-        changeType: 'added',
-        value: 'Must be >= 0',
+        "token": "euiRelativeTab.numberInputError",
+        "changeType": "added",
+        "value": "Must be >= 0"
       },
       {
-        token: 'euiRelativeTab.numberInputLabel',
-        changeType: 'added',
-        value: 'Time span amount',
+        "token": "euiRelativeTab.numberInputLabel",
+        "changeType": "added",
+        "value": "Time span amount"
       },
       {
-        token: 'euiFieldPassword.showPassword',
-        changeType: 'added',
-        value:
-          'Show password as plain text. Note: this will visually expose your password on the screen.',
+        "token": "euiFieldPassword.showPassword",
+        "changeType": "added",
+        "value": "Show password as plain text. Note: this will visually expose your password on the screen."
       },
       {
-        token: 'euiFieldPassword.maskPassword',
-        changeType: 'added',
-        value: 'Mask password',
+        "token": "euiFieldPassword.maskPassword",
+        "changeType": "added",
+        "value": "Mask password"
       },
       {
-        token: 'euiFilePicker.clearSelectedFiles',
-        changeType: 'added',
-        value: 'Clear selected files',
+        "token": "euiFilePicker.clearSelectedFiles",
+        "changeType": "added",
+        "value": "Clear selected files"
       },
       {
-        token: 'euiFilePicker.filesSelected',
-        changeType: 'added',
-        value: 'files selected',
+        "token": "euiFilePicker.filesSelected",
+        "changeType": "added",
+        "value": "files selected"
       },
       {
-        token: 'euiPinnableListGroup.pinExtraActionLabel',
-        changeType: 'added',
-        value: 'Pin item',
+        "token": "euiPinnableListGroup.pinExtraActionLabel",
+        "changeType": "added",
+        "value": "Pin item"
       },
       {
-        token: 'euiPinnableListGroup.pinnedExtraActionLabel',
-        changeType: 'added',
-        value: 'Unpin item',
+        "token": "euiPinnableListGroup.pinnedExtraActionLabel",
+        "changeType": "added",
+        "value": "Unpin item"
       },
       {
-        token: 'euiMarkdownEditorFooter.descriptionPrefix',
-        changeType: 'added',
-        value: 'This editor uses',
+        "token": "euiMarkdownEditorFooter.descriptionPrefix",
+        "changeType": "added",
+        "value": "This editor uses"
       },
       {
-        token: 'euiMarkdownEditorFooter.descriptionSuffix',
-        changeType: 'added',
-        value:
-          'You can also utilize these additional syntax plugins to add rich content to your text.',
+        "token": "euiMarkdownEditorFooter.descriptionSuffix",
+        "changeType": "added",
+        "value": "You can also utilize these additional syntax plugins to add rich content to your text."
       },
       {
-        token: 'euiResizableButton.horizontalResizerAriaLabel',
-        changeType: 'added',
-        value: 'Press left or right to adjust panels size',
+        "token": "euiResizableButton.horizontalResizerAriaLabel",
+        "changeType": "added",
+        "value": "Press left or right to adjust panels size"
       },
       {
-        token: 'euiResizableButton.verticalResizerAriaLabel',
-        changeType: 'added',
-        value: 'Press up or down to adjust panels size',
+        "token": "euiResizableButton.verticalResizerAriaLabel",
+        "changeType": "added",
+        "value": "Press up or down to adjust panels size"
       },
       {
-        token: 'euiSelectableTemplateSitewide.searchPlaceholder',
-        changeType: 'added',
-        value: 'Search for anything...',
+        "token": "euiSelectableTemplateSitewide.searchPlaceholder",
+        "changeType": "added",
+        "value": "Search for anything..."
       },
       {
-        token: 'euiTourStep.endTour',
-        changeType: 'added',
-        value: 'End tour',
+        "token": "euiTourStep.endTour",
+        "changeType": "added",
+        "value": "End tour"
       },
       {
-        token: 'euiTourStep.skipTour',
-        changeType: 'added',
-        value: 'Skip tour',
+        "token": "euiTourStep.skipTour",
+        "changeType": "added",
+        "value": "Skip tour"
       },
       {
-        token: 'euiTourStep.closeTour',
-        changeType: 'added',
-        value: 'Close',
-      },
-    ],
+        "token": "euiTourStep.closeTour",
+        "changeType": "added",
+        "value": "Close"
+      }
+    ]
   },
   {
-    version: '31.6.0',
-    changes: [
+    "version": "31.6.0",
+    "changes": [
       {
-        token: 'euiMarkdownEditorFooter.closeButton',
-        changeType: 'added',
-        value: 'Close',
-      },
-    ],
+        "token": "euiMarkdownEditorFooter.closeButton",
+        "changeType": "added",
+        "value": "Close"
+      }
+    ]
   },
   {
-    version: '31.0.0',
-    changes: [
+    "version": "31.0.0",
+    "changes": [
       {
-        token: 'euiRecentlyUsed.legend',
-        changeType: 'added',
-        value: 'Recently used date ranges',
+        "token": "euiRecentlyUsed.legend",
+        "changeType": "added",
+        "value": "Recently used date ranges"
       },
       {
-        token: 'euiResizablePanel.toggleButtonAriaLabel',
-        changeType: 'added',
-        value: 'Press to toggle this panel',
-      },
-    ],
+        "token": "euiResizablePanel.toggleButtonAriaLabel",
+        "changeType": "added",
+        "value": "Press to toggle this panel"
+      }
+    ]
   },
   {
-    version: '30.6.0',
-    changes: [
+    "version": "30.6.0",
+    "changes": [
       {
-        token: 'euiStepStrings.loading',
-        changeType: 'added',
-        value: 'Step {number}: {title} is loading',
+        "token": "euiStepStrings.loading",
+        "changeType": "added",
+        "value": "Step {number}: {title} is loading"
       },
       {
-        token: 'euiStepStrings.simpleLoading',
-        changeType: 'added',
-        value: 'Step {number} is loading',
-      },
-    ],
+        "token": "euiStepStrings.simpleLoading",
+        "changeType": "added",
+        "value": "Step {number} is loading"
+      }
+    ]
   },
   {
-    version: '30.2.0',
-    changes: [
+    "version": "30.2.0",
+    "changes": [
       {
-        token: 'euiColumnActions.sortAsc',
-        changeType: 'deleted',
+        "token": "euiColumnActions.sortAsc",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColumnActions.sortDesc',
-        changeType: 'deleted',
+        "token": "euiColumnActions.sortDesc",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColumnActions.sort',
-        changeType: 'added',
-        value: 'Sort {schemaLabel}',
+        "token": "euiColumnActions.sort",
+        "changeType": "added",
+        "value": "Sort {schemaLabel}"
       },
       {
-        token: 'euiLink.newTarget.screenReaderOnlyText',
-        changeType: 'added',
-        value: '(opens in a new tab or window)',
-      },
-    ],
+        "token": "euiLink.newTarget.screenReaderOnlyText",
+        "changeType": "added",
+        "value": "(opens in a new tab or window)"
+      }
+    ]
   },
   {
-    version: '30.0.0',
-    changes: [
+    "version": "30.0.0",
+    "changes": [
       {
-        token: 'euiDataGridCell.expandButtonTitle',
-        changeType: 'deleted',
+        "token": "euiDataGridCell.expandButtonTitle",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStepHorizontal.buttonTitle',
-        changeType: 'deleted',
+        "token": "euiStepHorizontal.buttonTitle",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStepHorizontal.step',
-        changeType: 'deleted',
+        "token": "euiStepHorizontal.step",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStepNumber.isComplete',
-        changeType: 'deleted',
+        "token": "euiStepNumber.isComplete",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStepNumber.hasWarnings',
-        changeType: 'deleted',
+        "token": "euiStepNumber.hasWarnings",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStepNumber.hasErrors',
-        changeType: 'deleted',
+        "token": "euiStepNumber.hasErrors",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStep.ariaLabel',
-        changeType: 'deleted',
+        "token": "euiStep.ariaLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiDataGridCellButtons.expandButtonTitle',
-        changeType: 'added',
-        value: 'Click or hit enter to interact with cell content',
+        "token": "euiDataGridCellButtons.expandButtonTitle",
+        "changeType": "added",
+        "value": "Click or hit enter to interact with cell content"
       },
       {
-        token: 'euiStepStrings.step',
-        changeType: 'added',
-        value: 'Step {number}: {title}',
+        "token": "euiStepStrings.step",
+        "changeType": "added",
+        "value": "Step {number}: {title}"
       },
       {
-        token: 'euiStepStrings.simpleStep',
-        changeType: 'added',
-        value: 'Step {number}',
+        "token": "euiStepStrings.simpleStep",
+        "changeType": "added",
+        "value": "Step {number}"
       },
       {
-        token: 'euiStepStrings.complete',
-        changeType: 'added',
-        value: 'Step {number}: {title} is complete',
+        "token": "euiStepStrings.complete",
+        "changeType": "added",
+        "value": "Step {number}: {title} is complete"
       },
       {
-        token: 'euiStepStrings.simpleComplete',
-        changeType: 'added',
-        value: 'Step {number} is complete',
+        "token": "euiStepStrings.simpleComplete",
+        "changeType": "added",
+        "value": "Step {number} is complete"
       },
       {
-        token: 'euiStepStrings.warning',
-        changeType: 'added',
-        value: 'Step {number}: {title} has warnings',
+        "token": "euiStepStrings.warning",
+        "changeType": "added",
+        "value": "Step {number}: {title} has warnings"
       },
       {
-        token: 'euiStepStrings.simpleWarning',
-        changeType: 'added',
-        value: 'Step {number} has warnings',
+        "token": "euiStepStrings.simpleWarning",
+        "changeType": "added",
+        "value": "Step {number} has warnings"
       },
       {
-        token: 'euiStepStrings.errors',
-        changeType: 'added',
-        value: 'Step {number}: {title} has errors',
+        "token": "euiStepStrings.errors",
+        "changeType": "added",
+        "value": "Step {number}: {title} has errors"
       },
       {
-        token: 'euiStepStrings.simpleErrors',
-        changeType: 'added',
-        value: 'Step {number} has errors',
+        "token": "euiStepStrings.simpleErrors",
+        "changeType": "added",
+        "value": "Step {number} has errors"
       },
       {
-        token: 'euiStepStrings.incomplete',
-        changeType: 'added',
-        value: 'Step {number}: {title} is incomplete',
+        "token": "euiStepStrings.incomplete",
+        "changeType": "added",
+        "value": "Step {number}: {title} is incomplete"
       },
       {
-        token: 'euiStepStrings.simpleIncomplete',
-        changeType: 'added',
-        value: 'Step {number} is incomplete',
+        "token": "euiStepStrings.simpleIncomplete",
+        "changeType": "added",
+        "value": "Step {number} is incomplete"
       },
       {
-        token: 'euiStepStrings.disabled',
-        changeType: 'added',
-        value: 'Step {number}: {title} is disabled',
+        "token": "euiStepStrings.disabled",
+        "changeType": "added",
+        "value": "Step {number}: {title} is disabled"
       },
       {
-        token: 'euiStepStrings.simpleDisabled',
-        changeType: 'added',
-        value: 'Step {number} is disabled',
-      },
-    ],
+        "token": "euiStepStrings.simpleDisabled",
+        "changeType": "added",
+        "value": "Step {number} is disabled"
+      }
+    ]
   },
   {
-    version: '29.1.0',
-    changes: [
+    "version": "29.1.0",
+    "changes": [
       {
-        token: 'euiHeaderLinks.openNavigationMenu',
-        changeType: 'modified',
-        value: 'Open menu',
+        "token": "euiHeaderLinks.openNavigationMenu",
+        "changeType": "modified",
+        "value": "Open menu"
       },
       {
-        token: 'euiHeaderLinks.appNavigation',
-        changeType: 'modified',
-        value: 'App menu',
+        "token": "euiHeaderLinks.appNavigation",
+        "changeType": "modified",
+        "value": "App menu"
       },
       {
-        token: 'euiColumnActions.hideColumn',
-        changeType: 'added',
-        value: 'Hide column',
+        "token": "euiColumnActions.hideColumn",
+        "changeType": "added",
+        "value": "Hide column"
       },
       {
-        token: 'euiColumnActions.sortAsc',
-        changeType: 'added',
-        value: 'Sort schema asc',
+        "token": "euiColumnActions.sortAsc",
+        "changeType": "added",
+        "value": "Sort schema asc"
       },
       {
-        token: 'euiColumnActions.sortDesc',
-        changeType: 'added',
-        value: 'Sort schema desc',
+        "token": "euiColumnActions.sortDesc",
+        "changeType": "added",
+        "value": "Sort schema desc"
       },
       {
-        token: 'euiColumnActions.moveLeft',
-        changeType: 'added',
-        value: 'Move left',
+        "token": "euiColumnActions.moveLeft",
+        "changeType": "added",
+        "value": "Move left"
       },
       {
-        token: 'euiColumnActions.moveRight',
-        changeType: 'added',
-        value: 'Move right',
+        "token": "euiColumnActions.moveRight",
+        "changeType": "added",
+        "value": "Move right"
       },
       {
-        token: 'euiDataGridHeaderCell.headerActions',
-        changeType: 'added',
-        value: 'Header actions',
-      },
-    ],
+        "token": "euiDataGridHeaderCell.headerActions",
+        "changeType": "added",
+        "value": "Header actions"
+      }
+    ]
   },
   {
-    version: '28.2.0',
-    changes: [
+    "version": "28.2.0",
+    "changes": [
       {
-        token: 'euiSelectableTemplateSitewide.loadingResults',
-        changeType: 'added',
-        value: 'Loading results',
+        "token": "euiSelectableTemplateSitewide.loadingResults",
+        "changeType": "added",
+        "value": "Loading results"
       },
       {
-        token: 'euiSelectableTemplateSitewide.noResults',
-        changeType: 'added',
-        value: 'No results available',
+        "token": "euiSelectableTemplateSitewide.noResults",
+        "changeType": "added",
+        "value": "No results available"
       },
       {
-        token: 'euiSelectableTemplateSitewide.onFocusBadgeGoTo',
-        changeType: 'added',
-        value: 'Go to',
-      },
-    ],
+        "token": "euiSelectableTemplateSitewide.onFocusBadgeGoTo",
+        "changeType": "added",
+        "value": "Go to"
+      }
+    ]
   },
   {
-    version: '28.1.0',
-    changes: [
+    "version": "28.1.0",
+    "changes": [
       {
-        token: 'euiAccordion.isLoading',
-        changeType: 'added',
-        value: 'Loading',
-      },
-    ],
+        "token": "euiAccordion.isLoading",
+        "changeType": "added",
+        "value": "Loading"
+      }
+    ]
   },
   {
-    version: '28.0.0',
-    changes: [
+    "version": "28.0.0",
+    "changes": [
       {
-        token: 'euiMarkdownEditorFooter.uploadingFiles',
-        changeType: 'added',
-        value: 'Click to upload files',
+        "token": "euiMarkdownEditorFooter.uploadingFiles",
+        "changeType": "added",
+        "value": "Click to upload files"
       },
       {
-        token: 'euiMarkdownEditorFooter.openUploadModal',
-        changeType: 'added',
-        value: 'Open upload files modal',
+        "token": "euiMarkdownEditorFooter.openUploadModal",
+        "changeType": "added",
+        "value": "Open upload files modal"
       },
       {
-        token: 'euiMarkdownEditorFooter.unsupportedFileType',
-        changeType: 'added',
-        value: 'File type not supported',
+        "token": "euiMarkdownEditorFooter.unsupportedFileType",
+        "changeType": "added",
+        "value": "File type not supported"
       },
       {
-        token: 'euiMarkdownEditorFooter.supportedFileTypes',
-        changeType: 'added',
-        value: 'Supported files: {supportedFileTypes}',
+        "token": "euiMarkdownEditorFooter.supportedFileTypes",
+        "changeType": "added",
+        "value": "Supported files: {supportedFileTypes}"
       },
       {
-        token: 'euiMarkdownEditorFooter.showSyntaxErrors',
-        changeType: 'added',
-        value: 'Show errors',
+        "token": "euiMarkdownEditorFooter.showSyntaxErrors",
+        "changeType": "added",
+        "value": "Show errors"
       },
       {
-        token: 'euiMarkdownEditorFooter.showMarkdownHelp',
-        changeType: 'added',
-        value: 'Show markdown help',
+        "token": "euiMarkdownEditorFooter.showMarkdownHelp",
+        "changeType": "added",
+        "value": "Show markdown help"
       },
       {
-        token: 'euiMarkdownEditorFooter.errorsTitle',
-        changeType: 'added',
-        value: 'Errors',
+        "token": "euiMarkdownEditorFooter.errorsTitle",
+        "changeType": "added",
+        "value": "Errors"
       },
       {
-        token: 'euiMarkdownEditorFooter.syntaxTitle',
-        changeType: 'added',
-        value: 'Syntax help',
+        "token": "euiMarkdownEditorFooter.syntaxTitle",
+        "changeType": "added",
+        "value": "Syntax help"
       },
       {
-        token: 'euiMarkdownEditorToolbar.editor',
-        changeType: 'added',
-        value: 'Editor',
+        "token": "euiMarkdownEditorToolbar.editor",
+        "changeType": "added",
+        "value": "Editor"
       },
       {
-        token: 'euiMarkdownEditorToolbar.previewMarkdown',
-        changeType: 'added',
-        value: 'Preview',
-      },
-    ],
+        "token": "euiMarkdownEditorToolbar.previewMarkdown",
+        "changeType": "added",
+        "value": "Preview"
+      }
+    ]
   },
   {
-    version: '27.3.0',
-    changes: [
+    "version": "27.3.0",
+    "changes": [
       {
-        token: 'euiComboBoxOptionsList.createCustomOption',
-        changeType: 'modified',
-        value: 'Add {searchValue} as a custom option',
+        "token": "euiComboBoxOptionsList.createCustomOption",
+        "changeType": "modified",
+        "value": "Add {searchValue} as a custom option"
       },
       {
-        token: 'euiComboBoxOptionsList.delimiterMessage',
-        changeType: 'modified',
-        value: 'Add each item separated by {delimiter}',
-      },
-    ],
+        "token": "euiComboBoxOptionsList.delimiterMessage",
+        "changeType": "modified",
+        "value": "Add each item separated by {delimiter}"
+      }
+    ]
   },
   {
-    version: '27.2.0',
-    changes: [
+    "version": "27.2.0",
+    "changes": [
       {
-        token: 'euiSelectableListItem.includedOptionInstructions',
-        changeType: 'modified',
-        value: 'To exclude this option, press enter.',
+        "token": "euiSelectableListItem.includedOptionInstructions",
+        "changeType": "modified",
+        "value": "To exclude this option, press enter."
       },
       {
-        token: 'euiSelectableListItem.excludedOptionInstructions',
-        changeType: 'modified',
-        value: 'To deselect this option, press enter.',
-      },
-    ],
+        "token": "euiSelectableListItem.excludedOptionInstructions",
+        "changeType": "modified",
+        "value": "To deselect this option, press enter."
+      }
+    ]
   },
   {
-    version: '27.0.0',
-    changes: [
+    "version": "27.0.0",
+    "changes": [
       {
-        token: 'euiProgress.valueText',
-        changeType: 'added',
-        value: '{value}%',
+        "token": "euiProgress.valueText",
+        "changeType": "added",
+        "value": "{value}%"
       },
       {
-        token: 'euiSelectableListItem.includedOption',
-        changeType: 'added',
-        value: 'Included option.',
+        "token": "euiSelectableListItem.includedOption",
+        "changeType": "added",
+        "value": "Included option."
       },
       {
-        token: 'euiSelectableListItem.includedOptionInstructions',
-        changeType: 'added',
-        value: 'To exclude this option, press enter or space.',
+        "token": "euiSelectableListItem.includedOptionInstructions",
+        "changeType": "added",
+        "value": "To exclude this option, press enter or space."
       },
       {
-        token: 'euiSelectableListItem.excludedOption',
-        changeType: 'added',
-        value: 'Excluded option.',
+        "token": "euiSelectableListItem.excludedOption",
+        "changeType": "added",
+        "value": "Excluded option."
       },
       {
-        token: 'euiSelectableListItem.excludedOptionInstructions',
-        changeType: 'added',
-        value: 'To deselect this option, press enter or space.',
+        "token": "euiSelectableListItem.excludedOptionInstructions",
+        "changeType": "added",
+        "value": "To deselect this option, press enter or space."
       },
       {
-        token: 'euiSelectable.placeholderName',
-        changeType: 'added',
-        value: 'Filter options',
-      },
-    ],
+        "token": "euiSelectable.placeholderName",
+        "changeType": "added",
+        "value": "Filter options"
+      }
+    ]
   },
   {
-    version: '26.0.0',
-    changes: [
+    "version": "26.0.0",
+    "changes": [
       {
-        token: 'euiBreadcrumbs.collapsedBadge.ariaLabel',
-        changeType: 'modified',
-        value: 'Show collapsed breadcrumbs',
+        "token": "euiBreadcrumbs.collapsedBadge.ariaLabel",
+        "changeType": "modified",
+        "value": "Show collapsed breadcrumbs"
       },
       {
-        token: 'euiForm.addressFormErrors',
-        changeType: 'modified',
-        value: 'Please address the highlighted errors.',
-      },
-    ],
+        "token": "euiForm.addressFormErrors",
+        "changeType": "modified",
+        "value": "Please address the highlighted errors."
+      }
+    ]
   },
   {
-    version: '25.0.0',
-    changes: [
+    "version": "25.0.0",
+    "changes": [
       {
-        token: 'euiBasicTable.tableDescriptionWithPagination',
-        changeType: 'deleted',
+        "token": "euiBasicTable.tableDescriptionWithPagination",
+        "changeType": "deleted"
       },
       {
-        token: 'euiBasicTable.tableDescriptionWithoutPagination',
-        changeType: 'deleted',
+        "token": "euiBasicTable.tableDescriptionWithoutPagination",
+        "changeType": "deleted"
       },
       {
-        token: 'euiPagination.pageOfTotal',
-        changeType: 'deleted',
+        "token": "euiPagination.pageOfTotal",
+        "changeType": "deleted"
       },
       {
-        token: 'euiPagination.previousPage',
-        changeType: 'modified',
-        value: 'Previous page, {page}',
+        "token": "euiPagination.previousPage",
+        "changeType": "modified",
+        "value": "Previous page, {page}"
       },
       {
-        token: 'euiPagination.jumpToLastPage',
-        changeType: 'deleted',
+        "token": "euiPagination.jumpToLastPage",
+        "changeType": "deleted"
       },
       {
-        token: 'euiPagination.nextPage',
-        changeType: 'modified',
-        value: 'Next page, {page}',
+        "token": "euiPagination.nextPage",
+        "changeType": "modified",
+        "value": "Next page, {page}"
       },
       {
-        token: 'euiBasicTable.tableCaptionWithPagination',
-        changeType: 'added',
-        value: '{tableCaption}; Page {page} of {pageCount}.',
+        "token": "euiBasicTable.tableCaptionWithPagination",
+        "changeType": "added",
+        "value": "{tableCaption}; Page {page} of {pageCount}."
       },
       {
-        token: 'euiBasicTable.tableAutoCaptionWithPagination',
-        changeType: 'added',
-        value:
-          'This table contains {itemCount} rows out of {totalItemCount} rows; Page {page} of {pageCount}.',
+        "token": "euiBasicTable.tableAutoCaptionWithPagination",
+        "changeType": "added",
+        "value": "This table contains {itemCount} rows out of {totalItemCount} rows; Page {page} of {pageCount}."
       },
       {
-        token: 'euiBasicTable.tableSimpleAutoCaptionWithPagination',
-        changeType: 'added',
-        value:
-          'This table contains {itemCount} rows; Page {page} of {pageCount}.',
+        "token": "euiBasicTable.tableSimpleAutoCaptionWithPagination",
+        "changeType": "added",
+        "value": "This table contains {itemCount} rows; Page {page} of {pageCount}."
       },
       {
-        token: 'euiBasicTable.tableAutoCaptionWithoutPagination',
-        changeType: 'added',
-        value: 'This table contains {itemCount} rows.',
+        "token": "euiBasicTable.tableAutoCaptionWithoutPagination",
+        "changeType": "added",
+        "value": "This table contains {itemCount} rows."
       },
       {
-        token: 'euiBasicTable.tablePagination',
-        changeType: 'added',
-        value: 'Pagination for preceding table: {tableCaption}',
+        "token": "euiBasicTable.tablePagination",
+        "changeType": "added",
+        "value": "Pagination for preceding table: {tableCaption}"
       },
       {
-        token: 'euiDataGrid.ariaLabelGridPagination',
-        changeType: 'added',
-        value: 'Pagination for preceding grid: {label}',
+        "token": "euiDataGrid.ariaLabelGridPagination",
+        "changeType": "added",
+        "value": "Pagination for preceding grid: {label}"
       },
       {
-        token: 'euiDataGrid.ariaLabelledByGridPagination',
-        changeType: 'added',
-        value: 'Pagination for preceding grid',
+        "token": "euiDataGrid.ariaLabelledByGridPagination",
+        "changeType": "added",
+        "value": "Pagination for preceding grid"
       },
       {
-        token: 'euiDataGrid.ariaLabel',
-        changeType: 'added',
-        value: '{label}; Page {page} of {pageCount}.',
+        "token": "euiDataGrid.ariaLabel",
+        "changeType": "added",
+        "value": "{label}; Page {page} of {pageCount}."
       },
       {
-        token: 'euiDataGrid.ariaLabelledBy',
-        changeType: 'added',
-        value: 'Page {page} of {pageCount}.',
+        "token": "euiDataGrid.ariaLabelledBy",
+        "changeType": "added",
+        "value": "Page {page} of {pageCount}."
       },
       {
-        token: 'euiPaginationButton.longPageString',
-        changeType: 'added',
-        value: 'Page {page} of {totalPages}',
+        "token": "euiPaginationButton.longPageString",
+        "changeType": "added",
+        "value": "Page {page} of {totalPages}"
       },
       {
-        token: 'euiPaginationButton.shortPageString',
-        changeType: 'added',
-        value: 'Page {page}',
+        "token": "euiPaginationButton.shortPageString",
+        "changeType": "added",
+        "value": "Page {page}"
       },
       {
-        token: 'euiPagination.disabledPreviousPage',
-        changeType: 'added',
-        value: 'Previous page',
+        "token": "euiPagination.disabledPreviousPage",
+        "changeType": "added",
+        "value": "Previous page"
       },
       {
-        token: 'euiPagination.firstRangeAriaLabel',
-        changeType: 'added',
-        value: 'Skipping pages 2 to {lastPage}',
+        "token": "euiPagination.firstRangeAriaLabel",
+        "changeType": "added",
+        "value": "Skipping pages 2 to {lastPage}"
       },
       {
-        token: 'euiPagination.lastRangeAriaLabel',
-        changeType: 'added',
-        value: 'Skipping pages {firstPage} to {lastPage}',
+        "token": "euiPagination.lastRangeAriaLabel",
+        "changeType": "added",
+        "value": "Skipping pages {firstPage} to {lastPage}"
       },
       {
-        token: 'euiPagination.disabledNextPage',
-        changeType: 'added',
-        value: 'Next page',
-      },
-    ],
+        "token": "euiPagination.disabledNextPage",
+        "changeType": "added",
+        "value": "Next page"
+      }
+    ]
   },
   {
-    version: '23.2.0',
-    changes: [
+    "version": "23.2.0",
+    "changes": [
       {
-        token: 'euiFlyout.closeAriaLabel',
-        changeType: 'added',
-        value: 'Close this dialog',
-      },
-    ],
+        "token": "euiFlyout.closeAriaLabel",
+        "changeType": "added",
+        "value": "Close this dialog"
+      }
+    ]
   },
   {
-    version: '22.6.0',
-    changes: [
+    "version": "22.6.0",
+    "changes": [
       {
-        token: 'euiRefreshInterval.fullDescription',
-        changeType: 'modified',
-        value: 'Refresh interval currently set to {optionValue} {optionText}.',
+        "token": "euiRefreshInterval.fullDescription",
+        "changeType": "modified",
+        "value": "Refresh interval currently set to {optionValue} {optionText}."
       },
       {
-        token: 'euiTourStepIndicator.isActive',
-        changeType: 'added',
-        value: 'active',
+        "token": "euiTourStepIndicator.isActive",
+        "changeType": "added",
+        "value": "active"
       },
       {
-        token: 'euiTourStepIndicator.isComplete',
-        changeType: 'added',
-        value: 'complete',
+        "token": "euiTourStepIndicator.isComplete",
+        "changeType": "added",
+        "value": "complete"
       },
       {
-        token: 'euiTourStepIndicator.isIncomplete',
-        changeType: 'added',
-        value: 'incomplete',
+        "token": "euiTourStepIndicator.isIncomplete",
+        "changeType": "added",
+        "value": "incomplete"
       },
       {
-        token: 'euiTourStepIndicator.ariaLabel',
-        changeType: 'added',
-        value:
-          '({\n  status\n}: {\n  status: EuiTourStepStatus;\n}) => {\n  return `Step ${number} ${status}`;\n};',
-      },
-    ],
+        "token": "euiTourStepIndicator.ariaLabel",
+        "changeType": "added",
+        "value": "({\n  status\n}: {\n  status: EuiTourStepStatus;\n}) => {\n  return `Step ${number} ${status}`;\n};"
+      }
+    ]
   },
   {
-    version: '22.2.0',
-    changes: [
+    "version": "22.2.0",
+    "changes": [
       {
-        token: 'euiCollapsibleNav.closeButtonLabel',
-        changeType: 'added',
-        value: 'close',
-      },
-    ],
+        "token": "euiCollapsibleNav.closeButtonLabel",
+        "changeType": "added",
+        "value": "close"
+      }
+    ]
   },
   {
-    version: '22.1.0',
-    changes: [
+    "version": "22.1.0",
+    "changes": [
       {
-        token: 'euiComboBoxOptionsList.delimiterMessage',
-        changeType: 'added',
-        value: 'Hit enter to add each item separated by {delimiter}',
-      },
-    ],
+        "token": "euiComboBoxOptionsList.delimiterMessage",
+        "changeType": "added",
+        "value": "Hit enter to add each item separated by {delimiter}"
+      }
+    ]
   },
   {
-    version: '22.0.0',
-    changes: [
+    "version": "22.0.0",
+    "changes": [
       {
-        token: 'euiTableHeaderCell.clickForDescending',
-        changeType: 'added',
-        value: 'Click to sort in descending order',
+        "token": "euiTableHeaderCell.clickForDescending",
+        "changeType": "added",
+        "value": "Click to sort in descending order"
       },
       {
-        token: 'euiTableHeaderCell.clickForUnsort',
-        changeType: 'added',
-        value: 'Click to unsort',
+        "token": "euiTableHeaderCell.clickForUnsort",
+        "changeType": "added",
+        "value": "Click to unsort"
       },
       {
-        token: 'euiTableHeaderCell.clickForAscending',
-        changeType: 'added',
-        value: 'Click to sort in ascending order',
+        "token": "euiTableHeaderCell.clickForAscending",
+        "changeType": "added",
+        "value": "Click to sort in ascending order"
       },
       {
-        token: 'euiTableHeaderCell.titleTextWithSort',
-        changeType: 'added',
-        value: '{innerText}; Sorted in {ariaSortValue} order',
+        "token": "euiTableHeaderCell.titleTextWithSort",
+        "changeType": "added",
+        "value": "{innerText}; Sorted in {ariaSortValue} order"
       },
       {
-        token: 'euiTableHeaderCell.sortedAriaLabel',
-        changeType: 'added',
-        value: 'Sorted in {ariaSortValue} order',
-      },
-    ],
+        "token": "euiTableHeaderCell.sortedAriaLabel",
+        "changeType": "added",
+        "value": "Sorted in {ariaSortValue} order"
+      }
+    ]
   },
   {
-    version: '21.1.0',
-    changes: [
+    "version": "21.1.0",
+    "changes": [
       {
-        token: 'euiColorPicker.alphaLabel',
-        changeType: 'added',
-        value: 'Alpha channel (opacity) value',
+        "token": "euiColorPicker.alphaLabel",
+        "changeType": "added",
+        "value": "Alpha channel (opacity) value"
       },
       {
-        token: 'euiColumnSelector.button',
-        changeType: 'added',
-        value: 'Columns',
+        "token": "euiColumnSelector.button",
+        "changeType": "added",
+        "value": "Columns"
       },
       {
-        token: 'euiColumnSelector.buttonActiveSingular',
-        changeType: 'added',
-        value: '{numberOfHiddenFields} column hidden',
+        "token": "euiColumnSelector.buttonActiveSingular",
+        "changeType": "added",
+        "value": "{numberOfHiddenFields} column hidden"
       },
       {
-        token: 'euiColumnSelector.buttonActivePlural',
-        changeType: 'added',
-        value: '{numberOfHiddenFields} columns hidden',
-      },
-    ],
+        "token": "euiColumnSelector.buttonActivePlural",
+        "changeType": "added",
+        "value": "{numberOfHiddenFields} columns hidden"
+      }
+    ]
   },
   {
-    version: '20.0.0',
-    changes: [
+    "version": "20.0.0",
+    "changes": [
       {
-        token: 'euiBottomBar.screenReaderAnnouncement',
-        changeType: 'modified',
-        value:
-          'There is a new region landmark with page level controls at the end of the document.',
+        "token": "euiBottomBar.screenReaderAnnouncement",
+        "changeType": "modified",
+        "value": "There is a new region landmark with page level controls at the end of the document."
       },
       {
-        token: 'euiBottomBar.screenReaderHeading',
-        changeType: 'added',
-        value: 'Page level controls',
+        "token": "euiBottomBar.screenReaderHeading",
+        "changeType": "added",
+        "value": "Page level controls"
       },
       {
-        token: 'euiBottomBar.customScreenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          'There is a new region landmark called {landmarkHeading} with page level controls at the end of the document.',
+        "token": "euiBottomBar.customScreenReaderAnnouncement",
+        "changeType": "added",
+        "value": "There is a new region landmark called {landmarkHeading} with page level controls at the end of the document."
       },
       {
-        token: 'euiControlBar.screenReaderHeading',
-        changeType: 'added',
-        value: 'Page level controls',
+        "token": "euiControlBar.screenReaderHeading",
+        "changeType": "added",
+        "value": "Page level controls"
       },
       {
-        token: 'euiControlBar.customScreenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          'There is a new region landmark called {landmarkHeading} with page level controls at the end of the document.',
+        "token": "euiControlBar.customScreenReaderAnnouncement",
+        "changeType": "added",
+        "value": "There is a new region landmark called {landmarkHeading} with page level controls at the end of the document."
       },
       {
-        token: 'euiControlBar.screenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          'There is a new region landmark with page level controls at the end of the document.',
-      },
-    ],
+        "token": "euiControlBar.screenReaderAnnouncement",
+        "changeType": "added",
+        "value": "There is a new region landmark with page level controls at the end of the document."
+      }
+    ]
   },
   {
-    version: '19.0.0',
-    changes: [
+    "version": "19.0.0",
+    "changes": [
       {
-        token: 'euiBasicTable.tableDescription',
-        changeType: 'deleted',
+        "token": "euiBasicTable.tableDescription",
+        "changeType": "deleted"
       },
       {
-        token: 'euiBasicTable.tableDescriptionWithPagination',
-        changeType: 'added',
-        value:
-          'This table contains {itemCount} rows out of {totalItemCount} rows.',
+        "token": "euiBasicTable.tableDescriptionWithPagination",
+        "changeType": "added",
+        "value": "This table contains {itemCount} rows out of {totalItemCount} rows."
       },
       {
-        token: 'euiBasicTable.tableDescriptionWithoutPagination',
-        changeType: 'added',
-        value: 'This table contains {itemCount} rows.',
-      },
-    ],
+        "token": "euiBasicTable.tableDescriptionWithoutPagination",
+        "changeType": "added",
+        "value": "This table contains {itemCount} rows."
+      }
+    ]
   },
   {
-    version: '18.3.0',
-    changes: [
+    "version": "18.3.0",
+    "changes": [
       {
-        token: 'euiFilterButton.filterBadge',
-        changeType: 'modified',
-        value: '{count} {hasActiveFilters} filters',
+        "token": "euiFilterButton.filterBadge",
+        "changeType": "modified",
+        "value": "{count} {hasActiveFilters} filters"
       },
       {
-        token: 'euiPagination.pageOfTotalCompressed',
-        changeType: 'added',
-        value: '{page} of {total}',
-      },
-    ],
+        "token": "euiPagination.pageOfTotalCompressed",
+        "changeType": "added",
+        "value": "{page} of {total}"
+      }
+    ]
   },
   {
-    version: '16.1.0',
-    changes: [
+    "version": "16.1.0",
+    "changes": [
       {
-        token: 'euiHeaderAlert.dismiss',
-        changeType: 'deleted',
-      },
-    ],
+        "token": "euiHeaderAlert.dismiss",
+        "changeType": "deleted"
+      }
+    ]
   },
   {
-    version: '14.9.0',
-    changes: [
+    "version": "14.9.0",
+    "changes": [
       {
-        token: 'euiTreeView.listNavigationInstructions',
-        changeType: 'added',
-        value: 'You can quickly navigate this list using arrow keys.',
+        "token": "euiTreeView.listNavigationInstructions",
+        "changeType": "added",
+        "value": "You can quickly navigate this list using arrow keys."
       },
       {
-        token: 'euiTreeView.ariaLabel',
-        changeType: 'added',
-        value: '{nodeLabel} child of {ariaLabel}',
-      },
-    ],
+        "token": "euiTreeView.ariaLabel",
+        "changeType": "added",
+        "value": "{nodeLabel} child of {ariaLabel}"
+      }
+    ]
   },
   {
-    version: '14.8.0',
-    changes: [
+    "version": "14.8.0",
+    "changes": [
       {
-        token: 'euiPopover.screenReaderAnnouncement',
-        changeType: 'modified',
-        value: 'You are in a dialog. To close this dialog, hit escape.',
+        "token": "euiPopover.screenReaderAnnouncement",
+        "changeType": "modified",
+        "value": "You are in a dialog. To close this dialog, hit escape."
       },
       {
-        token: 'euiColumnSelector.selectAll',
-        changeType: 'added',
-        value: 'Show all',
+        "token": "euiColumnSelector.selectAll",
+        "changeType": "added",
+        "value": "Show all"
       },
       {
-        token: 'euiColumnSelector.hideAll',
-        changeType: 'added',
-        value: 'Hide all',
+        "token": "euiColumnSelector.hideAll",
+        "changeType": "added",
+        "value": "Hide all"
       },
       {
-        token: 'euiColumnSortingDraggable.defaultSortAsc',
-        changeType: 'added',
-        value: 'A-Z',
+        "token": "euiColumnSortingDraggable.defaultSortAsc",
+        "changeType": "added",
+        "value": "A-Z"
       },
       {
-        token: 'euiColumnSortingDraggable.defaultSortDesc',
-        changeType: 'added',
-        value: 'Z-A',
+        "token": "euiColumnSortingDraggable.defaultSortDesc",
+        "changeType": "added",
+        "value": "Z-A"
       },
       {
-        token: 'euiColumnSortingDraggable.activeSortLabel',
-        changeType: 'added',
-        value: 'is sorting this data grid',
+        "token": "euiColumnSortingDraggable.activeSortLabel",
+        "changeType": "added",
+        "value": "is sorting this data grid"
       },
       {
-        token: 'euiColumnSortingDraggable.removeSortLabel',
-        changeType: 'added',
-        value: 'Remove from data grid sort:',
+        "token": "euiColumnSortingDraggable.removeSortLabel",
+        "changeType": "added",
+        "value": "Remove from data grid sort:"
       },
       {
-        token: 'euiColumnSortingDraggable.toggleLegend',
-        changeType: 'added',
-        value: 'Select sorting method for field: ',
+        "token": "euiColumnSortingDraggable.toggleLegend",
+        "changeType": "added",
+        "value": "Select sorting method for field: "
       },
       {
-        token: 'euiColumnSorting.emptySorting',
-        changeType: 'added',
-        value: 'Currently no fields are sorted',
+        "token": "euiColumnSorting.emptySorting",
+        "changeType": "added",
+        "value": "Currently no fields are sorted"
       },
       {
-        token: 'euiColumnSorting.pickFields',
-        changeType: 'added',
-        value: 'Pick fields to sort by',
+        "token": "euiColumnSorting.pickFields",
+        "changeType": "added",
+        "value": "Pick fields to sort by"
       },
       {
-        token: 'euiColumnSorting.sortFieldAriaLabel',
-        changeType: 'added',
-        value: 'Sort by: ',
+        "token": "euiColumnSorting.sortFieldAriaLabel",
+        "changeType": "added",
+        "value": "Sort by: "
       },
       {
-        token: 'euiColumnSorting.clearAll',
-        changeType: 'added',
-        value: 'Clear sorting',
+        "token": "euiColumnSorting.clearAll",
+        "changeType": "added",
+        "value": "Clear sorting"
       },
       {
-        token: 'euiDataGridCell.expandButtonTitle',
-        changeType: 'added',
-        value: 'Click or hit enter to interact with cell content',
+        "token": "euiDataGridCell.expandButtonTitle",
+        "changeType": "added",
+        "value": "Click or hit enter to interact with cell content"
       },
       {
-        token: 'euiDataGridSchema.booleanSortTextAsc',
-        changeType: 'added',
-        value: 'True-False',
+        "token": "euiDataGridSchema.booleanSortTextAsc",
+        "changeType": "added",
+        "value": "True-False"
       },
       {
-        token: 'euiDataGridSchema.booleanSortTextDesc',
-        changeType: 'added',
-        value: 'False-True',
+        "token": "euiDataGridSchema.booleanSortTextDesc",
+        "changeType": "added",
+        "value": "False-True"
       },
       {
-        token: 'euiDataGridSchema.currencySortTextAsc',
-        changeType: 'added',
-        value: 'Low-High',
+        "token": "euiDataGridSchema.currencySortTextAsc",
+        "changeType": "added",
+        "value": "Low-High"
       },
       {
-        token: 'euiDataGridSchema.currencySortTextDesc',
-        changeType: 'added',
-        value: 'High-Low',
+        "token": "euiDataGridSchema.currencySortTextDesc",
+        "changeType": "added",
+        "value": "High-Low"
       },
       {
-        token: 'euiDataGridSchema.dateSortTextAsc',
-        changeType: 'added',
-        value: 'New-Old',
+        "token": "euiDataGridSchema.dateSortTextAsc",
+        "changeType": "added",
+        "value": "New-Old"
       },
       {
-        token: 'euiDataGridSchema.dateSortTextDesc',
-        changeType: 'added',
-        value: 'Old-New',
+        "token": "euiDataGridSchema.dateSortTextDesc",
+        "changeType": "added",
+        "value": "Old-New"
       },
       {
-        token: 'euiDataGridSchema.numberSortTextAsc',
-        changeType: 'added',
-        value: 'Low-High',
+        "token": "euiDataGridSchema.numberSortTextAsc",
+        "changeType": "added",
+        "value": "Low-High"
       },
       {
-        token: 'euiDataGridSchema.numberSortTextDesc',
-        changeType: 'added',
-        value: 'High-Low',
+        "token": "euiDataGridSchema.numberSortTextDesc",
+        "changeType": "added",
+        "value": "High-Low"
       },
       {
-        token: 'euiDataGridSchema.jsonSortTextAsc',
-        changeType: 'added',
-        value: 'Small-Large',
+        "token": "euiDataGridSchema.jsonSortTextAsc",
+        "changeType": "added",
+        "value": "Small-Large"
       },
       {
-        token: 'euiDataGridSchema.jsonSortTextDesc',
-        changeType: 'added',
-        value: 'Large-Small',
+        "token": "euiDataGridSchema.jsonSortTextDesc",
+        "changeType": "added",
+        "value": "Large-Small"
       },
       {
-        token: 'euiDataGrid.screenReaderNotice',
-        changeType: 'added',
-        value: 'Cell contains interactive content.',
+        "token": "euiDataGrid.screenReaderNotice",
+        "changeType": "added",
+        "value": "Cell contains interactive content."
       },
       {
-        token: 'euiStyleSelector.buttonText',
-        changeType: 'added',
-        value: 'Density',
-      },
-    ],
+        "token": "euiStyleSelector.buttonText",
+        "changeType": "added",
+        "value": "Density"
+      }
+    ]
   },
   {
-    version: '14.7.0',
-    changes: [
+    "version": "14.7.0",
+    "changes": [
       {
-        token: 'euiImage.closeImage',
-        changeType: 'added',
-        value: 'Close full screen {alt} image',
+        "token": "euiImage.closeImage",
+        "changeType": "added",
+        "value": "Close full screen {alt} image"
       },
       {
-        token: 'euiImage.openImage',
-        changeType: 'added',
-        value: 'Open full screen {alt} image',
+        "token": "euiImage.openImage",
+        "changeType": "added",
+        "value": "Open full screen {alt} image"
       },
       {
-        token: 'euiLink.external.ariaLabel',
-        changeType: 'added',
-        value: 'External link',
-      },
-    ],
+        "token": "euiLink.external.ariaLabel",
+        "changeType": "added",
+        "value": "External link"
+      }
+    ]
   },
   {
-    version: '14.5.0',
-    changes: [
+    "version": "14.5.0",
+    "changes": [
       {
-        token: 'euiColorStopThumb.screenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          'A popup with a color stop edit form opened.\n            Tab forward to cycle through form controls or press\n            escape to close this popup.',
+        "token": "euiColorStopThumb.screenReaderAnnouncement",
+        "changeType": "added",
+        "value": "A popup with a color stop edit form opened.\n            Tab forward to cycle through form controls or press\n            escape to close this popup."
       },
       {
-        token: 'euiColorStopThumb.removeLabel',
-        changeType: 'added',
-        value: 'Remove this stop',
+        "token": "euiColorStopThumb.removeLabel",
+        "changeType": "added",
+        "value": "Remove this stop"
       },
       {
-        token: 'euiColorStops.screenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          '{label}: {readOnly} {disabled} Color stop picker. Each stop consists of a number and corresponding color value. Use the Down and Up arrow keys to select individual stops. Press the Enter key to create a new stop.',
+        "token": "euiColorStops.screenReaderAnnouncement",
+        "changeType": "added",
+        "value": "{label}: {readOnly} {disabled} Color stop picker. Each stop consists of a number and corresponding color value. Use the Down and Up arrow keys to select individual stops. Press the Enter key to create a new stop."
       },
       {
-        token: 'euiRelativeTab.unitInputLabel',
-        changeType: 'added',
-        value: 'Relative time span',
+        "token": "euiRelativeTab.unitInputLabel",
+        "changeType": "added",
+        "value": "Relative time span"
       },
       {
-        token: 'euiRelativeTab.roundingLabel',
-        changeType: 'added',
-        value: 'Round to the {unit}',
+        "token": "euiRelativeTab.roundingLabel",
+        "changeType": "added",
+        "value": "Round to the {unit}"
       },
       {
-        token: 'euiRelativeTab.relativeDate',
-        changeType: 'added',
-        value: '{position} date',
+        "token": "euiRelativeTab.relativeDate",
+        "changeType": "added",
+        "value": "{position} date"
       },
       {
-        token: 'euiRelativeTab.fullDescription',
-        changeType: 'added',
-        value: 'The unit is changeable. Currently set to {unit}.',
+        "token": "euiRelativeTab.fullDescription",
+        "changeType": "added",
+        "value": "The unit is changeable. Currently set to {unit}."
       },
       {
-        token: 'euiCommonlyUsedTimeRanges.legend',
-        changeType: 'added',
-        value: 'Commonly used',
+        "token": "euiCommonlyUsedTimeRanges.legend",
+        "changeType": "added",
+        "value": "Commonly used"
       },
       {
-        token: 'euiQuickSelect.legendText',
-        changeType: 'added',
-        value: 'Quick select a time range',
+        "token": "euiQuickSelect.legendText",
+        "changeType": "added",
+        "value": "Quick select a time range"
       },
       {
-        token: 'euiQuickSelect.quickSelectTitle',
-        changeType: 'added',
-        value: 'Quick select',
+        "token": "euiQuickSelect.quickSelectTitle",
+        "changeType": "added",
+        "value": "Quick select"
       },
       {
-        token: 'euiQuickSelect.previousLabel',
-        changeType: 'added',
-        value: 'Previous time window',
+        "token": "euiQuickSelect.previousLabel",
+        "changeType": "added",
+        "value": "Previous time window"
       },
       {
-        token: 'euiQuickSelect.nextLabel',
-        changeType: 'added',
-        value: 'Next time window',
+        "token": "euiQuickSelect.nextLabel",
+        "changeType": "added",
+        "value": "Next time window"
       },
       {
-        token: 'euiQuickSelect.tenseLabel',
-        changeType: 'added',
-        value: 'Time tense',
+        "token": "euiQuickSelect.tenseLabel",
+        "changeType": "added",
+        "value": "Time tense"
       },
       {
-        token: 'euiQuickSelect.valueLabel',
-        changeType: 'added',
-        value: 'Time value',
+        "token": "euiQuickSelect.valueLabel",
+        "changeType": "added",
+        "value": "Time value"
       },
       {
-        token: 'euiQuickSelect.unitLabel',
-        changeType: 'added',
-        value: 'Time unit',
+        "token": "euiQuickSelect.unitLabel",
+        "changeType": "added",
+        "value": "Time unit"
       },
       {
-        token: 'euiQuickSelect.applyButton',
-        changeType: 'added',
-        value: 'Apply',
+        "token": "euiQuickSelect.applyButton",
+        "changeType": "added",
+        "value": "Apply"
       },
       {
-        token: 'euiQuickSelect.fullDescription',
-        changeType: 'added',
-        value: 'Currently set to {timeTense} {timeValue} {timeUnit}.',
+        "token": "euiQuickSelect.fullDescription",
+        "changeType": "added",
+        "value": "Currently set to {timeTense} {timeValue} {timeUnit}."
       },
       {
-        token: 'euiRefreshInterval.legend',
-        changeType: 'added',
-        value: 'Refresh every',
+        "token": "euiRefreshInterval.legend",
+        "changeType": "added",
+        "value": "Refresh every"
       },
       {
-        token: 'euiRefreshInterval.start',
-        changeType: 'added',
-        value: 'Start',
+        "token": "euiRefreshInterval.start",
+        "changeType": "added",
+        "value": "Start"
       },
       {
-        token: 'euiRefreshInterval.stop',
-        changeType: 'added',
-        value: 'Stop',
+        "token": "euiRefreshInterval.stop",
+        "changeType": "added",
+        "value": "Stop"
       },
       {
-        token: 'euiRefreshInterval.fullDescription',
-        changeType: 'added',
-        value: 'Currently set to {optionValue} {optionText}.',
-      },
-    ],
+        "token": "euiRefreshInterval.fullDescription",
+        "changeType": "added",
+        "value": "Currently set to {optionValue} {optionText}."
+      }
+    ]
   },
   {
-    version: '14.3.0',
-    changes: [
+    "version": "14.3.0",
+    "changes": [
       {
-        token: 'euiBreadcrumbs.collapsedBadge.ariaLabel',
-        changeType: 'added',
-        value: 'Show all breadcrumbs',
-      },
-    ],
+        "token": "euiBreadcrumbs.collapsedBadge.ariaLabel",
+        "changeType": "added",
+        "value": "Show all breadcrumbs"
+      }
+    ]
   },
   {
-    version: '13.3.0',
-    changes: [
+    "version": "13.3.0",
+    "changes": [
       {
-        token: 'euiSuperDatePicker.showDatesButtonLabel',
-        changeType: 'added',
-        value: 'Show dates',
+        "token": "euiSuperDatePicker.showDatesButtonLabel",
+        "changeType": "added",
+        "value": "Show dates"
       },
       {
-        token: 'euiSuperUpdateButton.refreshButtonLabel',
-        changeType: 'added',
-        value: 'Refresh',
+        "token": "euiSuperUpdateButton.refreshButtonLabel",
+        "changeType": "added",
+        "value": "Refresh"
       },
       {
-        token: 'euiSuperUpdateButton.updatingButtonLabel',
-        changeType: 'added',
-        value: 'Updating',
+        "token": "euiSuperUpdateButton.updatingButtonLabel",
+        "changeType": "added",
+        "value": "Updating"
       },
       {
-        token: 'euiSuperUpdateButton.updateButtonLabel',
-        changeType: 'added',
-        value: 'Update',
+        "token": "euiSuperUpdateButton.updateButtonLabel",
+        "changeType": "added",
+        "value": "Update"
       },
       {
-        token: 'euiSuperUpdateButton.cannotUpdateTooltip',
-        changeType: 'added',
-        value: 'Cannot update',
+        "token": "euiSuperUpdateButton.cannotUpdateTooltip",
+        "changeType": "added",
+        "value": "Cannot update"
       },
       {
-        token: 'euiSuperUpdateButton.clickToApplyTooltip',
-        changeType: 'added',
-        value: 'Click to apply',
-      },
-    ],
+        "token": "euiSuperUpdateButton.clickToApplyTooltip",
+        "changeType": "added",
+        "value": "Click to apply"
+      }
+    ]
   },
   {
-    version: '13.2.0',
-    changes: [
+    "version": "13.2.0",
+    "changes": [
       {
-        token: 'euiStepHorizontal.buttonTitle',
-        changeType: 'modified',
-        value:
-          "({\n  step,\n  title,\n  disabled,\n  isComplete\n}: Pick<EuiStepHorizontalProps, 'step' | 'title' | 'disabled' | 'isComplete'>) => {\n  let titleAppendix = '';\n\n  if (disabled) {\n    titleAppendix = ' is disabled';\n  } else if (isComplete) {\n    titleAppendix = ' is complete';\n  }\n\n  return `Step ${step}: ${title}${titleAppendix}`;\n};",
+        "token": "euiStepHorizontal.buttonTitle",
+        "changeType": "modified",
+        "value": "({\n  step,\n  title,\n  disabled,\n  isComplete\n}: Pick<EuiStepHorizontalProps, 'step' | 'title' | 'disabled' | 'isComplete'>) => {\n  let titleAppendix = '';\n\n  if (disabled) {\n    titleAppendix = ' is disabled';\n  } else if (isComplete) {\n    titleAppendix = ' is complete';\n  }\n\n  return `Step ${step}: ${title}${titleAppendix}`;\n};"
       },
       {
-        token: 'euiStep.incompleteStep',
-        changeType: 'deleted',
+        "token": "euiStep.incompleteStep",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStep.completeStep',
-        changeType: 'deleted',
+        "token": "euiStep.completeStep",
+        "changeType": "deleted"
       },
       {
-        token: 'euiStep.ariaLabel',
-        changeType: 'added',
-        value:
-          "({\n  status\n}: {\n  status?: EuiStepStatus;\n}) => {\n  if (status === 'incomplete') return 'Incomplete Step';\n  return 'Step';\n};",
-      },
-    ],
+        "token": "euiStep.ariaLabel",
+        "changeType": "added",
+        "value": "({\n  status\n}: {\n  status?: EuiStepStatus;\n}) => {\n  if (status === 'incomplete') return 'Incomplete Step';\n  return 'Step';\n};"
+      }
+    ]
   },
   {
-    version: '12.0.0',
-    changes: [
+    "version": "12.0.0",
+    "changes": [
       {
-        token: 'euiColorPicker.screenReaderAnnouncement',
-        changeType: 'modified',
-        value:
-          'A popup with a range of selectable colors opened.\n                Tab forward to cycle through colors choices or press\n                escape to close this popup.',
-      },
-    ],
+        "token": "euiColorPicker.screenReaderAnnouncement",
+        "changeType": "modified",
+        "value": "A popup with a range of selectable colors opened.\n                Tab forward to cycle through colors choices or press\n                escape to close this popup."
+      }
+    ]
   },
   {
-    version: '11.3.0',
-    changes: [
+    "version": "11.3.0",
+    "changes": [
       {
-        token: 'euiColorPicker.transparentColor',
-        changeType: 'deleted',
+        "token": "euiColorPicker.transparentColor",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorPicker.colorSelectionLabel',
-        changeType: 'deleted',
+        "token": "euiColorPicker.colorSelectionLabel",
+        "changeType": "deleted"
       },
       {
-        token: 'euiColorPicker.screenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          'A popup with a range of selectable colors opened.\n                  Tab forward to cycle through colors choices or press\n                  escape to close this popup.',
+        "token": "euiColorPicker.screenReaderAnnouncement",
+        "changeType": "added",
+        "value": "A popup with a range of selectable colors opened.\n                  Tab forward to cycle through colors choices or press\n                  escape to close this popup."
       },
       {
-        token: 'euiColorPicker.swatchAriaLabel',
-        changeType: 'added',
-        value: 'Select {swatch} as the color',
+        "token": "euiColorPicker.swatchAriaLabel",
+        "changeType": "added",
+        "value": "Select {swatch} as the color"
       },
       {
-        token: 'euiHue.label',
-        changeType: 'added',
-        value: "Select the HSV color mode 'hue' value",
+        "token": "euiHue.label",
+        "changeType": "added",
+        "value": "Select the HSV color mode 'hue' value"
       },
       {
-        token: 'euiSaturation.roleDescription',
-        changeType: 'added',
-        value: 'HSV color mode saturation and value selection',
+        "token": "euiSaturation.roleDescription",
+        "changeType": "added",
+        "value": "HSV color mode saturation and value selection"
       },
       {
-        token: 'euiSaturation.screenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          "Use the arrow keys to navigate the square color gradient. The coordinates resulting from each key press will be used to calculate HSV color mode 'saturation' and 'value' numbers, in the range of 0 to 1. Left and right decrease and increase (respectively) the 'saturation' value. Up and down decrease and increase (respectively) the 'value' value.",
-      },
-    ],
+        "token": "euiSaturation.screenReaderAnnouncement",
+        "changeType": "added",
+        "value": "Use the arrow keys to navigate the square color gradient. The coordinates resulting from each key press will be used to calculate HSV color mode 'saturation' and 'value' numbers, in the range of 0 to 1. Left and right decrease and increase (respectively) the 'saturation' value. Up and down decrease and increase (respectively) the 'value' value."
+      }
+    ]
   },
   {
-    version: '10.3.0',
-    changes: [
+    "version": "10.3.0",
+    "changes": [
       {
-        token: 'euiCardSelect.selected',
-        changeType: 'added',
-        value: 'Selected',
+        "token": "euiCardSelect.selected",
+        "changeType": "added",
+        "value": "Selected"
       },
       {
-        token: 'euiCardSelect.unavailable',
-        changeType: 'added',
-        value: 'Unavailable',
+        "token": "euiCardSelect.unavailable",
+        "changeType": "added",
+        "value": "Unavailable"
       },
       {
-        token: 'euiCardSelect.select',
-        changeType: 'added',
-        value: 'Select',
-      },
-    ],
+        "token": "euiCardSelect.select",
+        "changeType": "added",
+        "value": "Select"
+      }
+    ]
   },
   {
-    version: '10.2.1',
-    changes: [
+    "version": "10.2.1",
+    "changes": [
       {
-        token: 'euiFilterButton.filterBadge',
-        changeType: 'added',
-        value:
-          "({\n  count,\n  hasActiveFilters\n}) => `${count} ${hasActiveFilters ? 'active' : 'available'} filters`;",
-      },
-    ],
+        "token": "euiFilterButton.filterBadge",
+        "changeType": "added",
+        "value": "({\n  count,\n  hasActiveFilters\n}) => `${count} ${hasActiveFilters ? 'active' : 'available'} filters`;"
+      }
+    ]
   },
   {
-    version: '10.2.0',
-    changes: [
+    "version": "10.2.0",
+    "changes": [
       {
-        token: 'euiStat.loadingText',
-        changeType: 'added',
-        value: 'Statistic is loading',
+        "token": "euiStat.loadingText",
+        "changeType": "added",
+        "value": "Statistic is loading"
       },
       {
-        token: 'euiTablePagination.rowsPerPageOption',
-        changeType: 'added',
-        value: '{rowsPerPage} rows',
-      },
-    ],
+        "token": "euiTablePagination.rowsPerPageOption",
+        "changeType": "added",
+        "value": "{rowsPerPage} rows"
+      }
+    ]
   },
   {
-    version: '9.8.0',
-    changes: [
+    "version": "9.8.0",
+    "changes": [
       {
-        token: 'euiSelectable.loadingOptions',
-        changeType: 'added',
-        value: 'Loading options',
+        "token": "euiSelectable.loadingOptions",
+        "changeType": "added",
+        "value": "Loading options"
       },
       {
-        token: 'euiSelectable.noMatchingOptions',
-        changeType: 'added',
-        value: "{searchValue} doesn't match any options",
+        "token": "euiSelectable.noMatchingOptions",
+        "changeType": "added",
+        "value": "{searchValue} doesn't match any options"
       },
       {
-        token: 'euiSelectable.noAvailableOptions',
-        changeType: 'added',
-        value: 'No options available',
-      },
-    ],
+        "token": "euiSelectable.noAvailableOptions",
+        "changeType": "added",
+        "value": "No options available"
+      }
+    ]
   },
   {
-    version: '9.4.1',
-    changes: [
+    "version": "9.4.1",
+    "changes": [
       {
-        token: 'euiBottomBar.screenReaderAnnouncement',
-        changeType: 'modified',
-        value:
-          'There is a new menu opening with page level controls at the end of the document.',
-      },
-    ],
+        "token": "euiBottomBar.screenReaderAnnouncement",
+        "changeType": "modified",
+        "value": "There is a new menu opening with page level controls at the end of the document."
+      }
+    ]
   },
   {
-    version: '9.0.0',
-    changes: [
+    "version": "9.0.0",
+    "changes": [
       {
-        token: 'euiBasicTable.tableDescription',
-        changeType: 'added',
-        value: 'Below is a table of {itemCount} items.',
+        "token": "euiBasicTable.tableDescription",
+        "changeType": "added",
+        "value": "Below is a table of {itemCount} items."
       },
       {
-        token: 'euiBasicTable.selectAllRows',
-        changeType: 'added',
-        value: 'Select all rows',
+        "token": "euiBasicTable.selectAllRows",
+        "changeType": "added",
+        "value": "Select all rows"
       },
       {
-        token: 'euiBasicTable.selectThisRow',
-        changeType: 'added',
-        value: 'Select this row',
+        "token": "euiBasicTable.selectThisRow",
+        "changeType": "added",
+        "value": "Select this row"
       },
       {
-        token: 'euiCollapsedItemActions.allActions',
-        changeType: 'added',
-        value: 'All actions',
+        "token": "euiCollapsedItemActions.allActions",
+        "changeType": "added",
+        "value": "All actions"
       },
       {
-        token: 'euiBottomBar.screenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          'There is a new menu opening with page level controls at the bottom of the document.',
+        "token": "euiBottomBar.screenReaderAnnouncement",
+        "changeType": "added",
+        "value": "There is a new menu opening with page level controls at the bottom of the document."
       },
       {
-        token: 'euiCodeEditor.startInteracting',
-        changeType: 'added',
-        value: 'Press Enter to start interacting with the code.',
+        "token": "euiCodeEditor.startInteracting",
+        "changeType": "added",
+        "value": "Press Enter to start interacting with the code."
       },
       {
-        token: 'euiCodeEditor.startEditing',
-        changeType: 'added',
-        value: 'Press Enter to start editing.',
+        "token": "euiCodeEditor.startEditing",
+        "changeType": "added",
+        "value": "Press Enter to start editing."
       },
       {
-        token: 'euiCodeEditor.stopInteracting',
-        changeType: 'added',
-        value:
-          "When you're done, press Escape to stop interacting with the code.",
+        "token": "euiCodeEditor.stopInteracting",
+        "changeType": "added",
+        "value": "When you're done, press Escape to stop interacting with the code."
       },
       {
-        token: 'euiCodeEditor.stopEditing',
-        changeType: 'added',
-        value: "When you're done, press Escape to stop editing.",
+        "token": "euiCodeEditor.stopEditing",
+        "changeType": "added",
+        "value": "When you're done, press Escape to stop editing."
       },
       {
-        token: 'euiCodeBlock.copyButton',
-        changeType: 'added',
-        value: 'Copy',
+        "token": "euiCodeBlock.copyButton",
+        "changeType": "added",
+        "value": "Copy"
       },
       {
-        token: 'euiColorPicker.transparentColor',
-        changeType: 'added',
-        value: 'transparent',
+        "token": "euiColorPicker.transparentColor",
+        "changeType": "added",
+        "value": "transparent"
       },
       {
-        token: 'euiColorPicker.colorSelectionLabel',
-        changeType: 'added',
-        value: 'Color selection is {colorValue}',
+        "token": "euiColorPicker.colorSelectionLabel",
+        "changeType": "added",
+        "value": "Color selection is {colorValue}"
       },
       {
-        token: 'euiComboBoxPill.removeSelection',
-        changeType: 'added',
-        value: 'Remove {children} from selection in this group',
+        "token": "euiComboBoxPill.removeSelection",
+        "changeType": "added",
+        "value": "Remove {children} from selection in this group"
       },
       {
-        token: 'euiComboBoxOptionsList.loadingOptions',
-        changeType: 'added',
-        value: 'Loading options',
+        "token": "euiComboBoxOptionsList.loadingOptions",
+        "changeType": "added",
+        "value": "Loading options"
       },
       {
-        token: 'euiComboBoxOptionsList.alreadyAdded',
-        changeType: 'added',
-        value: '{label} has already been added',
+        "token": "euiComboBoxOptionsList.alreadyAdded",
+        "changeType": "added",
+        "value": "{label} has already been added"
       },
       {
-        token: 'euiComboBoxOptionsList.createCustomOption',
-        changeType: 'added',
-        value: 'Hit {key} to add {searchValue} as a custom option',
+        "token": "euiComboBoxOptionsList.createCustomOption",
+        "changeType": "added",
+        "value": "Hit {key} to add {searchValue} as a custom option"
       },
       {
-        token: 'euiComboBoxOptionsList.noMatchingOptions',
-        changeType: 'added',
-        value: "{searchValue} doesn't match any options",
+        "token": "euiComboBoxOptionsList.noMatchingOptions",
+        "changeType": "added",
+        "value": "{searchValue} doesn't match any options"
       },
       {
-        token: 'euiComboBoxOptionsList.noAvailableOptions',
-        changeType: 'added',
-        value: "There aren't any options available",
+        "token": "euiComboBoxOptionsList.noAvailableOptions",
+        "changeType": "added",
+        "value": "There aren't any options available"
       },
       {
-        token: 'euiComboBoxOptionsList.allOptionsSelected',
-        changeType: 'added',
-        value: "You've selected all available options",
+        "token": "euiComboBoxOptionsList.allOptionsSelected",
+        "changeType": "added",
+        "value": "You've selected all available options"
       },
       {
-        token: 'euiFormControlLayoutClearButton.label',
-        changeType: 'added',
-        value: 'Clear input',
+        "token": "euiFormControlLayoutClearButton.label",
+        "changeType": "added",
+        "value": "Clear input"
       },
       {
-        token: 'euiForm.addressFormErrors',
-        changeType: 'added',
-        value: 'Please address the errors in your form.',
+        "token": "euiForm.addressFormErrors",
+        "changeType": "added",
+        "value": "Please address the errors in your form."
       },
       {
-        token: 'euiSuperSelectControl.selectAnOption',
-        changeType: 'added',
-        value: 'Select an option: {selectedValue}, is selected',
+        "token": "euiSuperSelectControl.selectAnOption",
+        "changeType": "added",
+        "value": "Select an option: {selectedValue}, is selected"
       },
       {
-        token: 'euiSuperSelect.screenReaderAnnouncement',
-        changeType: 'added',
-        value:
-          'You are in a form selector of {optionsCount} items and must select a single option.\n              Use the up and down keys to navigate or escape to close.',
+        "token": "euiSuperSelect.screenReaderAnnouncement",
+        "changeType": "added",
+        "value": "You are in a form selector of {optionsCount} items and must select a single option.\n              Use the up and down keys to navigate or escape to close."
       },
       {
-        token: 'euiHeaderAlert.dismiss',
-        changeType: 'added',
-        value: 'Dismiss',
+        "token": "euiHeaderAlert.dismiss",
+        "changeType": "added",
+        "value": "Dismiss"
       },
       {
-        token: 'euiHeaderLinks.openNavigationMenu',
-        changeType: 'added',
-        value: 'Open navigation menu',
+        "token": "euiHeaderLinks.openNavigationMenu",
+        "changeType": "added",
+        "value": "Open navigation menu"
       },
       {
-        token: 'euiHeaderLinks.appNavigation',
-        changeType: 'added',
-        value: 'App navigation',
+        "token": "euiHeaderLinks.appNavigation",
+        "changeType": "added",
+        "value": "App navigation"
       },
       {
-        token: 'euiModal.closeModal',
-        changeType: 'added',
-        value: 'Closes this modal window',
+        "token": "euiModal.closeModal",
+        "changeType": "added",
+        "value": "Closes this modal window"
       },
       {
-        token: 'euiPagination.pageOfTotal',
-        changeType: 'added',
-        value: 'Page {page} of {total}',
+        "token": "euiPagination.pageOfTotal",
+        "changeType": "added",
+        "value": "Page {page} of {total}"
       },
       {
-        token: 'euiPagination.previousPage',
-        changeType: 'added',
-        value: 'Previous page',
+        "token": "euiPagination.previousPage",
+        "changeType": "added",
+        "value": "Previous page"
       },
       {
-        token: 'euiPagination.jumpToLastPage',
-        changeType: 'added',
-        value: 'Jump to the last page, number {pageCount}',
+        "token": "euiPagination.jumpToLastPage",
+        "changeType": "added",
+        "value": "Jump to the last page, number {pageCount}"
       },
       {
-        token: 'euiPagination.nextPage',
-        changeType: 'added',
-        value: 'Next page',
+        "token": "euiPagination.nextPage",
+        "changeType": "added",
+        "value": "Next page"
       },
       {
-        token: 'euiPopover.screenReaderAnnouncement',
-        changeType: 'added',
-        value: 'You are in a popup. To exit this popup, hit escape.',
+        "token": "euiPopover.screenReaderAnnouncement",
+        "changeType": "added",
+        "value": "You are in a popup. To exit this popup, hit escape."
       },
       {
-        token: 'euiStepHorizontal.buttonTitle',
-        changeType: 'added',
-        value:
-          "({\n  step,\n  title,\n  disabled,\n  isComplete\n}) => {\n  let titleAppendix = '';\n\n  if (disabled) {\n    titleAppendix = ' is disabled';\n  } else if (isComplete) {\n    titleAppendix = ' is complete';\n  }\n\n  return `Step ${step}: ${title}${titleAppendix}`;\n};",
+        "token": "euiStepHorizontal.buttonTitle",
+        "changeType": "added",
+        "value": "({\n  step,\n  title,\n  disabled,\n  isComplete\n}) => {\n  let titleAppendix = '';\n\n  if (disabled) {\n    titleAppendix = ' is disabled';\n  } else if (isComplete) {\n    titleAppendix = ' is complete';\n  }\n\n  return `Step ${step}: ${title}${titleAppendix}`;\n};"
       },
       {
-        token: 'euiStepHorizontal.step',
-        changeType: 'added',
-        value: 'Step',
+        "token": "euiStepHorizontal.step",
+        "changeType": "added",
+        "value": "Step"
       },
       {
-        token: 'euiStepNumber.isComplete',
-        changeType: 'added',
-        value: 'complete',
+        "token": "euiStepNumber.isComplete",
+        "changeType": "added",
+        "value": "complete"
       },
       {
-        token: 'euiStepNumber.hasWarnings',
-        changeType: 'added',
-        value: 'has warnings',
+        "token": "euiStepNumber.hasWarnings",
+        "changeType": "added",
+        "value": "has warnings"
       },
       {
-        token: 'euiStepNumber.hasErrors',
-        changeType: 'added',
-        value: 'has errors',
+        "token": "euiStepNumber.hasErrors",
+        "changeType": "added",
+        "value": "has errors"
       },
       {
-        token: 'euiStep.incompleteStep',
-        changeType: 'added',
-        value: 'Incomplete Step',
+        "token": "euiStep.incompleteStep",
+        "changeType": "added",
+        "value": "Incomplete Step"
       },
       {
-        token: 'euiStep.completeStep',
-        changeType: 'added',
-        value: 'Step',
+        "token": "euiStep.completeStep",
+        "changeType": "added",
+        "value": "Step"
       },
       {
-        token: 'euiTableSortMobile.sorting',
-        changeType: 'added',
-        value: 'Sorting',
+        "token": "euiTableSortMobile.sorting",
+        "changeType": "added",
+        "value": "Sorting"
       },
       {
-        token: 'euiTablePagination.rowsPerPage',
-        changeType: 'added',
-        value: 'Rows per page',
+        "token": "euiTablePagination.rowsPerPage",
+        "changeType": "added",
+        "value": "Rows per page"
       },
       {
-        token: 'euiToast.dismissToast',
-        changeType: 'added',
-        value: 'Dismiss toast',
+        "token": "euiToast.dismissToast",
+        "changeType": "added",
+        "value": "Dismiss toast"
       },
       {
-        token: 'euiToast.newNotification',
-        changeType: 'added',
-        value: 'A new notification appears',
+        "token": "euiToast.newNotification",
+        "changeType": "added",
+        "value": "A new notification appears"
       },
       {
-        token: 'euiToast.notification',
-        changeType: 'added',
-        value: 'Notification',
-      },
-    ],
-  },
-];
+        "token": "euiToast.notification",
+        "changeType": "added",
+        "value": "Notification"
+      }
+    ]
+  }
+]

--- a/packages/release-cli/src/release.ts
+++ b/packages/release-cli/src/release.ts
@@ -118,9 +118,9 @@ export const release = async (options: ReleaseOptions) => {
 
   await stepInitChecks(options);
 
-  await stepBuildPackages(options);
-
   const changedWorkspaces = await stepUpdateVersions(options, currentWorkspaces);
+
+  await stepBuildPackages(options);
 
   await stepRunPreScripts(options);
 


### PR DESCRIPTION
## Context

> [!IMPORTANT]
> **High priority.** Blocks the merge of https://github.com/elastic/eui/pull/9726. 

`i18ntokens_changelog.json` content formatting was corrupted on https://github.com/elastic/eui/pull/9646/changes/f944a87d0c3ffb88eaa07eb27dfbfc6da0648612. Probably, it went through `node -p` which reformatted the whole file as JS. The reason this didn't surface since v116.0.0 release is because no i18n tokens were added until: https://github.com/elastic/eui/pull/9726 It's adding:
- `euiFlyoutMenu.pagination.previous`
- `euiFlyoutMenu.pagination.next`
- `euiFlyoutMenu.pagination.counter`

Which led to the "Build and deploy website" CI step failure in `eui-deploy-docs` when building `@elastic/eui-website`  dependencies, specifically `@elastic/eui`:

```
[@elastic/eui]: Process started
--
  | [@elastic/eui]: [i18ntokens] Found 3 changes
  | [@elastic/eui]: <anonymous_script>:3
  | [@elastic/eui]:     version: '116.0.0',
  | [@elastic/eui]:     ^
  | [@elastic/eui]:
  | [@elastic/eui]: SyntaxError: Expected property name or '}' in JSON at position 10 (line 3 column 5)
  | [@elastic/eui]:     at JSON.parse (<anonymous>)
  | [@elastic/eui]:     at readJson (file:///opt/buildkite-agent/builds/bk-agent-prod-gcp-1781782263113306112/elastic/eui-deploy-docs/packages/eui/scripts/build_i18ntokens.mjs:14:15)
  | [@elastic/eui]:     at async main (file:///opt/buildkite-agent/builds/bk-agent-prod-gcp-1781782263113306112/elastic/eui-deploy-docs/packages/eui/scripts/build_i18ntokens.mjs:39:21)
  | [@elastic/eui]:     at async file:///opt/buildkite-agent/builds/bk-agent-prod-gcp-1781782263113306112/elastic/eui-deploy-docs/packages/eui/scripts/build_i18ntokens.mjs:50:1
  | [@elastic/eui]:
  | [@elastic/eui]: Node.js v22.22.0
  | [@elastic/eui]: Process exited (exit code 1), completed in 9s 232ms
```

It detected the 3 new tokens, tried reading the changelog but it returned a syntax error.

But that's not the only issue... The reason this happened in the first place is because the `release.ts` script from our `release-cli` first builds packages (includes `build_i18ntokens.mjs`) and _then_ updates the version. I.e. the changelogs gets the previous version. That's why a commit was added on the 116.0.0 release PR with a manual fix.

## Solution

- Fix the formatting for `i18ntokens_changelog.json` https://github.com/elastic/eui/commit/f805e5c1d605255f356100003e9791fd08fa3c75
- swap the order of `stepBuildPackages` and `stepUpdateVersions` so that first versions are updated and only then built (the version detection does not require build artefacts) https://github.com/elastic/eui/commit/0fbc3cdf81e2e798763ee7104b2734f4346c4622.

## QA

- [x] CI passes
- [x] Changelog is a valid JSON
- [x] `yarn workspace @elastic/eui build:i18ntokens` logs "No token changes found", no `JSON.parse` crash
- [x] Add an a11y token locally, re-run the command - reads the changelog without errors, prepends an entry, writes valid JSON
- [x] `yarn workspace @elastic/eui-release-cli run build` and then `yarn release run official --dry-run --allow-custom --skip-auth-check` shows "Updating package versions" before "building packages", top entry in the changelog is the correct version, build succeeds