### PR TITLE
[EuiSelectable][EuiSelectableList] Fix stale option heights after updates

### DIFF
--- a/packages/eui/changelogs/upcoming/9770.md
+++ b/packages/eui/changelogs/upcoming/9770.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiSelectable` with group labels rendering options with stale heights

--- a/packages/eui/src/components/selectable/selectable.spec.tsx
+++ b/packages/eui/src/components/selectable/selectable.spec.tsx
@@ -231,9 +231,15 @@ describe('EuiSelectable', () => {
         cy.get('input').realClick().realType('Option');
 
         cy.get('li[role=option]').should('have.length', 3);
-        cy.get('li[role=option]').eq(0).invoke('outerHeight').should('eq', 32);
-        cy.get('li[role=option]').eq(1).invoke('outerHeight').should('eq', 32);
-        cy.get('li[role=option]').eq(2).invoke('outerHeight').should('eq', 32);
+        cy.get('li[role=option]')
+          .should('have.length', 3)
+          .then(($options) => {
+            const firstHeight = $options.eq(0).outerHeight();
+
+            $options.each((_, el) => {
+              expect(Cypress.$(el).outerHeight()).to.eq(firstHeight);
+            });
+          });
       });
     });
   });

--- a/packages/eui/src/components/selectable/selectable.spec.tsx
+++ b/packages/eui/src/components/selectable/selectable.spec.tsx
@@ -206,6 +206,36 @@ describe('EuiSelectable', () => {
           ]);
         });
     });
+
+    describe('with groups', () => {
+      it('renders filtered options with the correct height after searching', () => {
+        const groupOptions = [
+          { label: 'Group 1', isGroupLabel: true },
+          { label: 'Option A' },
+          { label: 'Group 2', isGroupLabel: true },
+          { label: 'Option B' },
+          { label: 'Option C' },
+        ];
+
+        cy.realMount(
+          <EuiSelectable searchable options={groupOptions}>
+            {(list, search) => (
+              <>
+                {search}
+                {list}
+              </>
+            )}
+          </EuiSelectable>
+        );
+
+        cy.get('input').realClick().realType('Option');
+
+        cy.get('li[role=option]').should('have.length', 3);
+        cy.get('li[role=option]').eq(0).invoke('outerHeight').should('eq', 32);
+        cy.get('li[role=option]').eq(1).invoke('outerHeight').should('eq', 32);
+        cy.get('li[role=option]').eq(2).invoke('outerHeight').should('eq', 32);
+      });
+    });
   });
 
   describe('without a `searchable` configuration', () => {

--- a/packages/eui/src/components/selectable/selectable.spec.tsx
+++ b/packages/eui/src/components/selectable/selectable.spec.tsx
@@ -230,7 +230,6 @@ describe('EuiSelectable', () => {
 
         cy.get('input').realClick().realType('Option');
 
-        cy.get('li[role=option]').should('have.length', 3);
         cy.get('li[role=option]')
           .should('have.length', 3)
           .then(($options) => {

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list.tsx
@@ -355,6 +355,13 @@ export class EuiSelectableList<T> extends Component<
       prevProps.visibleOptions !== visibleOptions ||
       prevProps.options !== options
     ) {
+      // Invalidate react-window's size cache before setState triggers a re-render
+      // to ensure that heights are re-calculated to prevent stale cached heights.
+      // Applies `shouldForceUpdate=false` to avoid an unnecessary extra render.
+      if (isVirtualized) {
+        this.listRef?.resetAfterIndex(0, false);
+      }
+
       this.setState({
         optionArray,
         itemData: { ...optionArray },


### PR DESCRIPTION
## Summary

- **What:** This PR fixes a bug in `EuiSelectableList` where some options would be rendered with wrong heights after updates for lists with group titles. Any group title elements that are not the first option element have a larger height (to add a separator), which is cached and then wrongly applied to a search result option, resulting in different heights between options.
- **Why:** This was noticed by Cloud-UI in https://github.com/elastic/cloud-ui/issues/3449
- **How:** 
  - adds a call of `this.listRef.resetAfterIndex(0, false)` to flush the `react-window` internal height cache on updates
  - uses `shouldForceUpdate=false` on `resetAfterIndex` to prevent an unnecessary duplicate state update

- The issue was only visible for selectable lists with group titles, and it would only show for options after an update (e.g. due to a search) that would then be placed in the same indexed spot as a previous (non-first element) group title element, which would result in an option being rendered with the cached height of a group title.

### API Changes

⚪ No API changes

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/b7c26069-ad35-4e1d-8bed-74e899a105c4" /> | <video src="https://github.com/user-attachments/assets/e0bda754-889d-4d3c-8670-dd76a979a5b2" /> |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

🧪 To reproduce the issue:
- open the "With Search and Groups" story ([production](https://eui.elastic.co/next/storybook/?path=/story/forms-euiselectable--with-search-and-groups&globals=colorMode:light))
- type "a" into the search
- observe that the last option has a larger height (as it's in the same indexed spot as the second group title)

✅ Verify that...
- all options have the same height when trying to reproduce the issue on this PR ([storybook](https://eui.elastic.co/pr_9770/storybook/?path=/story/forms-euiselectable--with-search-and-groups))
- there are no unexpected regressions with production

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
