### PR TITLE
[TEST – DO NOT MERGE] Trigger eui-test-helpers flake detection

### DIFF
--- a/.buildkite/pipelines/pipeline_pull_request_test.yml
+++ b/.buildkite/pipelines/pipeline_pull_request_test.yml
@@ -77,3 +77,19 @@ steps:
       - "cypress/videos/**/*.mp4"
     timeout_in_minutes: 45
     retry: *retry_policy
+
+  - command: .buildkite/scripts/pipelines/pipeline_test.sh
+    label: ":playwright: EUI test-helpers validation tests"
+    env:
+      TEST_TYPE: 'test-helpers'
+    if: build.branch != "main"
+    artifact_paths:
+      - "packages/test-helpers/playwright-report/**/*"
+      - "packages/test-helpers/test-results/**/*"
+    timeout_in_minutes: 30
+    retry: *retry_policy
+
+  - command: .buildkite/scripts/pipelines/pipeline_test_helpers_flaky.sh
+    label: ":playwright: Detect flaky test-helpers (changed components)"
+    if: build.branch != "main"
+    retry: *retry_policy

--- a/.buildkite/pipelines/pipeline_test_helpers_scheduled.yml
+++ b/.buildkite/pipelines/pipeline_test_helpers_scheduled.yml
@@ -1,0 +1,30 @@
+# 🏠/.buildkite/pipelines/pipeline_test_helpers_scheduled.yml
+
+agents:
+  provider: gcp
+  machineType: c4d-standard-4
+  preemptible: true
+  diskType: hyperdisk-balanced
+  diskSizeGb: 30
+  spotZones: us-central1-a,us-central1-b,us-central1-c
+
+retry_policy: &retry_policy
+  automatic:
+    - exit_status: -1 # agent loss
+      limit: 3
+
+steps:
+  - command: .buildkite/scripts/pipelines/pipeline_test.sh
+    label: ":playwright: Scheduled flake detection (all helpers, 5×)"
+    env:
+      TEST_TYPE: 'test-helpers'
+      PLAYWRIGHT_ARGS: '--repeat-each=5'
+    artifact_paths:
+      - "packages/test-helpers/playwright-report/**/*"
+      - "packages/test-helpers/test-results/**/*"
+    timeout_in_minutes: 60
+    retry: *retry_policy
+
+notify:
+  - slack: "#appex-qa"
+    if: build.state == "failed"

--- a/.buildkite/scripts/pipelines/pipeline_test.sh
+++ b/.buildkite/scripts/pipelines/pipeline_test.sh
@@ -20,6 +20,7 @@ DOCKER_OPTIONS=(
   --env BUILDKITE_JOB_ID
   --env BUILDKITE_MESSAGE
   --env CI=true
+  --env PLAYWRIGHT_ARGS="${PLAYWRIGHT_ARGS:-}"
   --user="$(id -u):$(id -g)"
   --volume="$(pwd):/app"
   --workdir=/app
@@ -65,6 +66,11 @@ case $TEST_TYPE in
   cypress:a11y)
     echo "[TASK]: Running Cypress accessibility tests against React 18"
     COMMAND="/opt/yarn*/bin/yarn --cwd packages/eui && yarn --cwd packages/eui build:workspaces && yarn --cwd packages/eui cypress install && yarn --cwd packages/eui run test-cypress-a11y --node-options=--max_old_space_size=2048"
+    ;;
+
+  test-helpers)
+    echo "[TASK]: Running EUI test-helpers validation tests"
+    COMMAND="/opt/yarn*/bin/yarn && yarn workspace @elastic/eui build:workspaces && yarn workspace @elastic/eui build-storybook && yarn workspace @elastic/eui-test-helpers exec playwright install chromium && yarn workspace @elastic/eui-test-helpers exec playwright test ${PLAYWRIGHT_ARGS:-}"
     ;;
 
   *)

