### PR TITLE
[EuiFlyout] Introduce EuiFlyoutPluginContext for enhanced integration and deprecate legacy props

### DIFF
--- a/packages/eui/src/components/flyout/flyout_menu.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu.tsx
@@ -20,6 +20,7 @@ import { CommonProps, PropsForAnchor } from '../common';
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiListGroup, EuiListGroupItem } from '../list_group';
 import { EuiPopover } from '../popover';
+import { EuiToolTip } from '../tool_tip';
 import { EuiTitle } from '../title';
 import { EuiFlyoutCloseButton } from './_flyout_close_button';
 import { euiFlyoutMenuStyles } from './flyout_menu.styles';
@@ -108,16 +109,31 @@ export type EuiFlyoutMenuProps = CommonProps &
      */
     hideCloseButton?: boolean;
     /**
+     * A self-contained component to render in place of the built-in Back button
+     * and history popover. When provided, `showBackButton`, `backButtonProps`,
+     * and `historyItems` are ignored.
+     *
+     * Set via `EuiFlyoutMenuBarSlot` context — provided by `FlyoutHistoryProvider`
+     * from `@kbn/flyout-history`.
+     */
+    menuBarSlot?: React.ReactNode;
+    /**
      * Shows a back button in the menu component
      * @default false
+     * @deprecated Use `EuiFlyoutMenuBarSlot` context to inject a `menuBarSlot` instead.
+     * Will be removed in a future major version.
      */
     showBackButton?: boolean;
     /**
      * Props to pass to the back button, such as `onClick` handler
+     * @deprecated Use `EuiFlyoutMenuBarSlot` context to inject a `menuBarSlot` instead.
+     * Will be removed in a future major version.
      */
     backButtonProps?: EuiFlyoutMenuBackButtonProps;
     /**
      * List of history items for the history popover
+     * @deprecated Use `EuiFlyoutMenuBarSlot` context to inject a `menuBarSlot` instead.
+     * Will be removed in a future major version.
      */
     historyItems?: EuiFlyoutHistoryItem[];
     /**
@@ -144,20 +160,26 @@ const HistoryPopover: React.FC<{
   items: EuiFlyoutHistoryItem[];
 }> = ({ items }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const historyLabel = useEuiI18n('euiFlyoutMenu.history', 'History');
   const handlePopoverButtonClick = () => {
     setIsPopoverOpen(!isPopoverOpen);
   };
 
+  const historyButton = (
+    <EuiToolTip content={historyLabel} disableScreenReaderOutput>
+      <EuiButtonIcon
+        iconType="chevronSingleDown"
+        color="text"
+        aria-label={historyLabel}
+        data-test-subj="euiFlyoutMenuHistoryButton"
+      />
+    </EuiToolTip>
+  );
+
   return (
     <EuiPopover
-      button={
-        <EuiButtonIcon
-          iconType="chevronSingleDown"
-          color="text"
-          aria-label={useEuiI18n('euiFlyoutMenu.history', 'History')}
-          data-test-subj="euiFlyoutMenuHistoryButton"
-        />
-      }
+      aria-label={historyLabel}
+      button={historyButton}
       isOpen={isPopoverOpen}
       onClick={handlePopoverButtonClick}
       closePopover={() => setIsPopoverOpen(false)}
@@ -199,6 +221,7 @@ export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
   titleId,
   hideTitle = true,
   hideCloseButton,
+  menuBarSlot,
   historyItems = [],
   showBackButton,
   backButtonProps,
@@ -245,16 +268,21 @@ export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
         gutterSize="none"
         responsive={false}
       >
-        {showBackButton && (
-          <EuiFlexItem grow={false}>
-            <BackButton {...backButtonProps} />
-          </EuiFlexItem>
-        )}
-
-        {historyItems.length > 0 && (
-          <EuiFlexItem grow={false}>
-            <HistoryPopover items={historyItems} />
-          </EuiFlexItem>
+        {menuBarSlot ? (
+          <EuiFlexItem grow={false}>{menuBarSlot}</EuiFlexItem>
+        ) : (
+          <>
+            {showBackButton && (
+              <EuiFlexItem grow={false}>
+                <BackButton {...backButtonProps} />
+              </EuiFlexItem>
+            )}
+            {historyItems.length > 0 && (
+              <EuiFlexItem grow={false}>
+                <HistoryPopover items={historyItems} />
+              </EuiFlexItem>
+            )}
+          </>
         )}
 
         {titleNode && <EuiFlexItem grow={false}>{titleNode}</EuiFlexItem>}
@@ -268,14 +296,19 @@ export const EuiFlyoutMenu: FunctionComponent<EuiFlyoutMenuProps> = ({
               key={`action-index-flex-item-${actionIndex}`}
               css={styles.euiFlyoutMenu__actions}
             >
-              <EuiButtonIcon
-                key={`action-index-icon-${actionIndex}`}
-                aria-label={action['aria-label']}
-                iconType={action.iconType}
-                onClick={action.onClick}
-                color="text"
-                size="s"
-              />
+              <EuiToolTip
+                content={action['aria-label']}
+                disableScreenReaderOutput
+              >
+                <EuiButtonIcon
+                  key={`action-index-icon-${actionIndex}`}
+                  aria-label={action['aria-label']}
+                  iconType={action.iconType}
+                  onClick={action.onClick}
+                  color="text"
+                  size="s"
+                />
+              </EuiToolTip>
             </EuiFlexItem>
           ))}
 

--- a/packages/eui/src/components/flyout/index.ts
+++ b/packages/eui/src/components/flyout/index.ts
@@ -41,4 +41,6 @@ export {
   type FlyoutManagerEvent,
   type EuiFlyoutManagerState,
   type FlyoutSession,
+  type EuiFlyoutPluginContextValue,
+  EuiFlyoutPluginContext,
 } from './manager';

--- a/packages/eui/src/components/flyout/manager/flyout_managed.tsx
+++ b/packages/eui/src/components/flyout/manager/flyout_managed.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, {
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -37,6 +38,7 @@ import {
 } from './const';
 import { EuiFlyoutIsManagedProvider } from './context';
 import { euiManagedFlyoutStyles } from './flyout_managed.styles';
+import { EuiFlyoutPluginContext } from './flyout_plugin';
 import { useFlyoutManager as _useFlyoutManager, useFlyoutId } from './hooks';
 import { useIsFlyoutRegistered } from './selectors';
 import { getFlyoutManagerStore } from './store';
@@ -55,8 +57,17 @@ import {
  */
 export interface EuiManagedFlyoutProps extends EuiFlyoutComponentProps {
   level: EuiFlyoutLevel;
+  /**
+   * Symbol that groups this session into a named history group.
+   *
+   * @deprecated Provide `historyKey` via `EuiFlyoutPluginContext` instead.
+   * The prop is still honored as an override; will be removed in a future major version.
+   */
   historyKey?: symbol;
-  flyoutMenuProps?: Omit<EuiFlyoutMenuProps, 'historyItems' | 'showBackButton'>;
+  flyoutMenuProps?: Omit<
+    EuiFlyoutMenuProps,
+    'historyItems' | 'showBackButton' | 'backButtonProps' | 'menuBarSlot'
+  >;
   onActive?: () => void;
 }
 
