### PR TITLE
[Docs] Disable fullscreen button for one-liner code snippets

### DIFF
--- a/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
@@ -40,11 +40,15 @@ export default function CodeBlock({
     return <Demo {...props}>{children}</Demo>;
   }
 
+  // Don't show the fullscreen button for single-line snippets
+  const isOneLiner =
+    typeof children === 'string' && !children.trim().includes('\n');
+
   return (
     <EuiCodeBlock
       {...props}
       fontSize="m"
-      overflowHeight={450}
+      overflowHeight={isOneLiner ? undefined : 450}
       language={language}
       isCopyable
       css={css`


### PR DESCRIPTION
## Summary

Fixes #9731.

The fullscreen button shows up on every code block in the docs because `overflowHeight` is always set to 450. For one-liner snippets there's nothing to expand, and the button just makes the box taller than it needs to be.

This checks if the snippet is a single line and skips `overflowHeight` in that case, which prevents the fullscreen button from rendering (it's gated on `!!overflowHeight` in `useFullScreen`).

Multi-line snippets are unaffected.

## QA

- [x] One-liner snippets on the [installation page](https://eui.elastic.co/docs/getting-started/setup/#installation) no longer show the fullscreen button
- [x] Multi-line snippets still have the fullscreen button and it works
- [x] Copy button still appears on all snippets