### PR TITLE
Release: @elastic/eui-test-helpers v1.1.0

### DIFF
--- a/packages/test-helpers/changelogs/CHANGELOG_2026.md
+++ b/packages/test-helpers/changelogs/CHANGELOG_2026.md
@@ -1,0 +1,4 @@
+## [`v1.1.0`](https://github.com/elastic/eui/releases/v1.1.0)
+
+- Prepared `@elastic/eui-test-helpers` for npm publishing (CommonJS + ESM + type declarations) ([#9772](https://github.com/elastic/eui/pull/9772))
+

--- a/packages/test-helpers/changelogs/upcoming/9772.md
+++ b/packages/test-helpers/changelogs/upcoming/9772.md
@@ -1,1 +1,0 @@
-- Prepared `@elastic/eui-test-helpers` for npm publishing (CommonJS + ESM + type declarations)

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/eui-test-helpers",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A library of EUI test helpers for RTL, Cypress and Scout",
   "license": "SEE LICENSE IN LICENSE.txt",
   "repository": {


### PR DESCRIPTION
Packages to release:
- `@elastic/eui-test-helpers` — v1.0.0 → v1.1.0

First publish of `@elastic/eui-test-helpers`. Scoped to this package only (`--workspaces @elastic/eui-test-helpers`).