--- a/.buildkite/scripts/pipelines/pipeline_test_helpers_flaky.sh
+++ b/.buildkite/scripts/pipelines/pipeline_test_helpers_flaky.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Re-runs test-helper specs for any EUI component changed in this PR, to surface
+# flakiness. See wiki/contributing-to-eui/testing/eui-test-helpers.md.
+
+set -euo pipefail
+
+source .buildkite/scripts/common/utils.sh
+
+FLAKY_REPEAT="${FLAKY_REPEAT:-25}"
+BASE_BRANCH="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
+HELPERS_DIR="packages/test-helpers/src/playwright/components"
+COMPONENTS_DIR="packages/eui/src/components"
+
+echo "+++ Determining components changed against ${BASE_BRANCH}"
+retry 3 git fetch -q origin "${BASE_BRANCH}"
+
+# Diff against the merge base. The CI checkout can be shallow, so deepen if the
+# common ancestor isn't present; if it still can't be found, skip rather than
+# block the PR — this is an additive flakiness check, not a correctness gate.
+base_sha="$(git merge-base "origin/${BASE_BRANCH}" HEAD 2>/dev/null || true)"
+if [[ -z "${base_sha}" ]]; then
+  git fetch -q --deepen=200 origin "${BASE_BRANCH}" 2>/dev/null || true
+  base_sha="$(git merge-base "origin/${BASE_BRANCH}" HEAD 2>/dev/null || true)"
+fi
+if [[ -z "${base_sha}" ]]; then
+  echo "Could not determine the merge base with ${BASE_BRANCH} — skipping flake detection."
+  exit 0
+fi
+
+changed_files="$(git diff --name-only "${base_sha}" HEAD)"
+
+# A helper is affected when this PR touched its component source or its own
+# specs. Correlation is by directory name: <helper>/<name> maps to
+# packages/eui/src/components/<name>.
+affected=""
+for helper_path in "${HELPERS_DIR}"/*/; do
+  [[ -d "${helper_path}" ]] || continue
+  name="$(basename "${helper_path}")"
+  helper_specs="${helper_path%/}"
+  if grep -qE "^(${COMPONENTS_DIR}/${name}|${helper_specs})/" <<< "${changed_files}"; then
+    # Playwright filters are resolved from the package dir, so strip the prefix.
+    affected+="${helper_specs#packages/test-helpers/} "
+  fi
+done
+affected="$(echo "${affected}" | xargs)"
+
+if [[ -z "${affected}" ]]; then
+  echo "No changed EUI components have correlated test helpers — skipping flake detection."
+  exit 0
+fi
+
+echo "Affected helper specs: ${affected} (running ${FLAKY_REPEAT}×)"
+
+cat <<YAML | buildkite-agent pipeline upload
+steps:
+  - command: .buildkite/scripts/pipelines/pipeline_test.sh
+    label: ":playwright: Flake detection (${FLAKY_REPEAT}× affected specs)"
+    env:
+      TEST_TYPE: 'test-helpers'
+      PLAYWRIGHT_ARGS: '${affected} --repeat-each=${FLAKY_REPEAT}'
+    artifact_paths:
+      - "packages/test-helpers/playwright-report/**/*"
+      - "packages/test-helpers/test-results/**/*"
+    timeout_in_minutes: 45
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 3
+YAML