@@ -185,6 +196,10 @@ export const EuiManagedFlyout = forwardRef<HTMLElement, EuiManagedFlyoutProps>(
       title = defaultTitle;
     }
 
+    const { historyKey: contextHistoryKey, MenuBarSlot: MenuBarSlotComponent } =
+      useContext(EuiFlyoutPluginContext);
+    const resolvedHistoryKey = historyKey ?? contextHistoryKey;
+
     const flyoutExistsInManager = useIsFlyoutRegistered(flyoutId);
 
     // Stabilize the onClose callback
@@ -222,7 +237,7 @@ export const EuiManagedFlyout = forwardRef<HTMLElement, EuiManagedFlyoutProps>(
         title!,
         level,
         size as string,
-        level === LEVEL_MAIN ? historyKey : undefined,
+        level === LEVEL_MAIN ? resolvedHistoryKey : undefined,
         _flyoutMenuProps?.iconType,
         typeof minWidth === 'number' ? minWidth : undefined
       );
@@ -248,7 +263,7 @@ export const EuiManagedFlyout = forwardRef<HTMLElement, EuiManagedFlyoutProps>(
       level,
       size,
       minWidth,
-      historyKey,
+      resolvedHistoryKey,
       _flyoutMenuProps?.iconType,
       addFlyout,
       closeFlyout,
@@ -320,23 +335,25 @@ export const EuiManagedFlyout = forwardRef<HTMLElement, EuiManagedFlyoutProps>(
       shouldAnimate: false,
     });
 
