### PR TITLE
feat(search_bar): Add isInvalidTooltipDisabled prop to opt-out of error tooltip

### DIFF
--- a/packages/eui/changelogs/upcoming/9754.md
+++ b/packages/eui/changelogs/upcoming/9754.md
@@ -1,0 +1,1 @@
+- Added `isInvalidTooltipDisabled` to `EuiSearchBar` to allow consumers to opt-out of the built-in parse-error tooltip (#9754)

--- a/packages/eui/changelogs/upcoming/9754.md
+++ b/packages/eui/changelogs/upcoming/9754.md
@@ -1,1 +1,0 @@
-- Added `isInvalidTooltipDisabled` to `EuiSearchBar` to allow consumers to opt-out of the built-in parse-error tooltip (#9754)

--- a/packages/eui/changelogs/upcoming/9773.md
+++ b/packages/eui/changelogs/upcoming/9773.md
@@ -1,0 +1,1 @@
+- Added `showErrorTooltip` (defaulting to `true`) to `EuiSearchBar` to allow consumers to opt-out of the built-in parse-error tooltip

--- a/packages/eui/src/components/search_bar/search_bar.test.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.test.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState } from 'react';
 import { fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { render, renderHook } from '../../test/rtl';
 import { requiredProps } from '../../test';
@@ -264,20 +265,40 @@ describe('SearchBar', () => {
     });
   });
   describe('error tooltip', () => {
-    test('does not render an error tooltip when isInvalidTooltipDisabled is true', () => {
+    test('renders an error tooltip by default on parse error', async () => {
+      const { getByTestSubject, container } = render(
+        <EuiSearchBar box={{ 'data-test-subj': 'searchbar' }} />
+      );
+
+      await userEvent.type(
+        getByTestSubject('searchbar'),
+        'tag:value OR{enter}'
+      );
+
+      expect(getByTestSubject('searchbar')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+      expect(container.querySelector('.euiToolTipAnchor')).toBeInTheDocument();
+    });
+
+    test('does not render an error tooltip when showErrorTooltip is false', async () => {
       const { getByTestSubject, container } = render(
         <EuiSearchBar
           box={{ 'data-test-subj': 'searchbar' }}
-          isInvalidTooltipDisabled={true}
+          showErrorTooltip={false}
         />
       );
 
-      // Trigger a search with a syntax error to set the internal error state
-      fireEvent.keyUp(getByTestSubject('searchbar'), {
-        key: keys.ENTER,
-        target: { value: 'tag:value OR' },
-      });
+      await userEvent.type(
+        getByTestSubject('searchbar'),
+        'tag:value OR{enter}'
+      );
 
+      expect(getByTestSubject('searchbar')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
       expect(container.querySelector('.euiToolTipAnchor')).toBeNull();
     });
   });

--- a/packages/eui/src/components/search_bar/search_bar.test.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.test.tsx
@@ -266,40 +266,46 @@ describe('SearchBar', () => {
   });
   describe('error tooltip', () => {
     test('renders an error tooltip by default on parse error', () => {
-      const { getByTestSubject, container } = render(
+      const { getByTestSubject, queryByRole } = render(
         <EuiSearchBar box={{ 'data-test-subj': 'searchbar' }} />
       );
 
-      userEvent.type(
-        getByTestSubject('searchbar'),
-        'tag:value OR{enter}'
-      );
+      act(() => {
+        userEvent.type(getByTestSubject('searchbar'), 'tag:value OR{enter}');
+      });
 
       expect(getByTestSubject('searchbar')).toHaveAttribute(
         'aria-invalid',
         'true'
       );
-      expect(container.querySelector('.euiToolTipAnchor')).toBeInTheDocument();
+
+      // The tooltip only renders its content on hover/focus-visible, so
+      // trigger a hover to confirm the error tooltip is present
+      fireEvent.mouseOver(getByTestSubject('searchbar'));
+
+      expect(queryByRole('tooltip')).toBeInTheDocument();
     });
 
     test('does not render an error tooltip when showErrorTooltip is false', () => {
-      const { getByTestSubject, container } = render(
+      const { getByTestSubject, queryByRole } = render(
         <EuiSearchBar
           box={{ 'data-test-subj': 'searchbar' }}
           showErrorTooltip={false}
         />
       );
 
-      userEvent.type(
-        getByTestSubject('searchbar'),
-        'tag:value OR{enter}'
-      );
+      act(() => {
+        userEvent.type(getByTestSubject('searchbar'), 'tag:value OR{enter}');
+      });
 
       expect(getByTestSubject('searchbar')).toHaveAttribute(
         'aria-invalid',
         'true'
       );
-      expect(container.querySelector('.euiToolTipAnchor')).toBeNull();
+
+      fireEvent.mouseOver(getByTestSubject('searchbar'));
+
+      expect(queryByRole('tooltip')).toBeNull();
     });
   });
 });

--- a/packages/eui/src/components/search_bar/search_bar.test.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.test.tsx
@@ -265,12 +265,12 @@ describe('SearchBar', () => {
     });
   });
   describe('error tooltip', () => {
-    test('renders an error tooltip by default on parse error', async () => {
+    test('renders an error tooltip by default on parse error', () => {
       const { getByTestSubject, container } = render(
         <EuiSearchBar box={{ 'data-test-subj': 'searchbar' }} />
       );
 
-      await userEvent.type(
+      userEvent.type(
         getByTestSubject('searchbar'),
         'tag:value OR{enter}'
       );
@@ -282,7 +282,7 @@ describe('SearchBar', () => {
       expect(container.querySelector('.euiToolTipAnchor')).toBeInTheDocument();
     });
 
-    test('does not render an error tooltip when showErrorTooltip is false', async () => {
+    test('does not render an error tooltip when showErrorTooltip is false', () => {
       const { getByTestSubject, container } = render(
         <EuiSearchBar
           box={{ 'data-test-subj': 'searchbar' }}
@@ -290,7 +290,7 @@ describe('SearchBar', () => {
         />
       );
 
-      await userEvent.type(
+      userEvent.type(
         getByTestSubject('searchbar'),
         'tag:value OR{enter}'
       );

--- a/packages/eui/src/components/search_bar/search_bar.test.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.test.tsx
@@ -281,7 +281,9 @@ describe('SearchBar', () => {
 
       // The tooltip only renders its content on hover/focus-visible, so
       // trigger a hover to confirm the error tooltip is present
-      fireEvent.mouseOver(getByTestSubject('searchbar'));
+      act(() => {
+        userEvent.hover(getByTestSubject('searchbar'));
+      });
 
       expect(queryByRole('tooltip')).toBeInTheDocument();
     });
@@ -303,7 +305,9 @@ describe('SearchBar', () => {
         'true'
       );
 
-      fireEvent.mouseOver(getByTestSubject('searchbar'));
+      act(() => {
+        userEvent.hover(getByTestSubject('searchbar'));
+      });
 
       expect(queryByRole('tooltip')).toBeNull();
     });

--- a/packages/eui/src/components/search_bar/search_bar.test.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.test.tsx
@@ -263,4 +263,22 @@ describe('SearchBar', () => {
       expect(queryByTestSubject('myHint')).toHaveTextContent('Hello from hint');
     });
   });
+  describe('error tooltip', () => {
+    test('does not render an error tooltip when isInvalidTooltipDisabled is true', () => {
+      const { getByTestSubject, container } = render(
+        <EuiSearchBar
+          box={{ 'data-test-subj': 'searchbar' }}
+          isInvalidTooltipDisabled={true}
+        />
+      );
+
+      // Trigger a search with a syntax error to set the internal error state
+      fireEvent.keyUp(getByTestSubject('searchbar'), {
+        key: keys.ENTER,
+        target: { value: 'tag:value OR' },
+      });
+
+      expect(container.querySelector('.euiToolTipAnchor')).toBeNull();
+    });
+  });
 });

--- a/packages/eui/src/components/search_bar/search_bar.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.tsx
@@ -139,10 +139,10 @@ export interface EuiSearchBarProps extends CommonProps {
   compressed?: boolean;
 
   /**
-   * Disables the built-in tooltip that appears when an invalid query is typed.
-   * Useful when consumers render their own custom error UI.
+   * Shows a built-in tooltip when an invalid query is typed.
+   * If set to `false`, consumers should provide an alternative way to surface and announce parse errors.
    */
-  isInvalidTooltipDisabled?: boolean;
+  showErrorTooltip?: boolean;
 }
 
 const parseQuery = (
@@ -221,7 +221,7 @@ export const EuiSearchBar = (props: EuiSearchBarProps) => {
     toolsRight,
     hint,
     compressed,
-    isInvalidTooltipDisabled = false,
+    showErrorTooltip = true,
   } = props;
 
   const theme = useEuiTheme();
@@ -327,12 +327,12 @@ export const EuiSearchBar = (props: EuiSearchBarProps) => {
         css={euiSearchBar__searchHolder(theme)}
         grow={true}
       >
-        {isInvalidTooltipDisabled ? (
-          searchBox
-        ) : (
+        {showErrorTooltip ? (
           <EuiToolTip content={error?.message} display="block">
             {searchBox}
           </EuiToolTip>
+        ) : (
+          searchBox
         )}
       </EuiFlexItem>
       {filters && (

--- a/packages/eui/src/components/search_bar/search_bar.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.tsx
@@ -137,6 +137,12 @@ export interface EuiSearchBarProps extends CommonProps {
    * When `true`, creates a shorter height search bar and filters
    */
   compressed?: boolean;
+
+  /**
+   * Disables the built-in tooltip that appears when an invalid query is typed.
+   * Useful when consumers render their own custom error UI.
+   */
+  isInvalidTooltipDisabled?: boolean;
 }
 
 const parseQuery = (
@@ -215,6 +221,7 @@ export const EuiSearchBar = (props: EuiSearchBarProps) => {
     toolsRight,
     hint,
     compressed,
+    isInvalidTooltipDisabled = false,
   } = props;
 
   const theme = useEuiTheme();
@@ -320,9 +327,13 @@ export const EuiSearchBar = (props: EuiSearchBarProps) => {
         css={euiSearchBar__searchHolder(theme)}
         grow={true}
       >
-        <EuiToolTip content={error?.message} display="block">
-          {searchBox}
-        </EuiToolTip>
+        {isInvalidTooltipDisabled ? (
+          searchBox
+        ) : (
+          <EuiToolTip content={error?.message} display="block">
+            {searchBox}
+          </EuiToolTip>
+        )}
       </EuiFlexItem>
       {filters && (
         <EuiFlexItem

--- a/packages/eui/src/components/search_bar/search_bar.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.tsx
@@ -215,7 +215,9 @@ function notifyControllingParent(
 
 export const EuiSearchBar = (props: EuiSearchBarProps) => {
   const {
-    box: { schema, ...box } = { schema: '' }, // strip `schema` out to prevent passing it to EuiSearchBox
+    box: { schema, 'aria-describedby': boxAriaDescribedBy, ...box } = {
+      schema: '',
+    }, // strip `schema` out to prevent passing it to EuiSearchBox
     filters,
     toolsLeft,
     toolsRight,
@@ -296,6 +298,13 @@ export const EuiSearchBar = (props: EuiSearchBarProps) => {
   const toolsLeftEl = renderTools(toolsLeft);
   const toolsRightEl = renderTools(toolsRight);
 
+  const describedByIds = [
+    boxAriaDescribedBy,
+    isHintVisible ? hintId : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   const searchBox = (
     <EuiSearchBox
       compressed={compressed}
@@ -303,7 +312,7 @@ export const EuiSearchBar = (props: EuiSearchBarProps) => {
       query={queryText}
       onSearch={onSearch}
       isInvalid={error != null}
-      aria-describedby={isHintVisible ? `${hintId}` : undefined}
+      aria-describedby={describedByIds || undefined}
       hint={
         hint
           ? {

--- a/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
@@ -394,7 +394,9 @@ By default, an **EuiSearchBar** displays a built-in tooltip when an invalid quer
 
 If you prefer to provide your own error UI, you can use the `showErrorTooltip={false}` prop to hide the built-in tooltip.
 
-**Important:** If you choose to hide the built-in tooltip, you *must* ensure that screen readers can still announce the validation error. Wrapping the search bar in an **EuiFormRow** does not do this automatically &mdash; **EuiSearchBar** is not a form control itself, so **EuiFormRow** cannot clone its `aria-describedby`/`id` props onto the underlying search input. Instead, pass `aria-describedby` directly via the `box` prop, pointing at the `id` of your own error message, as shown below.
+:::accessibility Use `aria-describedby` with `showErrorTooltip={false}`
+If you choose to hide the built-in tooltip, you *must* ensure that screen readers can still announce the validation error. Wrapping the search bar in an **EuiFormRow** does not do this automatically because **EuiSearchBar** is not a form control itself. Instead, pass `aria-describedby` directly via the `box` prop, pointing at the `id` of your own error message, as shown below.
+:::
 
 ```tsx interactive
 import React, { useState } from 'react';

--- a/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
@@ -392,43 +392,45 @@ export default () => {
 
 By default, an **EuiSearchBar** displays a built-in tooltip when an invalid query is typed. This tooltip informs sighted users (if no other error UI is provided by the consumer) as well as screen reader users.
 
-If you prefer to provide your own error UI (for instance, by wrapping the search bar in an **EuiFormRow**), you can use the `showErrorTooltip={false}` prop to hide the built-in tooltip. 
+If you prefer to provide your own error UI, you can use the `showErrorTooltip={false}` prop to hide the built-in tooltip.
 
-**Important:** If you choose to hide the built-in tooltip, you *must* ensure that screen readers can still announce the validation error using an alternative method, such as the **EuiFormRow** example below.
+**Important:** If you choose to hide the built-in tooltip, you *must* ensure that screen readers can still announce the validation error. Wrapping the search bar in an **EuiFormRow** does not do this automatically &mdash; **EuiSearchBar** is not a form control itself, so **EuiFormRow** cannot clone its `aria-describedby`/`id` props onto the underlying search input. Instead, pass `aria-describedby` directly via the `box` prop, pointing at the `id` of your own error message, as shown below.
 
 ```tsx interactive
 import React, { useState } from 'react';
-import { EuiSearchBar, EuiFormRow } from '@elastic/eui';
+import { EuiSearchBar, EuiCallOut, EuiSpacer, useGeneratedHtmlId } from '@elastic/eui';
 
 export default () => {
   const [error, setError] = useState(null);
+  const errorId = useGeneratedHtmlId();
 
   const onChange = ({ error }) => {
     setError(error);
   };
 
-  const schema = {
-    strict: true,
-    fields: {
-      status: { type: 'string' }
-    }
-  };
-
   return (
-    <EuiFormRow 
-      error={error ? `Invalid search: ${error.message}` : null} 
-      isInvalid={!!error}
-      fullWidth
-    >
+    <>
       <EuiSearchBar
         box={{
-          schema,
-          placeholder: 'Type an invalid query like "status: "',
+          placeholder: 'Type an invalid query like "tag:value OR"',
+          'aria-describedby': error ? errorId : undefined,
         }}
         onChange={onChange}
         showErrorTooltip={false}
       />
-    </EuiFormRow>
+      {error && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiCallOut
+            id={errorId}
+            iconType="faceSad"
+            color="danger"
+            size="s"
+            title={`Invalid search: ${error.message}`}
+          />
+        </>
+      )}
+    </>
   );
 };
 ```

--- a/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
@@ -400,7 +400,7 @@ If you choose to hide the built-in tooltip, you *must* ensure that screen reader
 
 ```tsx interactive
 import React, { useState } from 'react';
-import { EuiSearchBar, EuiCallOut, EuiSpacer, useGeneratedHtmlId } from '@elastic/eui';
+import { EuiSearchBar, EuiFormErrorText, EuiSpacer, useGeneratedHtmlId } from '@elastic/eui';
 
 export default () => {
   const [error, setError] = useState(null);
@@ -423,13 +423,9 @@ export default () => {
       {error && (
         <>
           <EuiSpacer size="s" />
-          <EuiCallOut
-            id={errorId}
-            iconType="faceSad"
-            color="danger"
-            size="s"
-            title={`Invalid search: ${error.message}`}
-          />
+          <EuiFormErrorText id={errorId}>
+            {`Invalid search: ${error.message}`}
+          </EuiFormErrorText>
         </>
       )}
     </>

--- a/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
+++ b/packages/website/docs/components/forms/search-and-filter/search-bar.mdx
@@ -388,6 +388,51 @@ export default () => {
 };
 ```
 
+## Validation error
+
+By default, an **EuiSearchBar** displays a built-in tooltip when an invalid query is typed. This tooltip informs sighted users (if no other error UI is provided by the consumer) as well as screen reader users.
+
+If you prefer to provide your own error UI (for instance, by wrapping the search bar in an **EuiFormRow**), you can use the `showErrorTooltip={false}` prop to hide the built-in tooltip. 
+
+**Important:** If you choose to hide the built-in tooltip, you *must* ensure that screen readers can still announce the validation error using an alternative method, such as the **EuiFormRow** example below.
+
+```tsx interactive
+import React, { useState } from 'react';
+import { EuiSearchBar, EuiFormRow } from '@elastic/eui';
+
+export default () => {
+  const [error, setError] = useState(null);
+
+  const onChange = ({ error }) => {
+    setError(error);
+  };
+
+  const schema = {
+    strict: true,
+    fields: {
+      status: { type: 'string' }
+    }
+  };
+
+  return (
+    <EuiFormRow 
+      error={error ? `Invalid search: ${error.message}` : null} 
+      isInvalid={!!error}
+      fullWidth
+    >
+      <EuiSearchBar
+        box={{
+          schema,
+          placeholder: 'Type an invalid query like "status: "',
+        }}
+        onChange={onChange}
+        showErrorTooltip={false}
+      />
+    </EuiFormRow>
+  );
+};
+```
+
 ## Controlled search bar
 
 An **EuiSearchBar** can have its query controlled by a parent component by passing the `query` prop. Changes to the query will be passed back up through the `onChange` callback where the new query must be stored in state and passed back into the search bar.


### PR DESCRIPTION
 ## Summary
  • What: Added an optional  showErrorTooltip  prop (defaulting to  true ) to  EuiSearchBar .
  • Why: Fixes #9754. Currently, when  EuiSearchBar  encounters an invalid query, it always renders its internal
  error.message  inside an  EuiToolTip . For consumers (like Kibana) that already render their own custom error UI,
  this creates duplicated and overlapping error messages.
  • How: Destructured  showErrorTooltip  in  EuiSearchBar  and used it to conditionally render the  EuiToolTip
  wrapper. If  false , it simply renders the  searchBox  without the tooltip.
  ### API Changes

   component / parent | prop / child     | change        | description
  --------------------|------------------|---------------|-----------------------------------------------------------
   EuiSearchBar       | showErrorTooltip | Added         | Conditionally opt-out of the built-in parse-error tooltip

  ## Screenshots
   Before                                                  | After
  ---------------------------------------------------------|---------------------------------------------------------
   Tooltip overlaps with custom Kibana error UI as seen in issue #9754           | Tooltip is suppressed, allowing only the consumer's custom error UI to show

  ## Impact Assessment
  Note: Most PRs should be tested in Kibana https://github.com/elastic/eui/blob/main/wiki/contributing-to-
  eui/testing/testing-in-kibana.md to help gauge their Impact before merging.
  [ ] 🔴 Breaking changes — What will break? How many usages in Kibana/Cloud UI are impacted?
  [ ] 💅 Visual changes — May impact style overrides; could require visual testing. Explain and estimate impact.
  [✓] 🧪 Test impact — Added unit tests in  search_bar.test.tsx  using  userEvent  to verify the tooltip is
  suppressed when  showErrorTooltip={false} , and that  aria-invalid  is properly asserted.
  [ ] 🔧 Hard to integrate — If changes require substantial updates to Kibana, please stage the changes and link them
  here.
  Impact level: 🟢 Low
  ## Release Readiness
  [✓] Documentation: Auto-generated via  react-docgen  from the new TSDoc comment in  search_bar.tsx , and added a
  new "Validation error" section to  search-bar.mdx  explaining accessibility requirements when opting out.
  [ ] Figma:
  [ ] Migration guide:
  [ ] Adoption plan (new features):

  ### QA instructions for reviewer

  • Open the  EuiSearchBar  component in the documentation/playground.
  [ ] Confirm that by default, entering an invalid EQL query (e.g.,  status:  ) still shows the built-in error
  tooltip.
  [ ] Pass  showErrorTooltip={false}  to the component.
  [ ] Enter an invalid EQL query and confirm the search box turns red (error state) but the tooltip does not appear.

  ### Checklist before marking Ready for Review

  [✓] Filled out all sections above
  [ ] QA: Tested light/dark modes, high contrast, mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
  (N/A - logic change only)
  [ ] QA: Tested in CodeSandbox and Kibana
  [✓] QA: Tested docs changes (Auto-generated via TSDoc and manual MDX updates)
  [✓] Tests: Added/updated Jest
  [✓] Changelog: Added changelog entry to  changelogs/upcoming/
  [ ] Breaking changes: Added breaking change label (if applicable)

  ### Reviewer checklist

  [ ] Approved Impact Assessment — Acceptable to merge given the consumer impact.
  [ ] Approved Release Readiness — Docs, Figma, and migration info are sufficient to ship.
