### PR TITLE
[Docs] Wrap EuiButtonIcon with tooltips

### DIFF
--- a/packages/docusaurus-theme/changelogs/upcoming/9771.md
+++ b/packages/docusaurus-theme/changelogs/upcoming/9771.md
@@ -1,0 +1,1 @@
+- Wrapped the documentation heading anchor link `EuiButtonIcon` in an `EuiToolTip` instead of using the native `title` attribute

--- a/packages/docusaurus-theme/changelogs/upcoming/9771.md
+++ b/packages/docusaurus-theme/changelogs/upcoming/9771.md
@@ -1,1 +1,2 @@
 - Wrapped the documentation heading anchor link `EuiButtonIcon` in an `EuiToolTip` instead of using the native `title` attribute
+- Wrapped navbar icon links and toggles in `EuiToolTip` instead of using the native `title` attribute

--- a/packages/docusaurus-theme/src/components/demo/actions_bar/actions_bar.tsx
+++ b/packages/docusaurus-theme/src/components/demo/actions_bar/actions_bar.tsx
@@ -61,6 +61,8 @@ export const DemoActionsBar = ({
   onClickCopyToClipboard,
 }: DemoActionsBarProps) => {
   const styles = useEuiMemoizedStyles(getDemoActionsBarStyles);
+  const copyToClipboardLabel = 'Copy to clipboard';
+  const reloadExampleLabel = 'Reload example';
 
   return (
     <EuiFlexGroup alignItems="center" css={styles.actionsBar} gutterSize="s">
@@ -82,22 +84,22 @@ export const DemoActionsBar = ({
           activeSource={activeSource}
         />
       ))}
-      <EuiToolTip content="Copy to clipboard">
+      <EuiToolTip content={copyToClipboardLabel} disableScreenReaderOutput>
         <EuiButtonIcon
           size="s"
           iconType="copy"
           color="text"
           onClick={onClickCopyToClipboard}
-          aria-label="Copy code to clipboard"
+          aria-label={copyToClipboardLabel}
         />
       </EuiToolTip>
-      <EuiToolTip content="Reload example">
+      <EuiToolTip content={reloadExampleLabel} disableScreenReaderOutput>
         <EuiButtonIcon
           size="s"
           iconType="refresh"
           color="text"
           onClick={onClickReloadExample}
-          aria-label="Reload example"
+          aria-label={reloadExampleLabel}
         />
       </EuiToolTip>
     </EuiFlexGroup>

--- a/packages/docusaurus-theme/src/components/demo/codesandbox/open_action.tsx
+++ b/packages/docusaurus-theme/src/components/demo/codesandbox/open_action.tsx
@@ -145,6 +145,8 @@ export const createOpenInCodeSandboxAction =
       } as any);
     }, [activeSource, extraFiles, previewWrapperSource]);
 
+    const openInCodeSandboxLabel = 'Open in CodeSandbox';
+
     return (
       <form
         action="https://codesandbox.io/api/v1/sandboxes/define"
@@ -157,13 +159,13 @@ export const createOpenInCodeSandboxAction =
           name="query"
           value={`module=/demo.tsx&view=split`}
         />
-        <EuiToolTip content="Open in CodeSandbox">
+        <EuiToolTip content={openInCodeSandboxLabel} disableScreenReaderOutput>
           <EuiButtonIcon
             type="submit"
             size="s"
             iconType={CodeSandboxIcon}
             color="text"
-            aria-label="Open in CodeSandbox"
+            aria-label={openInCodeSandboxLabel}
           />
         </EuiToolTip>
       </form>

--- a/packages/docusaurus-theme/src/components/navbar_item/index.tsx
+++ b/packages/docusaurus-theme/src/components/navbar_item/index.tsx
@@ -12,9 +12,9 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 import {
   CommonProps,
   EuiIcon,
+  EuiToolTip,
   ExclusiveUnion,
   IconType,
-  mathWithUnits,
   PropsForAnchor,
   PropsForButton,
   useEuiMemoizedStyles,
@@ -89,6 +89,9 @@ export const getStyles = (euiThemeContext: UseEuiTheme) => {
         display: none;
       }
     `,
+    tooltipAnchor: css`
+      display: inline-flex;
+    `,
   };
 };
 
@@ -124,6 +127,7 @@ export const NavbarItem = (props: Props) => {
     !isBrowser && styles.disabled,
     isSelected && styles.selected,
     isDarkMode && styles.darkMode,
+    css,
   ];
 
   const content = showLabel ? (
@@ -135,36 +139,45 @@ export const NavbarItem = (props: Props) => {
     <EuiIcon type={icon} />
   );
 
-  if (isAnchorClick(onClick, href)) {
-    return (
-      <a
-        href={href}
-        target={target ?? '_blank'}
-        title={title}
-        className={className}
-        css={cssStyles}
-        onClick={onClick}
-        aria-label={title}
-        aria-live="polite"
-      >
-        {content}
-      </a>
-    );
-  }
-
-  return (
+  const control = isAnchorClick(onClick, href) ? (
+    <a
+      href={href}
+      target={target ?? '_blank'}
+      className={className}
+      css={cssStyles}
+      onClick={onClick}
+      aria-label={title}
+      aria-live="polite"
+    >
+      {content}
+    </a>
+  ) : (
     <button
       type="button"
       disabled={!isBrowser}
       className={className}
       css={cssStyles}
       onClick={onClick}
-      title={title}
       aria-label={title}
       aria-live="polite"
       aria-pressed={isSelected != null ? isSelected : undefined}
     >
       {content}
     </button>
+  );
+
+  if (!title) {
+    return control;
+  }
+
+  return (
+    <EuiToolTip
+      content={title}
+      disableScreenReaderOutput
+      repositionOnScroll
+      anchorProps={{ css: styles.tooltipAnchor }}
+    >
+      {control}
+    </EuiToolTip>
   );
 };

--- a/packages/docusaurus-theme/src/theme/Heading/index.tsx
+++ b/packages/docusaurus-theme/src/theme/Heading/index.tsx
@@ -11,6 +11,7 @@ import { Props as HeadingProps } from '@theme/Heading';
 import {
   EuiTitle,
   EuiButtonIcon,
+  EuiToolTip,
   UseEuiTheme,
   EuiTitleProps,
   useEuiMemoizedStyles,
@@ -76,15 +77,16 @@ const Heading = ({
       >
         {children}
         {shouldShowSectionLink && (
-          <EuiButtonIcon
-            css={styles.anchor}
-            href={`#${id}`}
-            aria-label={anchorTitle}
-            title={anchorTitle}
-            iconType="link"
-            color="text"
-            size="xs"
-          />
+          <EuiToolTip content={anchorTitle} disableScreenReaderOutput>
+            <EuiButtonIcon
+              css={styles.anchor}
+              href={`#${id}`}
+              aria-label={anchorTitle}
+              iconType="link"
+              color="text"
+              size="xs"
+            />
+          </EuiToolTip>
         )}
       </Component>
     </EuiTitle>

