### PR TITLE
[Chore] Set `id-token: write` on snapshot release job

### DIFF
--- a/.github/workflows/update_kibana_dependencies.yml
+++ b/.github/workflows/update_kibana_dependencies.yml
@@ -36,6 +36,9 @@ jobs:
   release:
     name: Create snapshot release
     if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:regression-integration-test-kibana' }}
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/release.yml
     with:
       release_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.release_ref }}


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Noticed on https://github.com/elastic/eui/pull/9749, failing build: https://github.com/elastic/eui/actions/runs/28584386688/job/84754634776?pr=9749

The workflow fails on publishing a snapshot. Publishing uses npm trusted publishing (OIDC), which needs `id-token: write`. `release.yml` has it but as a reusable workflow its permissions are capped by the caller and `update_kibana_dependencies.yml` never granted `id-token`, so it was dropped to `none`.

Cannot be tested until merged to main.