### PR TITLE
[EuiSelectable] Support invalid state

### DIFF
--- a/packages/eui/src/components/selectable/selectable.test.tsx
+++ b/packages/eui/src/components/selectable/selectable.test.tsx
@@ -106,6 +106,22 @@ describe('EuiSelectable', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
+    test('isInvalid', () => {
+      const { getByRole } = render(
+        <EuiSelectable options={options} searchable isInvalid>
+          {(list, search) => (
+            <>
+              {search}
+              {list}
+            </>
+          )}
+        </EuiSelectable>
+      );
+
+      expect(getByRole('searchbox')).toHaveAttribute('aria-invalid', 'true');
+      expect(getByRole('listbox')).toHaveAttribute('aria-invalid', 'true');
+    });
+
     test('height can be forced', () => {
       const { container } = render(
         <EuiSelectable options={options} height={200} />

--- a/packages/eui/src/components/selectable/selectable.tsx
+++ b/packages/eui/src/components/selectable/selectable.tsx
@@ -186,6 +186,10 @@ export type EuiSelectableProps<T = {}> = CommonProps &
      */
     errorMessage?: ReactElement | string | null;
     /**
+     * Marks the searchable input and options list as invalid for assistive technologies.
+     */
+    isInvalid?: boolean;
+    /**
      * Control whether or not options get filtered internally (i.e., whether filtering is
      * handled by EUI or by you, the consumer).
      * If set to `true`, all passed `options` will be displayed regardless of the user's
@@ -567,6 +571,7 @@ export class EuiSelectable<T = {}> extends Component<
       noMatchesMessage,
       emptyMessage,
       errorMessage,
+      isInvalid,
       selectableScreenReaderText,
       isPreFiltered,
       optionMatcher,
@@ -594,6 +599,7 @@ export class EuiSelectable<T = {}> extends Component<
     const {
       'aria-label': listAriaLabel,
       'aria-describedby': listAriaDescribedby,
+      isInvalid: listIsInvalid,
       isVirtualized,
       rowHeight,
       ...cleanedListProps
@@ -772,6 +778,7 @@ export class EuiSelectable<T = {}> extends Component<
                 ? searchAccessibleName
                 : { 'aria-label': placeholderName })}
               {...cleanedSearchProps}
+              {...(isInvalid == null ? {} : { isInvalid })}
             />
 
             <EuiScreenReaderOnly>
@@ -854,6 +861,7 @@ export class EuiSelectable<T = {}> extends Component<
                 {...(listHasAccessibleName
                   ? listAccessibleName
                   : searchable && { 'aria-label': placeholderName })}
+                isInvalid={isInvalid ?? listIsInvalid}
                 {...cleanedListProps}
                 {...virtualizedProps}
               />

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list.test.tsx
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list.test.tsx
@@ -249,6 +249,28 @@ describe('EuiSelectableListItem', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
+    test('isInvalid', () => {
+      const { getByRole, rerender } = render(
+        <EuiSelectableList
+          options={options}
+          isInvalid
+          {...selectableListRequiredProps}
+        />
+      );
+
+      expect(getByRole('listbox')).toHaveAttribute('aria-invalid', 'true');
+
+      rerender(
+        <EuiSelectableList
+          options={options}
+          isInvalid={false}
+          {...selectableListRequiredProps}
+        />
+      );
+
+      expect(getByRole('listbox')).not.toHaveAttribute('aria-invalid');
+    });
+
     describe('isVirtualized={false}', () => {
       it('renders', () => {
         const { container } = render(

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list.tsx
@@ -119,6 +119,10 @@ export type EuiSelectableOptionsListProps = CommonProps &
      * text will always take precedence.
      */
     truncationProps?: EuiSelectableOption['truncationProps'];
+    /**
+     * Marks the options list as invalid for assistive technologies.
+     */
+    isInvalid?: boolean;
   } & EuiSelectableOptionsListVirtualizedProps;
 
 export type EuiSelectableListProps<T> = EuiSelectableOptionsListProps & {
@@ -240,6 +244,7 @@ export class EuiSelectableList<T> extends Component<
       searchable,
       singleSelection,
       autoFocus,
+      isInvalid,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledby,
       'aria-describedby': ariaDescribedby,
@@ -272,6 +277,18 @@ export class EuiSelectableList<T> extends Component<
         // use last stack execution to prevent potential focus order issues
         setTimeout(() => ref.focus());
       }
+
+      this.setListBoxInvalidState(isInvalid);
+    }
+  };
+
+  setListBoxInvalidState = (isInvalid = this.props.isInvalid) => {
+    if (!this.listBoxRef) return;
+
+    if (isInvalid) {
+      this.listBoxRef.setAttribute('aria-invalid', 'true');
+    } else {
+      this.listBoxRef.removeAttribute('aria-invalid');
     }
   };
 
@@ -318,7 +335,12 @@ export class EuiSelectableList<T> extends Component<
       onFocusBadge,
       searchable,
       singleSelection,
+      isInvalid,
     } = this.props;
+
+    if (prevProps.isInvalid !== isInvalid) {
+      this.setListBoxInvalidState(isInvalid);
+    }
 
     if (prevProps.activeOptionIndex !== activeOptionIndex) {
       const { makeOptionId } = this.props;
@@ -755,6 +777,7 @@ export class EuiSelectableList<T> extends Component<
       textWrap,
       truncationProps,
       autoFocus,
+      isInvalid,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
## Summary

- Add a top-level `isInvalid` prop to `EuiSelectable`.
- Apply the invalid state to both the searchable input and options listbox for assistive technologies.
- Preserve `searchProps` and `listProps` invalid-state configuration when the top-level prop is omitted.
- Add an interactive validation example and an accessibility changelog entry.

Closes #8991

### API Changes

| component / parent | prop / child | change | description |
| --- | --- | --- | --- |
| `EuiSelectable` | `isInvalid` | Added | Marks the search input and listbox as invalid for assistive technologies. |

## Screenshots

The interactive documentation example demonstrates the invalid state and its error message.

## Impact Assessment

Optional accessibility API addition. Existing behavior is unchanged when `isInvalid` is omitted.

Impact level: Low

## Release Readiness

- Documentation: Added an interactive invalid-state example.
- Changelog: Added an accessibility entry.
- Figma: Not applicable.
- Migration guide: Not applicable.
- Adoption plan: Not applicable.

### QA instructions for reviewer

1. Open the Selectable documentation and locate the Invalid state example.
2. Confirm the search field and listbox expose `aria-invalid="true"` before an option is selected.
3. Select an option and confirm the invalid attributes and error message are removed.

### Checklist before marking Ready for Review

- [x] Filled out all applicable sections.
- [x] Added tests for the searchable input and listbox.
- [x] Ran 69 focused tests and verified 30 snapshots.
- [x] Ran the full staged-change gate: workspace builds, lint with zero errors, and 148 related tests.
- [x] Ran the production documentation build.