--- a/packages/website/docs/components/containers/accordion.mdx
+++ b/packages/website/docs/components/containers/accordion.mdx
@@ -593,6 +593,7 @@ import {
   EuiFlexItem,
   EuiTitle,
   EuiButtonIcon,
+  EuiToolTip,
   useEuiTheme,
   useGeneratedHtmlId,
   euiCanAnimate,
@@ -661,25 +662,29 @@ const buttonCss = css`
 const extraAction = () => {
   const { euiTheme } = useEuiTheme();
 
+  const deleteLabel = 'Delete';
+
   return (
-    <EuiButtonIcon
-      aria-label="Delete"
-      iconType="cross"
-      color="danger"
-      css={css`
-        opacity: 0;
+    <EuiToolTip content={deleteLabel} disableScreenReaderOutput>
+      <EuiButtonIcon
+        aria-label={deleteLabel}
+        iconType="cross"
+        color="danger"
+        css={css`
+          opacity: 0;
 
-        &:focus,
-        .euiAccordion:hover & {
-          opacity: 1;
-        }
+          &:focus,
+          .euiAccordion:hover & {
+            opacity: 1;
+          }
 
-        ${euiCanAnimate} {
-          transition: opacity ${euiTheme.animation.normal}
-            ${euiTheme.animation.resistance};
-        }
-      `}
-    />
+          ${euiCanAnimate} {
+            transition: opacity ${euiTheme.animation.normal}
+              ${euiTheme.animation.resistance};
+          }
+        `}
+      />
+    </EuiToolTip>
   );
 };
 

--- a/packages/website/docs/components/containers/resizable-container.mdx
+++ b/packages/website/docs/components/containers/resizable-container.mdx
@@ -832,6 +832,7 @@ For consistency, we recommend the usage of the `menuLeft`, `menuRight`, etc, ico
     EuiSpacer,
     EuiButtonGroup,
     EuiButtonIcon,
+    EuiToolTip,
     EuiFlexGroup,
     EuiFlexItem,
     EuiText,
@@ -891,6 +892,8 @@ For consistency, we recommend the usage of the `menuLeft`, `menuRight`, etc, ico
               direction: 'left' | 'right' = 'left'
             ) => togglePanel?.(id, { direction });
 
+            const togglePanel3Label = 'Toggle panel 3';
+
             return (
               <>
                 <EuiResizablePanel id="panel1" initialSize={30} minSize="10%">
@@ -930,12 +933,14 @@ For consistency, we recommend the usage of the `menuLeft`, `menuRight`, etc, ico
                         </EuiTitle>
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>
-                        <EuiButtonIcon
-                          color="text"
-                          aria-label={'Toggle panel 3'}
-                          iconType="menuRight"
-                          onClick={() => onChange('3')}
-                        />
+                        <EuiToolTip content={togglePanel3Label} disableScreenReaderOutput>
+                          <EuiButtonIcon
+                            color="text"
+                            aria-label={togglePanel3Label}
+                            iconType="menuRight"
+                            onClick={() => onChange('3')}
+                          />
+                        </EuiToolTip>
                       </EuiFlexItem>
                     </EuiFlexGroup>
                     <EuiSpacer />

--- a/packages/website/docs/components/data-grid/advanced/custom-body-rendering/data_columns_cells.tsx
+++ b/packages/website/docs/components/data-grid/advanced/custom-body-rendering/data_columns_cells.tsx
@@ -7,6 +7,7 @@ import {
   EuiCallOut,
   EuiButton,
   EuiButtonIcon,
+  EuiToolTip,
 } from '@elastic/eui';
 import { faker } from '@faker-js/faker';
 
@@ -141,12 +142,17 @@ export const trailingControlColumns: EuiDataGridProps['trailingControlColumns'] 
           <span>Actions</span>
         </EuiScreenReaderOnly>
       ),
-      rowCellRender: () => (
-        <EuiButtonIcon
-          iconType="boxes_vertical"
-          aria-label="See row actions"
-        />
-      ),
+      rowCellRender: () => {
+        const seeRowActionsLabel = 'See row actions';
+        return (
+          <EuiToolTip content={seeRowActionsLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              iconType="boxes_vertical"
+              aria-label={seeRowActionsLabel}
+            />
+          </EuiToolTip>
+        );
+      },
     },
     // The custom row details is actually a trailing control column cell with
     // a hidden header. This is important for accessibility and markup reasons

--- a/packages/website/docs/components/data-grid/cells-and-popovers.mdx
+++ b/packages/website/docs/components/data-grid/cells-and-popovers.mdx
@@ -729,6 +729,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiTextColor,
+  EuiToolTip,
 } from '@elastic/eui';
 import { faker } from '@faker-js/faker';
 
@@ -774,6 +775,8 @@ for (let i = 0; i < 10; i++) {
 }
 
 export default () => {
+  const columnSettingsLabel = 'Column settings';
+
   const columns = [
     {
       id: 'no-interactives not expandable',
@@ -806,11 +809,13 @@ export default () => {
       id: 'one-interactive not expandable',
       display: (
         <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
-          <EuiButtonIcon
-            aria-label="column settings"
-            iconType="gear"
-            onClick={() => {}}
-          />
+          <EuiToolTip content={columnSettingsLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              aria-label={columnSettingsLabel}
+              iconType="gear"
+              onClick={() => {}}
+            />
+          </EuiToolTip>
           <EuiBadge>1 interactive</EuiBadge>
         </EuiFlexGroup>
       ),
@@ -842,16 +847,20 @@ export default () => {
       id: 'two-interactives not expandable',
       display: (
         <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
-          <EuiButtonIcon
-            aria-label="column settings"
-            iconType="gear"
-            onClick={() => {}}
-          />
-          <EuiButtonIcon
-            aria-label="column settings"
-            iconType="gear"
-            onClick={() => {}}
-          />
+          <EuiToolTip content={columnSettingsLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              aria-label={columnSettingsLabel}
+              iconType="gear"
+              onClick={() => {}}
+            />
+          </EuiToolTip>
+          <EuiToolTip content={columnSettingsLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              aria-label={columnSettingsLabel}
+              iconType="gear"
+              onClick={() => {}}
+            />
+          </EuiToolTip>
           <EuiBadge>2 interactive</EuiBadge>
         </EuiFlexGroup>
       ),

--- a/packages/website/docs/components/data-grid/data-grid.mdx
+++ b/packages/website/docs/components/data-grid/data-grid.mdx
@@ -29,6 +29,7 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiButtonIcon,
+  EuiToolTip,
   EuiCode,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -357,6 +358,8 @@ const trailingControlColumns = [
         </EuiContextMenuItem>,
       ];
 
+      const showActionsLabel = 'Show actions';
+
       return (
         <>
           <EuiPopover
@@ -364,12 +367,14 @@ const trailingControlColumns = [
             panelPaddingSize="none"
             anchorPosition="upCenter"
             button={
-              <EuiButtonIcon
-                aria-label="Show actions"
-                iconType="boxesVertical"
-                color="text"
-                onClick={() => setIsPopoverVisible(!isPopoverVisible)}
-              />
+              <EuiToolTip content={showActionsLabel} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  aria-label={showActionsLabel}
+                  iconType="boxesVertical"
+                  color="text"
+                  onClick={() => setIsPopoverVisible(!isPopoverVisible)}
+                />
+              </EuiToolTip>
             }
             closePopover={closePopover}
           >

--- a/packages/website/docs/components/data-grid/schema-and-columns.mdx
+++ b/packages/website/docs/components/data-grid/schema-and-columns.mdx
@@ -503,6 +503,7 @@ import {
   EuiDescriptionListDescription,
   EuiContextMenuItem,
   EuiContextMenuPanel,
+  EuiToolTip,
 } from '@elastic/eui';
 import { faker } from '@faker-js/faker';
 
@@ -688,15 +689,19 @@ const FlyoutRowCell = (rowIndex) => {
     );
   }
 
+  const viewDetailsLabel = 'View details';
+
   return (
     <>
-      <EuiButtonIcon
-        color="text"
-        iconType="eye"
-        iconSize="s"
-        aria-label="View details"
-        onClick={() => setIsFlyoutOpen(!isFlyoutOpen)}
-      />
+      <EuiToolTip content={viewDetailsLabel} disableScreenReaderOutput>
+        <EuiButtonIcon
+          color="text"
+          iconType="eye"
+          iconSize="s"
+          aria-label={viewDetailsLabel}
+          onClick={() => setIsFlyoutOpen(!isFlyoutOpen)}
+        />
+      </EuiToolTip>
       {flyout}
     </>
   );
@@ -724,6 +729,9 @@ const trailingControlColumns = [
     headerCellRender: () => null,
     rowCellRender: function RowCellRender() {
       const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+      const showActionsLabel = 'Show actions';
+      const pinSelectedItemsLabel = 'Pin selected items';
+      const deleteSelectedItemsLabel = 'Delete selected items';
       return (
         <div>
           <EuiPopover
@@ -731,12 +739,14 @@ const trailingControlColumns = [
             anchorPosition="upCenter"
             panelPaddingSize="s"
             button={
-              <EuiButtonIcon
-                aria-label="show actions"
-                iconType="boxesVertical"
-                color="text"
-                onClick={() => setIsPopoverOpen(!isPopoverOpen)}
-              />
+              <EuiToolTip content={showActionsLabel} disableScreenReaderOutput>
+                <EuiButtonIcon
+                  aria-label={showActionsLabel}
+                  iconType="boxesVertical"
+                  color="text"
+                  onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                />
+              </EuiToolTip>
             }
             closePopover={() => setIsPopoverOpen(false)}
           >
@@ -749,11 +759,13 @@ const trailingControlColumns = [
                   gutterSize="s"
                 >
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      aria-label="Pin selected items"
-                      iconType="pin"
-                      color="text"
-                    />
+                    <EuiToolTip content={pinSelectedItemsLabel} disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        aria-label={pinSelectedItemsLabel}
+                        iconType="pin"
+                        color="text"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                   <EuiFlexItem>Pin</EuiFlexItem>
                 </EuiFlexGroup>
@@ -766,11 +778,13 @@ const trailingControlColumns = [
                   gutterSize="s"
                 >
                   <EuiFlexItem grow={false}>
-                    <EuiButtonIcon
-                      aria-label="Delete selected items"
-                      iconType="trash"
-                      color="text"
-                    />
+                    <EuiToolTip content={deleteSelectedItemsLabel} disableScreenReaderOutput>
+                      <EuiButtonIcon
+                        aria-label={deleteSelectedItemsLabel}
+                        iconType="trash"
+                        color="text"
+                      />
+                    </EuiToolTip>
                   </EuiFlexItem>
                   <EuiFlexItem>Delete</EuiFlexItem>
                 </EuiFlexGroup>
@@ -874,6 +888,7 @@ import {
   EuiSwitch,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiToolTip,
 } from '@elastic/eui';
 import { faker } from '@faker-js/faker';
 
@@ -969,9 +984,14 @@ const trailingControlColumns = [
     headerCellRender: () => (
       <span className="euiScreenReaderOnly">Actions</span>
     ),
-    rowCellRender: () => (
-      <EuiButtonIcon aria-label="Show actions" iconType="boxes_vertical" />
-    ),
+    rowCellRender: () => {
+      const showActionsLabel = 'Show actions';
+      return (
+        <EuiToolTip content={showActionsLabel} disableScreenReaderOutput>
+          <EuiButtonIcon aria-label={showActionsLabel} iconType="boxes_vertical" />
+        </EuiToolTip>
+      );
+    },
   },
 ];
 

--- a/packages/website/docs/components/display/comment-list/comment_list_props.tsx
+++ b/packages/website/docs/components/display/comment-list/comment_list_props.tsx
@@ -2,8 +2,8 @@ import React, { ReactNode } from 'react';
 import { css } from '@emotion/react';
 
 import {
-  EuiPanel,
   EuiButtonIcon,
+  EuiToolTip,
   EuiCommentList,
   EuiComment,
   useEuiTheme,
@@ -111,11 +111,13 @@ export const CommentListProps = ({ snippet }: { snippet: ReactNode }) => {
 
               <HighlightedArea>
                 <CircleIndicator name="6" />
-                <EuiButtonIcon
-                  aria-hidden="true"
-                  iconType="boxesVertical"
-                  color="text"
-                />
+                <EuiToolTip content="actions" disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    aria-hidden="true"
+                    iconType="boxesVertical"
+                    color="text"
+                  />
+                </EuiToolTip>
               </HighlightedArea>
             </div>
             <div

--- a/packages/website/docs/components/display/comment-list/index.mdx
+++ b/packages/website/docs/components/display/comment-list/index.mdx
@@ -24,6 +24,7 @@ import {
   EuiBadge,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiToolTip,
 } from '@elastic/eui';
 
 const body = (
@@ -35,13 +36,16 @@ const body = (
   </EuiText>
 );
 
+const customActionLabel = 'Custom action';
+
 const copyAction = (
-  <EuiButtonIcon
-    title="Custom action"
-    aria-label="Custom action"
-    color="text"
-    iconType="copy"
-  />
+  <EuiToolTip content={customActionLabel} disableScreenReaderOutput>
+    <EuiButtonIcon
+      aria-label={customActionLabel}
+      color="text"
+      iconType="copy"
+    />
+  </EuiToolTip>
 );
 
 const complexEvent = (
@@ -157,6 +161,7 @@ import {
   EuiSelect,
   EuiCode,
   EuiCommentEventProps,
+  EuiToolTip,
 } from '@elastic/eui';
 
 const body = (
@@ -168,13 +173,16 @@ const body = (
   </EuiText>
 );
 
+const customActionLabel = 'Custom action';
+
 const copyAction = (
-  <EuiButtonIcon
-    title="Custom action"
-    aria-label="Custom action"
-    color="text"
-    iconType="copy"
-  />
+  <EuiToolTip content={customActionLabel} disableScreenReaderOutput>
+    <EuiButtonIcon
+      aria-label={customActionLabel}
+      color="text"
+      iconType="copy"
+    />
+  </EuiToolTip>
 );
 
 const eventWithMultipleTags = (
@@ -460,16 +468,20 @@ export default () => {
     </EuiFlyout>
   );
 
+  const actionsLabel = 'Actions';
+
   const customActions = (
     <EuiPopover
       button={
-        <EuiButtonIcon
-          aria-label="Actions"
-          iconType="boxes_vertical"
-          size="xs"
-          color="text"
-          onClick={togglePopover}
-        />
+        <EuiToolTip content={actionsLabel} disableScreenReaderOutput>
+          <EuiButtonIcon
+            aria-label={actionsLabel}
+            iconType="boxes_vertical"
+            size="xs"
+            color="text"
+            onClick={togglePopover}
+          />
+        </EuiToolTip>
       }
       isOpen={isPopoverOpen}
       closePopover={togglePopover}
@@ -492,24 +504,26 @@ export default () => {
     </EuiPopover>
   );
 
+  const copyAlertLinkLabel = 'Copy alert link';
+
   const updateActions = [
-    <EuiButtonIcon
-      key="copy-alert"
-      title="Copy alert link"
-      aria-label="Copy alert link"
-      iconType="link"
-      size="xs"
-      color="text"
-    />,
-    <EuiButtonIcon
-      key="show-details"
-      title="Show the alert details in a flyout"
-      aria-label="Show details"
-      iconType="external"
-      size="xs"
-      color="text"
-      onClick={toggleFlyout}
-    />,
+    <EuiToolTip key="copy-alert" content={copyAlertLinkLabel} disableScreenReaderOutput>
+      <EuiButtonIcon
+        aria-label={copyAlertLinkLabel}
+        iconType="link"
+        size="xs"
+        color="text"
+      />
+    </EuiToolTip>,
+    <EuiToolTip key="show-details" content="Show the alert details in a flyout">
+      <EuiButtonIcon
+        aria-label="Show details"
+        iconType="external"
+        size="xs"
+        color="text"
+        onClick={toggleFlyout}
+      />
+    </EuiToolTip>,
   ];
 
   return (
@@ -574,13 +588,16 @@ import {
   EuiAvatar,
 } from '@elastic/eui';
 
+const customActionLabel = 'Custom action';
+
 const actionButton = (
-  <EuiButtonIcon
-    title="Custom action"
-    aria-label="Custom action"
-    color="text"
-    iconType="copy"
-  />
+  <EuiToolTip content={customActionLabel} disableScreenReaderOutput>
+    <EuiButtonIcon
+      aria-label={customActionLabel}
+      color="text"
+      iconType="copy"
+    />
+  </EuiToolTip>
 );
 
 const complexEvent = (

--- a/packages/website/docs/components/display/drag-and-drop.mdx
+++ b/packages/website/docs/components/display/drag-and-drop.mdx
@@ -604,6 +604,7 @@ The EUI `copy` method is available and demonstrated in the example below. Note t
 import React, { useState } from 'react';
 import {
   EuiButtonIcon,
+  EuiToolTip,
   EuiDragDropContext,
   EuiFlexGroup,
   EuiFlexItem,
@@ -683,6 +684,8 @@ export default () => {
     }
   };
 
+  const removeLabel = 'Remove';
+
   return (
     <EuiDragDropContext onDragEnd={onDragEnd} onDragUpdate={onDragUpdate}>
       <EuiFlexGroup>
@@ -718,11 +721,13 @@ export default () => {
                         {isItemRemovable ? (
                           <EuiIcon type="trash" color="danger" />
                         ) : (
-                          <EuiButtonIcon
-                            iconType="cross"
-                            aria-label="Remove"
-                            onClick={() => remove('DROPPABLE_AREA_COPY_2', idx)}
-                          />
+                          <EuiToolTip content={removeLabel} disableScreenReaderOutput>
+                            <EuiButtonIcon
+                              iconType="cross"
+                              aria-label={removeLabel}
+                              onClick={() => remove('DROPPABLE_AREA_COPY_2', idx)}
+                            />
+                          </EuiToolTip>
                         )}
                       </EuiFlexItem>
                     </EuiFlexGroup>
@@ -945,6 +950,7 @@ import {
   EuiDraggable,
   EuiDroppable,
   EuiButtonIcon,
+  EuiToolTip,
   EuiPanel,
   euiDragDropMove,
   euiDragDropReorder,
@@ -1004,6 +1010,8 @@ export default () => {
     }
   };
 
+  const dragHandleLabel = 'Drag Handle';
+
   return (
     <EuiDragDropContext onDragEnd={onDragEnd}>
       <EuiDroppable
@@ -1026,11 +1034,13 @@ export default () => {
           >
             {(provided) => (
               <EuiPanel color="subdued" paddingSize="s">
-                <EuiButtonIcon
-                  iconType="dragVertical"
-                  aria-label="Drag Handle"
-                  {...provided.dragHandleProps}
-                />
+                <EuiToolTip content={dragHandleLabel} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    iconType="dragVertical"
+                    aria-label={dragHandleLabel}
+                    {...provided.dragHandleProps}
+                  />
+                </EuiToolTip>
                 <EuiDroppable
                   droppableId={`COMPLEX_DROPPABLE_AREA_${did}`}
                   type="MICRO"

--- a/packages/website/docs/components/display/tour/index.mdx
+++ b/packages/website/docs/components/display/tour/index.mdx
@@ -162,6 +162,7 @@ import {
   EuiFlexItem,
   EuiPanel,
   EuiButtonIcon,
+  EuiToolTip,
   EuiText,
 } from '@elastic/eui';
 
@@ -291,7 +292,14 @@ export default () => {
                   )
                 }
               >
-                <EuiButtonIcon size="m" iconType={step.iconType} color="text" />
+                <EuiToolTip content={step.title} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    size="m"
+                    iconType={step.iconType}
+                    color="text"
+                    aria-label={step.title}
+                  />
+                </EuiToolTip>
               </EuiTourStep>
             </EuiFlexItem>
           ))}

--- a/packages/website/docs/components/forms/date-and-time/super-date-picker.mdx
+++ b/packages/website/docs/components/forms/date-and-time/super-date-picker.mdx
@@ -638,6 +638,7 @@ import React, { useState } from 'react';
 import {
   EuiButtonEmpty,
   EuiButtonIcon,
+  EuiToolTip,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSearchBar,
@@ -702,6 +703,8 @@ export default () => {
     setRefreshInterval(refreshInterval);
   };
 
+  const savedSearchesLabel = 'Saved searches';
+
   return (
     <>
       <EuiFlexGroup gutterSize="s">
@@ -716,7 +719,9 @@ export default () => {
                 onFocus: () => setShowQuickSelectOnly(true),
                 onBlur: () => setShowQuickSelectOnly(false),
                 prepend: (
-                  <EuiButtonIcon aria-label="Saved searches" iconType="save" />
+                  <EuiToolTip content={savedSearchesLabel} disableScreenReaderOutput>
+                    <EuiButtonIcon aria-label={savedSearchesLabel} iconType="save" />
+                  </EuiToolTip>
                 ),
                 append: <EuiButtonEmpty>KQL</EuiButtonEmpty>,
                 'aria-label': 'Filter using KQL',
@@ -873,6 +878,7 @@ import React, { useState } from "react";
 import {
   EuiSuperDatePicker,
   EuiButtonIcon,
+  EuiToolTip,
   OnTimeChangeProps,
 } from "@elastic/eui";
 
@@ -887,14 +893,18 @@ export default () => {
     setEnd(end);
   };
 
+  const timeZonesDatabaseLabel = 'Time zones database';
+
   const customButton = (
-    <EuiButtonIcon
-      aria-label="Time zones database"
-      href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"
-      target="_blank"
-      rel="noopener noreferrer"
-      iconType="documentation"
-    />
+    <EuiToolTip content={timeZonesDatabaseLabel} disableScreenReaderOutput>
+      <EuiButtonIcon
+        aria-label={timeZonesDatabaseLabel}
+        href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"
+        target="_blank"
+        rel="noopener noreferrer"
+        iconType="documentation"
+      />
+    </EuiToolTip>
   );
 
   return (

--- a/packages/website/docs/components/navigation/buttons/button.mdx
+++ b/packages/website/docs/components/navigation/buttons/button.mdx
@@ -7,7 +7,7 @@ keywords: [EuiButton]
 ---
 
 ```mdx-code-block
-import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiButtonEmpty, EuiButtonIcon, EuiIcon, EuiTable, EuiTableBody, EuiTableHeader, EuiTableHeaderCell, EuiTableRow, EuiTableRowCell } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiButtonEmpty, EuiButtonIcon, EuiIcon, EuiTable, EuiTableBody, EuiTableHeader, EuiTableHeaderCell, EuiTableRow, EuiTableRowCell, EuiToolTip } from '@elastic/eui';
 ```
 
 # Button
@@ -184,6 +184,23 @@ export default () => (
 
 `EuiButtonIcon` is an **icon-only button**. Use `display` and `size` props to match standard buttons. The default appearance is `xs`, `empty`. Use only for common, intuitive actions with **immediately understood icons** (e.g., trash can for delete). `aria-label` is required for accessibility. Icon color inherits from the button's color property. Icon color is inherited from the button color property and, therefore, does not need to be set separately.
 
+Because the button has no visible text, **wrap every `EuiButtonIcon` in an [`EuiToolTip`](../../display/tooltip.mdx)** so sighted users who don't rely on a screen reader can understand its purpose. Don't use the native `title` prop for this - browser-native tooltips are unstyled, have no delay control and are not consistently announced across screen readers/browsers. The `@elastic/eui/tooltip-button-icon-wrap` ESLint rule warns when this is missing.
+
+When the tooltip `content` duplicates the button's accessible label (e.g. it's the same as the button's `aria-label`), set `disableScreenReaderOutput` on the `EuiToolTip` to avoid screen readers announcing the label twice (e.g. "Delete. Delete").
+
+```tsx
+// ✗ Bad - no tooltip for sighted users
+<EuiButtonIcon aria-label="Delete" iconType="trash" color="danger" />
+
+// ✗ Bad - browser-native tooltip
+<EuiButtonIcon title="Delete" aria-label="Delete" iconType="trash" color="danger" />
+
+// ✓ Good
+<EuiToolTip content="Delete" disableScreenReaderOutput>
+  <EuiButtonIcon aria-label="Delete" iconType="trash" color="danger" />
+</EuiToolTip>
+```
+
 ```tsx interactive
 import React, { useState } from 'react';
 