-    // Note: history controls are only relevant for main flyouts
+    // History controls are only relevant for main flyouts.
+    // When MenuBarSlotComponent is provided, it fully replaces the built-in controls.
     const historyItems = useMemo(() => {
-      const result = level === LEVEL_MAIN ? _historyItems : undefined;
-      return result;
-    }, [level, _historyItems]);
+      if (level !== LEVEL_MAIN || MenuBarSlotComponent) return undefined;
+      return _historyItems;
+    }, [level, MenuBarSlotComponent, _historyItems]);
 
     const backButtonProps = useMemo(() => {
-      return level === LEVEL_MAIN ? { onClick: goBack } : undefined;
-    }, [level, goBack]);
+      if (level !== LEVEL_MAIN || MenuBarSlotComponent) return undefined;
+      return { onClick: goBack };
+    }, [level, MenuBarSlotComponent, goBack]);
 
     const showBackButton = historyItems ? historyItems.length > 0 : false;
 
     const flyoutMenuProps = {
       ..._flyoutMenuProps,
-      historyItems,
-      showBackButton,
-      backButtonProps,
+      ...(MenuBarSlotComponent && level === LEVEL_MAIN
+        ? { menuBarSlot: <MenuBarSlotComponent /> }
+        : { historyItems, showBackButton, backButtonProps }),
       title,
     };
 

--- a/packages/eui/src/components/flyout/manager/flyout_plugin.ts
+++ b/packages/eui/src/components/flyout/manager/flyout_plugin.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { type ComponentType, createContext } from 'react';
+
+/**
+ * Context for integrating external packages with the flyout manager without
+ * compile-time coupling.
+ *
+ * - `historyKey`: tags each session with a history group, removing the need to
+ *   pass the prop at every call site.
+ * - `MenuBarSlot`: self-contained component (no props) injected into
+ *   `EuiFlyoutMenu` in place of the built-in Back button and history popover.
+ *
+ * Both fields are optional — safe to read without a provider.
+ */
+export interface EuiFlyoutPluginContextValue {
+  historyKey?: symbol;
+  MenuBarSlot?: ComponentType<Record<string, never>>;
+}
+
+export const EuiFlyoutPluginContext =
+  createContext<EuiFlyoutPluginContextValue>({});

--- a/packages/eui/src/components/flyout/manager/index.ts
+++ b/packages/eui/src/components/flyout/manager/index.ts
@@ -61,3 +61,12 @@ export { EuiFlyoutMain, type EuiFlyoutMainProps } from './flyout_main';
 
 /** Utility functions for flyout sizing and layout. */
 export { getWidthFromSize } from './layout_mode';
+
+/**
+ * Contexts for external packages to integrate with the flyout manager
+ * without coupling to internal history implementation details.
+ */
+export {
+  EuiFlyoutPluginContext,
+  type EuiFlyoutPluginContextValue,
+} from './flyout_plugin';

