### PR TITLE
[Chore] Dispatch snapshot releases directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,6 @@ jobs:
       id-token: write # Required for OIDC (npm trusted publishing)
       contents: read
       actions: write # Required to dispatch the Kibana integration chain
-    outputs:
-      published_packages_json: ${{ steps.published_packages_info.outputs.json }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -198,8 +196,6 @@ jobs:
       needs.lint_and_unit_tests.result == 'success' &&
       needs.cypress_tests.result == 'success'
     needs: [ lint_and_unit_tests, cypress_tests ]
-    outputs:
-      published_packages_json: ${{ steps.published_packages_info.outputs.json }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,12 +160,6 @@ jobs:
           result-encoding: string
       - name: Release
         run: yarn release run snapshot --skip-prompts --skip-auth-check --use-auth-token --allow-custom ${{ inputs.dry_run && '--dry-run' || ''}} ${{ steps.prepare_npm_tag_arg.outputs.result }} ${{ steps.prepare_workspaces_arg.outputs.result }}
-      - name: Output published packages info
-        id: published_packages_info
-        # language=bash
-        run: |
-          file_content=$(jq -c . .release/published_packages.json)
-          echo "json=$file_content" >> "$GITHUB_OUTPUT"
       - name: Trigger Kibana integration test
         # Keep `release.yml` as the npm trusted-publishing entry point; continue
         # the Kibana chain only after the snapshot package metadata exists.
@@ -255,9 +249,3 @@ jobs:
           result-encoding: string
       - name: Release
         run: yarn release run official --skip-prompts --skip-auth-check --use-auth-token --allow-custom --skip-update-versions ${{ inputs.dry_run && '--dry-run' || ''}} ${{ steps.prepare_npm_tag_arg.outputs.result }} ${{ steps.prepare_workspaces_arg.outputs.result }}
-      - name: Output published packages info
-        id: published_packages_info
-        # language=bash
-        run: |
-          file_content=$(jq -c . .release/published_packages.json)
-          echo "json=$file_content" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,37 +31,22 @@ on:
         description: "[Custom releases only] npm tag to use"
         required: false
         type: string
-  workflow_call:
-    inputs:
-      release_ref:
-        description: Upstream git ref to create the release from
-        required: true
-        type: string
-      type:
-        description: Release type - snapshot or official
-        required: true
-        type: string
-      workspaces:
-        description: A comma-separated list of workspaces to release
-        required: false
-        type: string
-      dry_run:
-        description: Dry run (do not publish the packages)
-        required: true
-        type: boolean
-      skip_tests:
-        description: Skip tests (snapshots only)
+      kibana_integration:
+        description: "[Snapshot only] Trigger the Kibana integration test chain after publishing"
         default: false
         type: boolean
-      npm_tag:
-        description: "[Custom releases only] npm tag to use"
+      kibana_pr_title:
+        description: "[Kibana integration only] Title for the Kibana PR"
         required: false
         type: string
-    outputs:
-      published_packages_json:
-        description: A JSON-formatted list of published packages and their versions
-        value: ${{ jobs.resolver.outputs.published_packages_json }}
-
+      kibana_pr_body:
+        description: "[Kibana integration only] Body for the Kibana PR"
+        required: false
+        type: string
+      kibana_source_pr_number:
+        description: "[Kibana integration only] Source EUI PR number that triggered the run"
+        required: false
+        type: string
 permissions:
   id-token: write # Required for OIDC
   contents: read
@@ -116,6 +101,10 @@ jobs:
       (needs.lint_and_unit_tests.result == 'success' || needs.lint_and_unit_tests.result == 'skipped') &&
       (needs.cypress_tests.result == 'success' || needs.cypress_tests.result == 'skipped')
     needs: [ lint_and_unit_tests, cypress_tests ]
+    permissions:
+      id-token: write # Required for OIDC (npm trusted publishing)
+      contents: read
+      actions: write # Required to dispatch the Kibana integration chain
     outputs:
       published_packages_json: ${{ steps.published_packages_info.outputs.json }}
     steps:
@@ -177,9 +166,30 @@ jobs:
         id: published_packages_info
         # language=bash
         run: |
-          # minify JSON content for easier handling
           file_content=$(jq -c . .release/published_packages.json)
           echo "json=$file_content" >> "$GITHUB_OUTPUT"
+      - name: Trigger Kibana integration test
+        # Keep `release.yml` as the npm trusted-publishing entry point; continue
+        # the Kibana chain only after the snapshot package metadata exists.
+        if: ${{ inputs.kibana_integration && !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ inputs.kibana_pr_title }}
+          PR_BODY: ${{ inputs.kibana_pr_body }}
+          SOURCE_PR_NUMBER: ${{ inputs.kibana_source_pr_number }}
+        # language=bash
+        run: |
+          set -euo pipefail
+          dependencies="$(jq -c . .release/published_packages.json)"
+          args=(
+            -f "dependencies=$dependencies"
+            -f "pr_title=$PR_TITLE"
+            -f "pr_body=$PR_BODY"
+          )
+          if [[ -n "${SOURCE_PR_NUMBER:-}" ]]; then
+            args+=( -f "source_pr_number=$SOURCE_PR_NUMBER" )
+          fi
+          gh workflow run update_kibana_dependencies__prepare_changes.yml "${args[@]}"
   release_official:
     name: Create an official release
     runs-on: ubuntu-latest
@@ -253,23 +263,5 @@ jobs:
         id: published_packages_info
         # language=bash
         run: |
-          # minify JSON content for easier handling
           file_content=$(jq -c . .release/published_packages.json)
           echo "json=$file_content" >> "$GITHUB_OUTPUT"
-  resolver:
-    name: Resolve outputs
-    needs: [release_snapshot, release_official]
-    runs-on: ubuntu-latest
-    outputs:
-      published_packages_json: ${{ steps.resolver.outputs.published_packages.json }}
-    if: |
-      always() &&
-      (needs.release_snapshot.result == 'success' || needs.release_snapshot.result == 'skipped') &&
-      (needs.release_official.result == 'success' || needs.release_official.result == 'skipped')
-    steps:
-      - id: resolver
-        run: |
-          PUBLISHED_PACKAGES_JSON_SNAPSHOT="${{ needs.release_snapshot.outputs.published_packages_json }}"
-          PUBLISHED_PACKAGES_JSON_OFFICIAL="${{ needs.release_official.outputs.published_packages_json }}"
-
-          echo "json=${PUBLISHED_PACKAGES_JSON_SNAPSHOT:-$PUBLISHED_PACKAGES_JSON_OFFICIAL}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Trigger Kibana integration test
         # Keep `release.yml` as the npm trusted-publishing entry point; continue
         # the Kibana chain only after the snapshot package metadata exists.
-        if: ${{ inputs.kibana_integration && !inputs.dry_run }}
+        if: ${{ inputs.type == 'snapshot' && inputs.kibana_integration && !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TITLE: ${{ inputs.kibana_pr_title }}

--- a/.github/workflows/update_kibana_dependencies.yml
+++ b/.github/workflows/update_kibana_dependencies.yml
@@ -17,67 +17,51 @@ on:
         description: Kibana PR body
         default: This PR updates EUI dependencies in Kibana
         type: string
-  workflow_call:
-    inputs:
-      release_ref:
-        description: Git ref to release
-        type: string
-        required: true
-      pr_title:
-        description: Kibana PR title
-        default: Update EUI dependencies
-        type: string
-      pr_body:
-        description: Kibana PR body
-        default: This PR updates EUI dependencies in Kibana
-        type: string
-
 jobs:
-  release:
-    name: Create snapshot release
+  # Triggers the `release.yml` workflow to publish a snapshot.
+  # We dispatch (instead of `workflow_call`) so `release.yml` stays the top-level
+  # workflow of the publish run and the single npm trusted publishing entry point
+  # shared with official releases. `release.yml` kicks off the rest of the
+  # Kibana integration chain after publishing.
+  trigger_release:
+    name: Trigger snapshot release
+    runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:regression-integration-test-kibana' }}
     permissions:
-      id-token: write
+      actions: write
       contents: read
-    uses: ./.github/workflows/release.yml
-    with:
-      release_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.release_ref }}
-      type: snapshot
-      dry_run: false
-
-  trigger_kibana_update:
-    name: Trigger Kibana dependency update
-    runs-on: ubuntu-latest
-    needs: [release]
     steps:
-      - name: Dispatch prepare changes workflow
+      - name: Dispatch release workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEPENDENCIES: ${{ needs.release.outputs.published_packages_json }}
           EVENT_NAME: ${{ github.event_name }}
+          RELEASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.release_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           INPUT_PR_TITLE: ${{ inputs.pr_title }}
           INPUT_PR_BODY: ${{ inputs.pr_body }}
         # language=bash
         run: |
+          set -euo pipefail
           workflow_args=(
-            "-f" "dependencies=$DEPENDENCIES"
+            "-f" "release_ref=$RELEASE_REF"
+            "-f" "type=snapshot"
+            "-f" "dry_run=false"
+            "-f" "kibana_integration=true"
           )
 
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             # Triggered by label - use PR context
             workflow_args+=(
-              "-f" "pr_title=[DO NOT MERGE] EUI Regression Integration Test - elastic/eui#$PR_NUMBER"
-              "-f" "pr_body=This PR was created programmatically to run regression integration tests of EUI changes from $PR_URL"
-              "-f" "source_pr_number=$PR_NUMBER"
+              "-f" "kibana_pr_title=[DO NOT MERGE] EUI Regression Integration Test - elastic/eui#$PR_NUMBER"
+              "-f" "kibana_pr_body=This PR was created programmatically to run regression integration tests of EUI changes from $PR_URL"
+              "-f" "kibana_source_pr_number=$PR_NUMBER"
             )
           else
-            # Manually dispatched - use provided inputs or defaults
             workflow_args+=(
-              "-f" "pr_title=$INPUT_PR_TITLE"
-              "-f" "pr_body=$INPUT_PR_BODY"
+              "-f" "kibana_pr_title=${INPUT_PR_TITLE:-Update EUI dependencies}"
+              "-f" "kibana_pr_body=${INPUT_PR_BODY:-This PR updates EUI dependencies in Kibana}"
             )
           fi
 
-          gh workflow run update_kibana_dependencies__prepare_changes.yml "${workflow_args[@]}"
+          gh workflow run release.yml "${workflow_args[@]}"

--- a/.github/workflows/update_kibana_dependencies.yml
+++ b/.github/workflows/update_kibana_dependencies.yml
@@ -59,8 +59,8 @@ jobs:
             )
           else
             workflow_args+=(
-              "-f" "kibana_pr_title=${INPUT_PR_TITLE:-Update EUI dependencies}"
-              "-f" "kibana_pr_body=${INPUT_PR_BODY:-This PR updates EUI dependencies in Kibana}"
+              "-f" "kibana_pr_title=$INPUT_PR_TITLE"
+              "-f" "kibana_pr_body=$INPUT_PR_BODY"
             )
           fi
 

--- a/.github/workflows/update_kibana_dependencies__open_pr.yml
+++ b/.github/workflows/update_kibana_dependencies__open_pr.yml
@@ -24,30 +24,6 @@ on:
       source_pr_number:
         description: Source PR number that triggered this workflow
         type: number
-  workflow_call:
-    inputs:
-      pr_head:
-        description: HEAD ref
-        required: true
-        type: string
-      pr_title:
-        description: Title of the PR
-        required: true
-        type: string
-      pr_body:
-        description: Body of the PR
-        type: string
-      pr_draft:
-        description: Whether the PR should be marked as draft
-        type: boolean
-      pr_labels:
-        description: Comma-separated list of labels to add to the PR
-        type: string
-    outputs:
-      pr_url:
-        description: 'URL of the created pull request'
-        value: ${{ jobs.open_pr.outputs.pr_url }}
-
 permissions:
   id-token: write
 

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -2,8 +2,8 @@
 # This workflow file is part of the chain of workflows focused on testing
 # EUI changes in Kibana as part of our regression integration testing.
 #
-# This workflow is triggered from the `update_kibana_dependencies.yml`
-# workflow and should not be run manually.
+# This workflow is dispatched from `release.yml` after a snapshot is published
+# and should not be run manually.
 #
 # Due to technical limitations and security rules, steps had to be divided
 # into multiple subworkflows that must be triggered through
@@ -19,7 +19,6 @@ on:
         description: JSON-serialized map of dependencies to update
         type: string
         required: true
-      # Passed through to `update_kibana_dependencies__open_pr.yml` workflow
       pr_title:
         description: PR title
         required: true
@@ -31,28 +30,10 @@ on:
       source_pr_number:
         description: Source PR number that triggered this workflow
         type: number
-  workflow_call:
-    inputs:
-      dependencies:
-        description: JSON-serialized map of dependencies to update
-        type: string
-        required: true
-      # Passed through to `update_kibana_dependencies__open_pr.yml` workflow
-      pr_title:
-        description: PR title
-        required: true
-        type: string
-      pr_body:
-        description: PR body
-        required: true
-        type: string
-    outputs:
-      branch_name:
-        description: Name of the branch created in the elastic/eui-kibana repository
-        value: ${{ jobs.update.outputs.branch_name }}
-
 permissions:
-  id-token: write
+  id-token: write # Required for OIDC (Vault ephemeral token)
+  contents: read
+  actions: write # Required to dispatch the open-PR workflow
 
 jobs:
   update:
@@ -149,13 +130,20 @@ jobs:
           SOURCE_PR_NUMBER: ${{ inputs.source_pr_number }}
         # language=bash
         run: |
+          set -euo pipefail
           # --repo is required because we're in the context of elastic/kibana right now
-          workflow_url=$(gh workflow run update_kibana_dependencies__open_pr.yml \
-            --repo elastic/eui \
-            -f pr_title="$PR_TITLE" \
-            -f pr_body="$PR_BODY" \
-            -f pr_head="$BRANCH_NAME" \
-            -f source_pr_number="$SOURCE_PR_NUMBER")
+          args=(
+            --repo elastic/eui
+            -f "pr_title=$PR_TITLE"
+            -f "pr_body=$PR_BODY"
+            -f "pr_head=$BRANCH_NAME"
+          )
+          # Only pass source_pr_number when set - it's a number-typed input, so an
+          # empty value (nightly/manual runs) would fail validation.
+          if [[ -n "${SOURCE_PR_NUMBER:-}" ]]; then
+            args+=( -f "source_pr_number=$SOURCE_PR_NUMBER" )
+          fi
+          workflow_url=$(gh workflow run update_kibana_dependencies__open_pr.yml "${args[@]}")
 
           {
             echo "### Success :rocket:"


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Closes https://github.com/elastic/eui-private/issues/719

This PR is infra-only.

Specifically, it rewrites the Kibana regression testing pipeline from `workflow_call` (so called "reusable workflows" not supported by npm trusted publishing) to `workflow_dispatch`.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

No way to test this until it lands in `main`. Ensure statically the file changes make sense.