### PR TITLE
docs: improve overlay mask prop table

### DIFF
--- a/packages/website/docs/utilities/overlay-mask.mdx
+++ b/packages/website/docs/utilities/overlay-mask.mdx
@@ -69,4 +69,23 @@ Managing z-index levels of multiple portal-positioned components and their diffe
 
 import docgen from '@elastic/eui-docgen/dist/components/overlay_mask';
 
-<PropTable definition={docgen.EuiOverlayMask} />
+export const overlayMaskProps = [
+  'children',
+  'headerZindexLocation',
+  'maskRef',
+  'hasAnimation',
+].reduce(
+  (props, propName) => ({
+    ...props,
+    [propName]: docgen.EuiOverlayMask.props[propName],
+  }),
+  {}
+);
+
+<PropTable
+  definition={{
+    ...docgen.EuiOverlayMask,
+    extends: [],
+    props: overlayMaskProps,
+  }}
+/>


### PR DESCRIPTION
Summary

- Limit the Overlay mask docs prop table to the EuiOverlayMask-specific props.
- Hide inherited HTML attribute extensions that made the table noisy.

Testing

- git diff --check
- git push pre-push checks

Closes #9733