@@ -194,6 +211,7 @@ import {
   EuiSelect,
   EuiSpacer,
   EuiSwitch,
+  EuiToolTip,
 } from '@elastic/eui';
 import { COLORS } from '@elastic/eui/es/components/button/button';
 
@@ -249,6 +267,8 @@ export default () => {
   const onChangeButtonColor = (e) => {
     setButtonColor(e.target.value);
   };
+
+  const openDocumentationLabel = 'Open documentation';
 
   return(
     <>
@@ -307,16 +327,19 @@ export default () => {
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="xl" />
-      <EuiButtonIcon
-        color={buttonColor}
-        display={displayType}
-        size={displaySize}
-        iconSize={iconSize}
-        disabled={disableButton}
-        onClick={() => {}}
-        iconType="documentation"
-        aria-label="Open documentation"
-      />
+      <EuiToolTip content={openDocumentationLabel} disableScreenReaderOutput>
+        <EuiButtonIcon
+          color={buttonColor}
+          display={displayType}
+          size={displaySize}
+          iconSize={iconSize}
+          isDisabled={disableButton}
+          hasAriaDisabled
+          onClick={() => {}}
+          iconType="documentation"
+          aria-label={openDocumentationLabel}
+        />
+      </EuiToolTip>
     </>
   );
 };
@@ -329,29 +352,38 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiToolTip,
 } from '@elastic/eui';
 
 export default () => (
   <EuiFlexGroup responsive={false} gutterSize="s" alignItems="flexStart">
     <EuiFlexItem grow={false}>
-      <EuiButtonIcon display="base" iconType="lensApp" size="m" aria-label="Lens" />
+      <EuiToolTip content="Lens" disableScreenReaderOutput>
+        <EuiButtonIcon display="base" iconType="lensApp" size="m" aria-label="Lens" />
+      </EuiToolTip>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiButtonIcon display="base" iconType="warning" size="s" color="warning" aria-label="Warning" />
+      <EuiToolTip content="Warning" disableScreenReaderOutput>
+        <EuiButtonIcon display="base" iconType="warning" size="s" color="warning" aria-label="Warning" />
+      </EuiToolTip>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        iconType="dashboardApp"
-        aria-label="Dashboard"
-        color="text"
-      />
+      <EuiToolTip content="Dashboard" disableScreenReaderOutput>
+        <EuiButtonIcon
+          iconType="dashboardApp"
+          aria-label="Dashboard"
+          color="text"
+        />
+      </EuiToolTip>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiButtonIcon
-        iconType="trash"
-        aria-label="Delete"
-        color="danger"
-      />
+      <EuiToolTip content="Delete" disableScreenReaderOutput>
+        <EuiButtonIcon
+          iconType="trash"
+          aria-label="Delete"
+          color="danger"
+        />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
 );
