### PR TITLE
[EuiFlyoutMenu] Dedupe i18n token usage

### DIFF
--- a/packages/eui/src/components/flyout/flyout_menu.tsx
+++ b/packages/eui/src/components/flyout/flyout_menu.tsx
@@ -221,6 +221,11 @@ const PaginationControls: React.FC<{
   const { currentIndex, total, onPrevious, onNext } = pagination;
   const prevLabel = useEuiI18n('euiFlyoutMenu.pagination.previous', 'Previous');
   const nextLabel = useEuiI18n('euiFlyoutMenu.pagination.next', 'Next');
+  const counterLabel = useEuiI18n(
+    'euiFlyoutMenu.pagination.counter',
+    '{position} of {total}',
+    { position: currentIndex + 1, total }
+  );
 
   const isPrevDisabled = currentIndex === 0;
   const isNextDisabled = currentIndex === total - 1;
@@ -267,19 +272,9 @@ const PaginationControls: React.FC<{
             css={styles.euiFlyoutMenu__paginationCounter}
             aria-hidden="true"
           >
-            <EuiI18n
-              token="euiFlyoutMenu.pagination.counter"
-              default="{position} of {total}"
-              values={{ position: currentIndex + 1, total }}
-            />
+            {counterLabel}
           </EuiText>
-          <EuiScreenReaderLive>
-            <EuiI18n
-              token="euiFlyoutMenu.pagination.counter"
-              default="{position} of {total}"
-              values={{ position: currentIndex + 1, total }}
-            />
-          </EuiScreenReaderLive>
+          <EuiScreenReaderLive>{counterLabel}</EuiScreenReaderLive>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           {isNextDisabled ? (


### PR DESCRIPTION
## Summary

This is a tiny follow-up to https://github.com/elastic/eui/pull/9726. It refactors the duplicate call to the `euiFlyoutMenu.pagination.counter` into a single one. This showed up in the recent release ([comment](https://github.com/elastic/eui/pull/9756#discussion_r3474917617)) as duplicate i18n token changelog entry.

>[!note]
This change does not impact any visual or functionality but rather an optimization to prevent duplicate i18n token builds.
The label `skip-changelog` was added because of this.

### API Changes

⚪  No API changes.

## Screenshots

⚪ No visual changes.


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