--- a/packages/eui/src/components/flyout/manager/store.ts
+++ b/packages/eui/src/components/flyout/manager/store.ts
@@ -33,10 +33,28 @@ type Listener = () => void;
 /**
  * Events emitted by the flyout manager store for external consumers.
  */
-export type FlyoutManagerEvent = {
-  type: 'CLOSE_SESSION';
-  session: FlyoutSession;
-};
+export type FlyoutManagerEvent =
+  | {
+      /** Fired when a new main flyout session is added to the stack. */
+      type: 'SESSION_START';
+      session: FlyoutSession;
+    }
+  | {
+      /** Fired when a session's main flyout is removed from the stack. */
+      type: 'CLOSE_SESSION';
+      session: FlyoutSession;
+    }
+  | {
+      /**
+       * Fired when the child flyout of an existing session changes (opens,
+       * closes, or swaps). Use this instead of `store.subscribe()` to avoid
+       * the sync gap that arises from a dual subscription.
+       */
+      type: 'CHILD_CHANGED';
+      sessionId: string;
+      previousChildId: string | null;
+      newChildId: string | null;
+    };
 
 type EventListener = (event: FlyoutManagerEvent) => void;
 
@@ -61,10 +79,22 @@ export interface FlyoutManagerStore {
   setFlyoutWidth: (flyoutId: string, width: number) => void;
   setPushPadding: (side: 'left' | 'right', width: number) => void;
   setContainerElement: (element: HTMLElement | null) => void;
+  /**
+   * @deprecated Subscribe to `SESSION_START` / `CLOSE_SESSION` / `CHILD_CHANGED` events via
+   * `subscribeToEvents` and maintain your own history state. Will be removed in a future major version.
+   */
   goBack: () => void;
+  /**
+   * @deprecated Subscribe to `SESSION_START` / `CLOSE_SESSION` / `CHILD_CHANGED` events via
+   * `subscribeToEvents` and maintain your own history state. Will be removed in a future major version.
+   */
   goToFlyout: (flyoutId: string, level?: EuiFlyoutLevel) => void;
   addUnmanagedFlyout: (flyoutId: string) => void;
   closeUnmanagedFlyout: (flyoutId: string) => void;
+  /**
+   * @deprecated Subscribe to `SESSION_START` / `CLOSE_SESSION` / `CHILD_CHANGED` events via
+   * `subscribeToEvents` and maintain your own history state. Will be removed in a future major version.
+   */
   historyItems: Array<{
     title: string;
     iconType?: IconType;
@@ -200,15 +230,41 @@ function createStore(
       if (nextState.sessions !== previousSessions) {
         store.historyItems = computeHistoryItems(dispatch);
 
-        // Detect removed sessions and emit CLOSE_SESSION events
+        const previousSessionIds = new Set(
+          previousSessions.map((s) => s.mainFlyoutId)
+        );
         const nextSessionIds = new Set(
           nextState.sessions.map((s) => s.mainFlyoutId)
         );
+
+        // Detect removed sessions → CLOSE_SESSION
         previousSessions.forEach((session) => {
           if (!nextSessionIds.has(session.mainFlyoutId)) {
+            emitEvent({ type: 'CLOSE_SESSION', session });
+          }
+        });
+
+        // Detect new sessions → SESSION_START
+        nextState.sessions.forEach((session) => {
+          if (!previousSessionIds.has(session.mainFlyoutId)) {
+            emitEvent({ type: 'SESSION_START', session });
+          }
+        });
+
+        // Detect child flyout changes → CHILD_CHANGED
+        nextState.sessions.forEach((session) => {
+          const prevSession = previousSessions.find(
+            (s) => s.mainFlyoutId === session.mainFlyoutId
+          );
+          if (
+            prevSession &&
+            prevSession.childFlyoutId !== session.childFlyoutId
+          ) {
             emitEvent({
-              type: 'CLOSE_SESSION',
-              session,
+              type: 'CHILD_CHANGED',
+              sessionId: session.mainFlyoutId,
+              previousChildId: prevSession.childFlyoutId,
+              newChildId: session.childFlyoutId,
             });
           }
         });

--- a/packages/eui/src/components/flyout/manager/types.ts
+++ b/packages/eui/src/components/flyout/manager/types.ts
@@ -123,10 +123,25 @@ export interface FlyoutManagerApi {
   setFlyoutWidth: (flyoutId: string, width: number) => void;
   setPushPadding: (side: 'left' | 'right', width: number) => void;
   setContainerElement: (element: HTMLElement | null) => void;
+  /**
+   * @deprecated Subscribe to `SESSION_START` / `CLOSE_SESSION` / `CHILD_CHANGED` events via
+   * `getFlyoutManagerStore().subscribeToEvents` and maintain your own history state.
+   * Will be removed in a future major version.
+   */
   goBack: () => void;
+  /**
+   * @deprecated Subscribe to `SESSION_START` / `CLOSE_SESSION` / `CHILD_CHANGED` events via
+   * `getFlyoutManagerStore().subscribeToEvents` and maintain your own history state.
+   * Will be removed in a future major version.
+   */
   goToFlyout: (flyoutId: string, level?: EuiFlyoutLevel) => void;
   addUnmanagedFlyout: (flyoutId: string) => void;
   closeUnmanagedFlyout: (flyoutId: string) => void;
+  /**
+   * @deprecated Subscribe to `SESSION_START` / `CLOSE_SESSION` / `CHILD_CHANGED` events via
+   * `getFlyoutManagerStore().subscribeToEvents` and maintain your own history state.
+   * Will be removed in a future major version.
+   */
   historyItems: Array<{
     title: string;
     iconType?: IconType;

--- a/packages/eui/src/components/flyout/use_flyout_menu.ts
+++ b/packages/eui/src/components/flyout/use_flyout_menu.ts
@@ -47,10 +47,11 @@ export const useEuiFlyoutMenu = ({
   }, [hasMenu, _titleId, generatedMenuId]);
 
   // Determine if the menu has any content
-  // hasBackButton or hasHistory or hasCustomActions or hasVisibleTitle
+  // hasMenuBarSlot or hasBackButton or hasHistory or hasCustomActions or hasVisibleTitle
   const menuHasContent =
     hasMenu &&
-    (!!flyoutMenuProps.showBackButton ||
+    (!!flyoutMenuProps.menuBarSlot ||
+      !!flyoutMenuProps.showBackButton ||
       (flyoutMenuProps.historyItems?.length ?? 0) > 0 ||
       (flyoutMenuProps.customActions?.length ?? 0) > 0 ||
       // Component defaults to hiding the title, so only explicit false means the title will be visible


### PR DESCRIPTION
Part of https://github.com/elastic/kibana-team/issues/3151

- Added `EuiFlyoutPluginContext` to facilitate external package integration with the flyout manager.
- Introduced `menuBarSlot` prop to replace the built-in Back button and history popover.
- Deprecated `showBackButton`, `backButtonProps`, and `historyItems` in favor of the new context.
- Updated `EuiFlyoutMenu` and related components to utilize the new context and props.
- Enhanced tooltip usage in the flyout menu for better accessibility and user experience.

<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

### API Changes

<!--
List any change to the public EUI API here.

Example:

| component / parent   | prop / child                 | change     | description                                                             |
| -------------------- | ---------------------------- | ---------- | ----------------------------------------------------------------------- |
| EuiOverlayMask       | hasAnimation                 | Added      | Conditionally add animation                                             |
| EuiBadge             | fill                         | Default    | Default is now "false" -- Makes all badges have a light fill by default |
| Tokens               | colors.severity.someOldColor | Deprecated | Use `colors.severity.someOtherColor` instead                            |
| Global CSS Variables | --my-variable                | Added      | Some reason listed here                                                 |

-->

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
|                    |              |        |             |

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| {Before image} | {After image} |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None / 🟢 Low / 🟡 Moderate / 🔴 High

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