@@ -363,7 +395,12 @@ export default () => (
 
 <EuiFlexGroup gutterSize="m">
   <Guideline type="do" text="Use icon buttons for universal actions that are easy to understand.">
-    <EuiButtonIcon size="m" iconType="pencil" aria-label="Edit" />&nbsp;&nbsp;<EuiButtonIcon size="m" iconType="maximize" aria-label="Expand" />
+    <EuiToolTip content="Edit" disableScreenReaderOutput>
+      <EuiButtonIcon size="m" iconType="pencil" aria-label="Edit" />
+    </EuiToolTip>
+    <EuiToolTip content="Expand" disableScreenReaderOutput>
+      <EuiButtonIcon size="m" iconType="maximize" aria-label="Expand" />
+    </EuiToolTip>
   </Guideline>
   <Guideline type="dont" text="Icons alone in a standard button look awkward and take too much space.">
     <EuiButton><EuiIcon type="pencil" aria-label="Edit" /></EuiButton>&nbsp;&nbsp;<EuiButton><EuiIcon type="maximize" aria-label="Expand" /></EuiButton>
@@ -461,6 +498,7 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiToolTip,
 } from '@elastic/eui';
 
 export default () => (
@@ -469,7 +507,9 @@ export default () => (
       <EuiButton color="text">Text color button</EuiButton>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
-      <EuiButtonIcon color="text" display="base" iconType="pencil" size="m" aria-label="Edit" />
+      <EuiToolTip content="Edit" disableScreenReaderOutput>
+        <EuiButtonIcon color="text" display="base" iconType="pencil" size="m" aria-label="Edit" />
+      </EuiToolTip>
     </EuiFlexItem>
   </EuiFlexGroup>
 );
@@ -489,7 +529,9 @@ Extra small applies only to `EuiButtonEmpty` and `EuiButtonIcon`.
         <EuiButton size="m">Button</EuiButton>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon iconType="gear" color="primary" size="m" aria-label="Settings"/>
+        <EuiToolTip content="Settings" disableScreenReaderOutput>
+          <EuiButtonIcon iconType="gear" color="primary" size="m" aria-label="Settings" />
+        </EuiToolTip>
       </EuiFlexItem>
     </EuiFlexGroup>
   </Guideline>
@@ -499,7 +541,9 @@ Extra small applies only to `EuiButtonEmpty` and `EuiButtonIcon`.
         <EuiButton size="m">Button</EuiButton>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiButtonIcon iconType="trash" color="danger" size="xs" aria-label="Delete"/>
+        <EuiToolTip content="Delete" disableScreenReaderOutput>
+          <EuiButtonIcon iconType="trash" color="danger" size="xs" aria-label="Delete" />
+        </EuiToolTip>
       </EuiFlexItem>
     </EuiFlexGroup>
   </Guideline>
@@ -942,11 +986,13 @@ If the button's **readable text** (children or `aria-label`) changes when toggli
 ```tsx interactive
 import React, { useState } from 'react';
 
-import { EuiButton, EuiButtonIcon } from '@elastic/eui';
+import { EuiButton, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 
 export default () => {
   const [toggle0On, setToggle0On] = useState(false);
   const [toggle1On, setToggle1On] = useState(true);
+
+  const playPauseLabel = toggle1On ? 'Play' : 'Pause';
 
   return (
     <>
@@ -958,15 +1004,16 @@ export default () => {
         {toggle0On ? 'Toggled' : 'Toggle me'}
       </EuiButton>
       &emsp;
-      <EuiButtonIcon
-        size="s"
-        title={toggle1On ? 'Play' : 'Pause'}
-        aria-label={toggle1On ? 'Play' : 'Pause'}
-        iconType={toggle1On ? 'play' : 'pause'}
-        onClick={() => {
-          setToggle1On((isOn) => !isOn);
-        }}
-      />
+      <EuiToolTip content={playPauseLabel} disableScreenReaderOutput>
+        <EuiButtonIcon
+          size="s"
+          aria-label={playPauseLabel}
+          iconType={toggle1On ? 'play' : 'pause'}
+          onClick={() => {
+            setToggle1On((isOn) => !isOn);
+          }}
+        />
+      </EuiToolTip>
     </>
   );
 };
@@ -976,11 +1023,13 @@ If only the **visual appearance** changes, add `aria-pressed` with a boolean for
 
 ```tsx interactive
 import React, { useState } from 'react';
-import { EuiButton, EuiButtonIcon } from '@elastic/eui';
+import { EuiButton, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 
 export default () => {
   const [toggle2On, setToggle2On] = useState(true);
   const [toggle3On, setToggle3On] = useState(false);
+
+  const autosaveLabel = 'Autosave';
 
   return (
     <>
@@ -995,18 +1044,19 @@ export default () => {
         Toggle me
       </EuiButton>
       &emsp;
-      <EuiButtonIcon
-        display={toggle3On ? 'base' : 'empty'}
-        size="m"
-        aria-label="Autosave"
-        title="Autosave"
-        iconType="save"
-        aria-pressed={toggle3On}
-        color={toggle3On ? 'success' : 'text'}
-        onClick={() => {
-          setToggle3On((isOn) => !isOn);
-        }}
-      />
+      <EuiToolTip content={autosaveLabel} disableScreenReaderOutput>
+        <EuiButtonIcon
+          display={toggle3On ? 'base' : 'empty'}
+          size="m"
+          aria-label={autosaveLabel}
+          iconType="save"
+          aria-pressed={toggle3On}
+          color={toggle3On ? 'success' : 'text'}
+          onClick={() => {
+            setToggle3On((isOn) => !isOn);
+          }}
+        />
+      </EuiToolTip>
     </>
   );
 };

--- a/packages/website/docs/components/navigation/collapsible-nav.mdx
+++ b/packages/website/docs/components/navigation/collapsible-nav.mdx
@@ -169,6 +169,7 @@ import {
   EuiSpacer,
   EuiButton,
   EuiButtonIcon,
+  EuiToolTip,
   EuiLink,
 } from '@elastic/eui';
 
@@ -227,6 +228,8 @@ const DeploymentsGroup = (
   </EuiCollapsibleNavGroup>
 );
 
+const hideAndNeverShowAgainLabel = 'Hide and never show again';
+
 const SecurityGroup = (
   <EuiCollapsibleNavGroup
     background="light"
@@ -236,11 +239,12 @@ const SecurityGroup = (
     initialIsOpen={true}
     arrowDisplay="none"
     extraAction={
-      <EuiButtonIcon
-        aria-label="Hide and never show again"
-        title="Hide and never show again"
-        iconType="cross"
-      />
+      <EuiToolTip content={hideAndNeverShowAgainLabel} disableScreenReaderOutput>
+        <EuiButtonIcon
+          aria-label={hideAndNeverShowAgainLabel}
+          iconType="cross"
+        />
+      </EuiToolTip>
     }
   >
     <EuiText size="s" color="subdued" style={{ padding: '0 8px 8px' }}>

--- a/packages/website/docs/components/tables/basic.mdx
+++ b/packages/website/docs/components/tables/basic.mdx
@@ -507,6 +507,7 @@ import {
   EuiTableSortingType,
   Criteria,
   EuiButtonIcon,
+  EuiToolTip,
   EuiHealth,
   EuiDescriptionList,
   EuiScreenReaderOnly,
@@ -648,17 +649,20 @@ export default () => {
       mobileOptions: { header: false },
       render: (user: User) => {
         const itemIdToExpandedRowMapValues = { ...itemIdToExpandedRowMap };
+        const expandCollapseLabel = itemIdToExpandedRowMapValues[user.id]
+          ? 'Collapse'
+          : 'Expand';
 
         return (
-          <EuiButtonIcon
-            onClick={() => toggleDetails(user)}
-            aria-label={
-              itemIdToExpandedRowMapValues[user.id] ? 'Collapse' : 'Expand'
-            }
-            iconType={
-              itemIdToExpandedRowMapValues[user.id] ? 'arrowDown' : 'arrowRight'
-            }
-          />
+          <EuiToolTip content={expandCollapseLabel} disableScreenReaderOutput>
+            <EuiButtonIcon
+              onClick={() => toggleDetails(user)}
+              aria-label={expandCollapseLabel}
+              iconType={
+                itemIdToExpandedRowMapValues[user.id] ? 'arrowDown' : 'arrowRight'
+              }
+            />
+          </EuiToolTip>
         );
       },
     },

--- a/packages/website/docs/components/tables/custom.mdx
+++ b/packages/website/docs/components/tables/custom.mdx
@@ -32,6 +32,7 @@ import {
   EuiHealth,
   EuiButton,
   EuiButtonIcon,
+  EuiToolTip,
   EuiCheckbox,
   EuiContextMenuItem,
   EuiContextMenuPanel,
@@ -603,6 +604,7 @@ export default class extends Component<{}, State> {
         }
 
         if (column.isActionsPopover) {
+          const actionsLabel = 'Actions';
           return (
             <EuiTableRowCell
               key={column.id}
@@ -614,13 +616,15 @@ export default class extends Component<{}, State> {
               <EuiPopover
                 id={`${item.id}-actions`}
                 button={
-                  <EuiButtonIcon
-                    aria-label="Actions"
-                    iconType="gear"
-                    size="s"
-                    color="text"
-                    onClick={() => this.togglePopover(item.id)}
-                  />
+                  <EuiToolTip content={actionsLabel} disableScreenReaderOutput>
+                    <EuiButtonIcon
+                      aria-label={actionsLabel}
+                      iconType="gear"
+                      size="s"
+                      color="text"
+                      onClick={() => this.togglePopover(item.id)}
+                    />
+                  </EuiToolTip>
                 }
                 isOpen={this.isPopoverOpen(item.id)}
                 closePopover={() => this.closePopover(item.id)}

--- a/packages/website/docs/patterns/nested-drag-and-drop/example.tsx
+++ b/packages/website/docs/patterns/nested-drag-and-drop/example.tsx
@@ -21,6 +21,7 @@ import {
 import {
   EuiAccordion,
   EuiButtonIcon,
+  EuiToolTip,
   EuiContextMenu,
   EuiIcon,
   EuiPanel,
@@ -544,6 +545,8 @@ const DraggablePanel = memo(function DraggablePanel({
     width: ${euiTheme.size.l};
   `;
 
+  const moreActionsLabel = 'More actions';
+
   return (
     <li css={wrapperStyles}>
       {instruction?.operation === 'reorder-before' && (
@@ -577,11 +580,13 @@ const DraggablePanel = memo(function DraggablePanel({
               isOpen={isPopoverOpen}
               closePopover={() => setIsPopoverOpen(false)}
               button={
-                <EuiButtonIcon
-                  aria-label="More actions"
-                  iconType="boxesVertical"
-                  onClick={() => setIsPopoverOpen((isOpen) => !isOpen)}
-                />
+                <EuiToolTip content={moreActionsLabel} disableScreenReaderOutput>
+                  <EuiButtonIcon
+                    aria-label={moreActionsLabel}
+                    iconType="boxesVertical"
+                    onClick={() => setIsPopoverOpen((isOpen) => !isOpen)}
+                  />
+                </EuiToolTip>
               }
             >
               <EuiContextMenu

--- a/packages/website/docs/utilities/portal.mdx
+++ b/packages/website/docs/utilities/portal.mdx
@@ -119,6 +119,7 @@ import {
   EuiTitle,
   EuiOverlayMask,
   EuiButtonIcon,
+  EuiToolTip,
   EuiText,
   EuiTextColor,
   EuiEmptyPrompt,
@@ -169,6 +170,7 @@ export default () => {
   let customFlyout;
 
   if (isCustomFlyoutVisible) {
+    const closeModalLabel = 'Close modal';
     customFlyout = (
       <EuiPortal>
         <EuiOverlayMask>
@@ -209,18 +211,20 @@ export default () => {
                   <EuiTitle size="m">
                     <h2 id={customFlyoutTitleId}>Let&apos;s get started!</h2>
                   </EuiTitle>
-                  <EuiButtonIcon
-                    iconType="cross"
-                    aria-label="Close modal"
-                    onClick={closeCustomFlyout}
-                    onKeyDown={onKeyDown}
-                    color="text"
-                    css={css`
-                      position: absolute;
-                      inset-block-start: ${euiTheme.size.base};
-                      inset-inline-end: ${euiTheme.size.base};
-                    `}
-                  />
+                  <EuiToolTip content={closeModalLabel} disableScreenReaderOutput>
+                    <EuiButtonIcon
+                      iconType="cross"
+                      aria-label={closeModalLabel}
+                      onClick={closeCustomFlyout}
+                      onKeyDown={onKeyDown}
+                      color="text"
+                      css={css`
+                        position: absolute;
+                        inset-block-start: ${euiTheme.size.base};
+                        inset-inline-end: ${euiTheme.size.base};
+                      `}
+                    />
+                  </EuiToolTip>
                   <EuiHorizontalRule />
                 </div>
                 {/* Flyout Body */}

--- a/packages/website/docs/utilities/portal.mdx
+++ b/packages/website/docs/utilities/portal.mdx
@@ -211,20 +211,27 @@ export default () => {
                   <EuiTitle size="m">
                     <h2 id={customFlyoutTitleId}>Let&apos;s get started!</h2>
                   </EuiTitle>
-                  <EuiToolTip content={closeModalLabel} disableScreenReaderOutput>
-                    <EuiButtonIcon
-                      iconType="cross"
-                      aria-label={closeModalLabel}
-                      onClick={closeCustomFlyout}
-                      onKeyDown={onKeyDown}
-                      color="text"
-                      css={css`
-                        position: absolute;
-                        inset-block-start: ${euiTheme.size.base};
-                        inset-inline-end: ${euiTheme.size.base};
-                      `}
-                    />
-                  </EuiToolTip>
+                  <div
+                    css={css`
+                      position: absolute;
+                      inset-block-start: ${euiTheme.size.base};
+                      inset-inline-end: ${euiTheme.size.base};
+                    `}
+                  >
+                    <EuiToolTip
+                      content={closeModalLabel}
+                      disableScreenReaderOutput
+                      repositionOnScroll
+                    >
+                      <EuiButtonIcon
+                        iconType="cross"
+                        aria-label={closeModalLabel}
+                        onClick={closeCustomFlyout}
+                        onKeyDown={onKeyDown}
+                        color="text"
+                      />
+                    </EuiToolTip>
+                  </div>
                   <EuiHorizontalRule />
                 </div>
                 {/* Flyout Body */}


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

@JasonStoltz raised a point about our button docs contradicting our guidelines: `EuiButtonIcon` were not wrapped with `EuiToolTip`. So this simply addresses that.

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->

| Before         | After         |
| -------------- | ------------- |
| No tooltip when hovering <img width="840" height="606" alt="Screenshot 2026-06-30 at 13 55 36" src="https://github.com/user-attachments/assets/bb2f37c3-0d8e-45f7-82a8-4e44cbc48763" /> | <img width="877" height="1100" alt="Screenshot 2026-06-30 at 13 54 58" src="https://github.com/user-attachments/assets/b14a8588-e451-48be-a5d1-6e9c6fc256f3" /> |

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Ensure that:

- [x] the examples render correctly
- [ ] the examples work in Codesandbox
- [ ] all `EuiButtonIcon` are wrapped with a tooltip

#### Site-wide (`docusaurus-theme` - check on any page)

- [x] **[Heading anchor link](https://eui.elastic.co/pr_9771/docs/components/navigation/buttons/button)** - hover any heading; the link icon shows a tooltip
- [x] **[Demo action bar](https://eui.elastic.co/pr_9771/docs/components/navigation/buttons/button)** on any interactive example - hover **Copy to clipboard** and **Reload example** buttons (tooltips present, `disableScreenReaderOutput`)
- [x] **"Open in CodeSandbox"** button on any demo - tooltip present

#### Specific pages

- [x] **[Button](https://eui.elastic.co/pr_9771/docs/components/navigation/buttons/button)** - guideline examples, icon-button showcase, config demo ("Open documentation"), toggle demos ("Play"/"Pause", "Autosave")
- [x] **[Comment list](https://eui.elastic.co/pr_9771/docs/components/display/comment-list)** - custom action, popover ("Actions"), "Copy alert link" (flag) vs "Show details" (no flag)
- [x] **[Data grid](https://eui.elastic.co/pr_9771/docs/components/data-grid/)** - "Show actions" popover trigger
- [x] **[Data grid - cells & popovers](https://eui.elastic.co/pr_9771/docs/components/data-grid/cells-and-popovers)** - "column settings" (x3)
- [x] **[Data grid - schema & columns](https://eui.elastic.co/pr_9771/docs/components/data-grid/schema-and-columns)** - "View details", "show actions", "Pin/Delete selected items", "Show actions"
- [x] **[Data grid - custom body rendering](https://eui.elastic.co/pr_9771/docs/components/data-grid/advanced/custom-body-rendering)** - "See row actions"
- [x] **[Tables - basic](https://eui.elastic.co/pr_9771/docs/components/tables/basic)** - row expand/collapse ("Expand"/"Collapse")
- [x] **[Tables - custom](https://eui.elastic.co/pr_9771/docs/components/tables/custom)** - "Actions" popover trigger
- [x] **[Accordion](https://eui.elastic.co/pr_9771/docs/components/containers/accordion)** - "Delete" extra action
- [x] **[Resizable container](https://eui.elastic.co/pr_9771/docs/components/containers/resizable-container)** - "Toggle panel 3"
- [x] **[Collapsible nav](https://eui.elastic.co/pr_9771/docs/components/navigation/collapsible-nav)** - "Hide and never show again"
- [x] **[Drag and drop](https://eui.elastic.co/pr_9771/docs/components/display/drag-and-drop)** - "Remove" and "Drag Handle"
- [x] **[Super date picker](https://eui.elastic.co/pr_9771/docs/components/forms/date-and-time/super-date-picker)** - "Saved searches" prepend, "Time zones database" button
- [x] **[Portal](https://eui.elastic.co/pr_9771/docs/utilities/portal)** - "Close modal"
- [x] **[Pattern: nested drag and drop](https://eui.elastic.co/pr_9771/docs/patterns/nested-drag-and-drop)** - "More actions" popover trigger