### PR TITLE
docs: add spacing around MDX code blocks

### DIFF
--- a/packages/docusaurus-theme/changelogs/upcoming/9762.md
+++ b/packages/docusaurus-theme/changelogs/upcoming/9762.md
@@ -1,0 +1,1 @@
+- Added vertical spacing around MDX code blocks in the Docusaurus theme.

--- a/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
@@ -48,6 +48,7 @@ export default function CodeBlock({
       language={language}
       isCopyable
       css={css`
+        margin-block: var(--eui-theme-content-vertical-spacing);
         word-break: break-word;
       `}
     >

--- a/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
@@ -8,10 +8,17 @@
 
 import React, { isValidElement, type ReactNode, JSX } from 'react';
 import { css } from '@emotion/react';
-import { EuiCodeBlock } from '@elastic/eui';
+import { EuiCodeBlock, useEuiMemoizedStyles, UseEuiTheme } from '@elastic/eui';
 import type { Props } from '@theme/CodeBlock';
 
 import { Demo } from '../../components/demo';
+
+const getStyles = ({ euiTheme }: UseEuiTheme) => ({
+  codeBlock: css`
+    margin-block: ${euiTheme.size.base};
+    word-break: break-word;
+  `,
+});
 
 /**
  * Best attempt to make the children a plain string so it is copyable. If there
@@ -35,6 +42,7 @@ export default function CodeBlock({
 }: Props): JSX.Element {
   const children = maybeStringifyChildren(rawChildren);
   const language = className?.replace('language-', '') || undefined;
+  const styles = useEuiMemoizedStyles(getStyles);
 
   if (metastring?.startsWith('interactive')) {
     return <Demo {...props}>{children}</Demo>;
@@ -47,10 +55,7 @@ export default function CodeBlock({
       overflowHeight={450}
       language={language}
       isCopyable
-      css={css`
-        margin-block: var(--eui-theme-content-vertical-spacing);
-        word-break: break-word;
-      `}
+      css={styles.codeBlock}
     >
       {children}
     </EuiCodeBlock>


### PR DESCRIPTION
Summary
- Add vertical spacing around fenced MDX code blocks using the docs theme spacing token.

Testing
- `git diff --check`

Closes #9730