--- a/packages/eui/src/components/combo_box/combo_box.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.tsx
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+// TEMP: no-op edit to trigger eui-test-helpers flake detection — do not merge.
+
 /**
  * Elements within EuiComboBox which would normally be tabbable (inputs, buttons) have been removed
  * from the tab order with tabindex={-1} so that we can control the keyboard navigation interface.

--- a/packages/test-helpers/CONTRIBUTING.md
+++ b/packages/test-helpers/CONTRIBUTING.md
@@ -94,3 +94,11 @@ After a failed run, open the HTML report (with traces, screenshots, and the full
 ```shell
 yarn workspace @elastic/eui-test-helpers show-report
 ```
+
+> The local workflow above is unchanged: Playwright's `webServer` is configured with `reuseExistingServer` (off in CI), so when you already have the dev server on `:6006` it is reused. In CI — where no dev server runs — `webServer` serves EUI's prebuilt static Storybook (`packages/eui/storybook-static`) instead.
+
+## CI integration
+
+These tests run in EUI's Buildkite CI on every PR, with flake detection when a component changes, plus a scheduled run. See [Testing → EUI test helpers](../../wiki/contributing-to-eui/testing/eui-test-helpers.md) in the wiki.
+
+Flake detection correlates a component to its helper **by directory name**: a change under `packages/eui/src/components/<name>` re-runs the specs in `src/playwright/components/<name>`. Keep that directory parity when adding a Component Object and no extra wiring is needed.

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.59.1",
+    "http-server": "^14.1.1",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/test-helpers/playwright.config.ts
+++ b/packages/test-helpers/playwright.config.ts
@@ -10,11 +10,13 @@ import { defineConfig, devices } from '@playwright/test';
 
 const STORYBOOK_PORT = 6006;
 const STORYBOOK_URL = `http://localhost:${STORYBOOK_PORT}`;
+const STORYBOOK_STATIC_DIR = '../eui/storybook-static';
 
 /**
- * Tests expect Storybook to already be running on `STORYBOOK_PORT`; see the
- * package README for the local workflow. Defaults track kbn-scout's config
- * (test-id attribute, timeouts, no auto-retries) for cross-team consistency.
+ * Locally, `webServer` reuses the already-running Storybook dev server; in CI it
+ * serves the prebuilt static Storybook (see the package README). Defaults track
+ * kbn-scout's config (test-id attribute, timeouts, no auto-retries) for
+ * cross-team consistency.
  */
 export default defineConfig({
   testDir: './src',
@@ -32,6 +34,12 @@ export default defineConfig({
     navigationTimeout: 20_000,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+  },
+  webServer: {
+    command: `npx http-server ${STORYBOOK_STATIC_DIR} --port ${STORYBOOK_PORT} --silent`,
+    url: STORYBOOK_URL,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 });

--- a/wiki/contributing-to-eui/testing/README.md
+++ b/wiki/contributing-to-eui/testing/README.md
@@ -8,6 +8,7 @@ All components should have, at minimum, unit tests for each prop.
 - **[Cypress component tests](./cypress-testing.md)** — optional, used for complex components or where real-browser DOM and interactions are needed.
 - **Storybook** — the component development environment and the source of stories used by visual regression testing.
 - **[Visual regression tests](./visual-regression-testing.md)** — Playwright + `jest-image-snapshot` against Storybook stories, run on every pull request.
+- **[EUI test helpers](./eui-test-helpers.md)** — Playwright validation tests for `@elastic/eui-test-helpers`, run on every pull request with flake detection when a component changes.
 
 ## Code coverage
 

--- a/wiki/contributing-to-eui/testing/eui-test-helpers.md
+++ b/wiki/contributing-to-eui/testing/eui-test-helpers.md
@@ -1,0 +1,25 @@
+# EUI test helpers
+
+[`@elastic/eui-test-helpers`](../../../packages/test-helpers) ships Playwright Component Objects used by downstream end-to-end tests (Kibana Scout). Each helper has validation tests that run its public API against the real component in Storybook. This page covers how those tests run in CI; for the package itself (directory layout, adding a Component Object, running locally) see the package [CONTRIBUTING](../../../packages/test-helpers/CONTRIBUTING.md).
+
+## On every pull request
+
+`eui-pull-request-test` runs two helper steps (`test-helpers` task in [`pipeline_test.sh`](../../../.buildkite/scripts/pipelines/pipeline_test.sh)):
+
+- **Validation** — builds the EUI workspaces and Storybook, then runs the full Playwright suite once. Storybook is served by Playwright's `webServer` from the static build.
+- **Flake detection** — [`pipeline_test_helpers_flaky.sh`](../../../.buildkite/scripts/pipelines/pipeline_test_helpers_flaky.sh) diffs the PR against its merge base and, for any changed component with a correlated helper, runs that helper's specs `--repeat-each=25` to surface flakiness — even when the helper itself was not touched. A flaky failure fails the build. It is a no-op when no correlated component changed.
+
+### Component ↔ helper correlation
+
+The correlation is **by directory name**: a change under `packages/eui/src/components/<name>` (or the helper's own specs) re-runs `packages/test-helpers/src/playwright/components/<name>`. Keeping that directory parity is all that is required — there is no map to maintain.
+
+## Scheduled run
+
+[`pipeline_test_helpers_scheduled.yml`](../../../.buildkite/pipelines/pipeline_test_helpers_scheduled.yml) runs the whole suite with `--repeat-each=5` and notifies Slack on failure.
+
+## One-time Buildkite setup
+
+Not configurable from the repo — requires Buildkite org-admin access:
+
+- A pipeline pointing at `pipeline_test_helpers_scheduled.yml`, with a scheduled build every 8 hours (cron `0 */8 * * *`).
+- The Buildkite Slack integration enabled for the elastic org; confirm the destination channel (currently `#appex-qa`).

--- a/yarn.lock
+++ b/yarn.lock
@@ -7135,6 +7135,7 @@ __metadata:
   resolution: "@elastic/eui-test-helpers@workspace:packages/test-helpers"
   dependencies:
     "@playwright/test": "npm:1.59.1"
+    http-server: "npm:^14.1.1"
     typescript: "npm:^5.7.3"
   peerDependencies:
     "@playwright/test": ^1.50.0
@@ -14489,6 +14490,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^3.2.6":
+  version: 3.2.6
+  resolution: "async@npm:3.2.6"
+  checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
+  languageName: node
+  linkType: hard
+
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -14916,6 +14924,15 @@ __metadata:
     mixin-deep: "npm:^1.2.0"
     pascalcase: "npm:^0.1.1"
   checksum: 10c0/30a2c0675eb52136b05ef496feb41574d9f0bb2d6d677761da579c00a841523fccf07f1dbabec2337b5f5750f428683b8ca60d89e56a1052c4ae1c0cd05de64d
+  languageName: node
+  linkType: hard
+
+"basic-auth@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "basic-auth@npm:2.0.1"
+  dependencies:
+    safe-buffer: "npm:5.1.2"
+  checksum: 10c0/05f56db3a0fc31c89c86b605231e32ee143fb6ae38dc60616bc0970ae6a0f034172def99e69d3aed0e2c9e7cac84e2d63bc51a0b5ff6ab5fc8808cc8b29923c1
   languageName: node
   linkType: hard
 
@@ -15725,6 +15742,16 @@ __metadata:
     function-bind: "npm:^1.1.1"
     get-intrinsic: "npm:^1.0.2"
   checksum: 10c0/74ba3f31e715456e22e451d8d098779b861eba3c7cac0d9b510049aced70d75c231ba05071f97e1812c98e34e2bee734c0c6126653e0088c2d9819ca047f4073
+  languageName: node
+  linkType: hard
+
+"call-bound@npm:^1.0.2":
+  version: 1.0.4
+  resolution: "call-bound@npm:1.0.4"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.3.0"
+  checksum: 10c0/f4796a6a0941e71c766aea672f63b72bc61234c4f4964dc6d7606e3664c307e7d77845328a8f3359ce39ddb377fed67318f9ee203dea1d47e46165dcf2917644
   languageName: node
   linkType: hard
 
@@ -17428,6 +17455,13 @@ __metadata:
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
   checksum: 10c0/90a0e40abbddfd7618f8ccd63a74d88deea94e77d0e8dbbea059fa7ebebb8fbb4e2909667fe26f3a467073de1a542ebe6ae4c73a73745ac5833786759cd906c9
+  languageName: node
+  linkType: hard
+
+"corser@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "corser@npm:2.0.1"
+  checksum: 10c0/1f319a752a560342dd22d936e5a4c158bfcbc332524ef5b05a7277236dad8b0b2868fd5cf818559f29954ec4d777d82e797fccd76601fcfe431610e4143c8acc
   languageName: node
   linkType: hard
 
@@ -22449,7 +22483,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.6":
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.1
   resolution: "get-intrinsic@npm:1.3.1"
   dependencies:
@@ -23927,6 +23961,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-encoding-sniffer@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "html-encoding-sniffer@npm:3.0.0"
+  dependencies:
+    whatwg-encoding: "npm:^2.0.0"
+  checksum: 10c0/b17b3b0fb5d061d8eb15121c3b0b536376c3e295ecaf09ba48dd69c6b6c957839db124fe1e2b3f11329753a4ee01aa7dedf63b7677999e86da17fbbdd82c5386
+  languageName: node
+  linkType: hard
+
 "html-encoding-sniffer@npm:^4.0.0":
   version: 4.0.0
   resolution: "html-encoding-sniffer@npm:4.0.0"
@@ -24214,6 +24257,29 @@ __metadata:
     follow-redirects: "npm:^1.0.0"
     requires-port: "npm:^1.0.0"
   checksum: 10c0/148dfa700a03fb421e383aaaf88ac1d94521dfc34072f6c59770528c65250983c2e4ec996f2f03aa9f3fe46cd1270a593126068319311e3e8d9e610a37533e94
+  languageName: node
+  linkType: hard
+
+"http-server@npm:^14.1.1":
+  version: 14.1.1
+  resolution: "http-server@npm:14.1.1"
+  dependencies:
+    basic-auth: "npm:^2.0.1"
+    chalk: "npm:^4.1.2"
+    corser: "npm:^2.0.1"
+    he: "npm:^1.2.0"
+    html-encoding-sniffer: "npm:^3.0.0"
+    http-proxy: "npm:^1.18.1"
+    mime: "npm:^1.6.0"
+    minimist: "npm:^1.2.6"
+    opener: "npm:^1.5.1"
+    portfinder: "npm:^1.0.28"
+    secure-compare: "npm:3.0.1"
+    union: "npm:~0.5.0"
+    url-join: "npm:^4.0.1"
+  bin:
+    http-server: bin/http-server
+  checksum: 10c0/c5770ddd722dd520ce0af25efee6bfb7c6300ff4e934636d4eec83fa995739e64de2e699e89e7a795b3a1894bcc37bec226617c1023600aacd7871fd8d6ffe6d
   languageName: node
   linkType: hard
 
@@ -29204,7 +29270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:1.6.0":
+"mime@npm:1.6.0, mime@npm:^1.6.0":
   version: 1.6.0
   resolution: "mime@npm:1.6.0"
   bin:
@@ -30564,6 +30630,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
+  version: 1.13.4
+  resolution: "object-inspect@npm:1.13.4"
+  checksum: 10c0/d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
+  languageName: node
+  linkType: hard
+
 "object-is@npm:^1.0.1, object-is@npm:^1.1.5":
   version: 1.1.5
   resolution: "object-is@npm:1.1.5"
@@ -30804,7 +30877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"opener@npm:^1.5.2":
+"opener@npm:^1.5.1, opener@npm:^1.5.2":
   version: 1.5.2
   resolution: "opener@npm:1.5.2"
   bin:
@@ -31942,6 +32015,16 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:^7.17.8"
   checksum: 10c0/1d054d1fea18ac7d921ca91504ffcf1ef0f505eda6acbfec6e205a98ebfea80b658664995deb35907dabc5f75f287dc2894812503a8aed28285bb91f25cf7400
+  languageName: node
+  linkType: hard
+
+"portfinder@npm:^1.0.28":
+  version: 1.0.38
+  resolution: "portfinder@npm:1.0.38"
+  dependencies:
+    async: "npm:^3.2.6"
+    debug: "npm:^4.3.6"
+  checksum: 10c0/59b2f2aa0b620c90ce0d477241e62c277f38bfd4fb6074106c23560248dd5e5c2c629dd048ef721f32b19df4213d09b77234880e4f0ab04abf1ab70b6d8048fa
   languageName: node
   linkType: hard
 
@@ -33812,6 +33895,15 @@ __metadata:
   dependencies:
     side-channel: "npm:^1.0.4"
   checksum: 10c0/4f95d4ff18ed480befcafa3390022817ffd3087fc65f146cceb40fc5edb9fa96cb31f648cae2fa96ca23818f0798bd63ad4ca369a0e22702fcd41379b3ab6571
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.4.0":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 
@@ -36190,6 +36282,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"secure-compare@npm:3.0.1":
+  version: 3.0.1
+  resolution: "secure-compare@npm:3.0.1"
+  checksum: 10c0/af3102f3f555d917c8ffff7a5f6f00f70195708f4faf82d48794485c9f3cb365cee0dd4da6b4e53e8964f172970bce6069b6101ba3ce8c309bff54f460d1f650
+  languageName: node
+  linkType: hard
+
 "secure-json-parse@npm:^3.0.1":
   version: 3.0.2
   resolution: "secure-json-parse@npm:3.0.2"
@@ -36588,6 +36687,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+  checksum: 10c0/d346c787fd2f9f1c2fdea14f00e8250118db0e7596d85a6cb9faa75f105d31a73a8f7a341c93d7df2a2429098c3d37a77bd3be9e88c37094b8c01807bc77c7a2
+  languageName: node
+  linkType: hard
+
+"side-channel-map@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-map@npm:1.0.1"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.5"
+    object-inspect: "npm:^1.13.3"
+  checksum: 10c0/010584e6444dd8a20b85bc926d934424bd809e1a3af941cace229f7fdcb751aada0fb7164f60c2e22292b7fa3c0ff0bce237081fd4cdbc80de1dc68e95430672
+  languageName: node
+  linkType: hard
+
+"side-channel-weakmap@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "side-channel-weakmap@npm:1.0.2"
+  dependencies:
+    call-bound: "npm:^1.0.2"
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.5"
+    object-inspect: "npm:^1.13.3"
+    side-channel-map: "npm:^1.0.1"
+  checksum: 10c0/71362709ac233e08807ccd980101c3e2d7efe849edc51455030327b059f6c4d292c237f94dc0685031dd11c07dd17a68afde235d6cf2102d949567f98ab58185
+  languageName: node
+  linkType: hard
+
 "side-channel@npm:^1.0.4":
   version: 1.0.4
   resolution: "side-channel@npm:1.0.4"
@@ -36596,6 +36730,19 @@ __metadata:
     get-intrinsic: "npm:^1.0.2"
     object-inspect: "npm:^1.9.0"
   checksum: 10c0/054a5d23ee35054b2c4609b9fd2a0587760737782b5d765a9c7852264710cc39c6dcb56a9bbd6c12cd84071648aea3edb2359d2f6e560677eedadce511ac1da5
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+    side-channel-list: "npm:^1.0.1"
+    side-channel-map: "npm:^1.0.1"
+    side-channel-weakmap: "npm:^1.0.2"
+  checksum: 10c0/dc0ab81d67f61bda9247d053ce93f41c3fd8ad2bdcb9cf9d8d2f8540d488f26d87a5e99ebfc07eea49ec025867b2452b705442d974b1478f0395e69f6bfb3270
   languageName: node
   linkType: hard
 
@@ -39604,6 +39751,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"union@npm:~0.5.0":
+  version: 0.5.0
+  resolution: "union@npm:0.5.0"
+  dependencies:
+    qs: "npm:^6.4.0"
+  checksum: 10c0/9ac158d99991063180e56f408f5991e808fa07594713439c098116da09215c154672ee8c832e16a6b39b037609c08bcaff8ff07c1e3e46c3cc622897972af2aa
+  languageName: node
+  linkType: hard
+
 "uniq@npm:^1.0.1":
   version: 1.0.1
   resolution: "uniq@npm:1.0.1"
@@ -40108,6 +40264,13 @@ __metadata:
   version: 0.1.0
   resolution: "urix@npm:0.1.0"
   checksum: 10c0/264f1b29360c33c0aec5fb9819d7e28f15d1a3b83175d2bcc9131efe8583f459f07364957ae3527f1478659ec5b2d0f1ad401dfb625f73e4d424b3ae35fc5fc0
+  languageName: node
+  linkType: hard
+
+"url-join@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "url-join@npm:4.0.1"
+  checksum: 10c0/ac65e2c7c562d7b49b68edddcf55385d3e922bc1dd5d90419ea40b53b6de1607d1e45ceb71efb9d60da02c681d13c6cb3a1aa8b13fc0c989dfc219df97ee992d
   languageName: node
   linkType: hard
 
@@ -41139,6 +41302,15 @@ __metadata:
   version: 0.1.4
   resolution: "websocket-extensions@npm:0.1.4"
   checksum: 10c0/bbc8c233388a0eb8a40786ee2e30d35935cacbfe26ab188b3e020987e85d519c2009fe07cfc37b7f718b85afdba7e54654c9153e6697301f72561bfe429177e0
+  languageName: node
+  linkType: hard
+
+"whatwg-encoding@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "whatwg-encoding@npm:2.0.0"
+  dependencies:
+    iconv-lite: "npm:0.6.3"
+  checksum: 10c0/91b90a49f312dc751496fd23a7e68981e62f33afe938b97281ad766235c4872fc4e66319f925c5e9001502b3040dd25a33b02a9c693b73a4cbbfdc4ad10c3e3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
⚠️ **Throwaway test PR — do not merge / do not review.** Close after CI runs.

Branched off `feat/test-helpers-ci-integration` (#9740) + a single no-op comment in `combo_box.tsx`, to validate that eui-test-helpers **flake detection** triggers when a correlated component changes.

**Expected on `eui-pull-request-test`:** the `Detect flaky test-helpers` step finds `combo_box` changed and uploads a `Flake detection (25× affected specs)` job that runs the combo_box specs 25× and passes. Large diff is expected (based on the M3 branch).