### PR TITLE
[Docs] Disable fullscreen button for one-liner code snippets

### DIFF
--- a/packages/docusaurus-theme/changelogs/upcoming/9792.md
+++ b/packages/docusaurus-theme/changelogs/upcoming/9792.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Disabled the fullscreen button for one-liner code snippets on the docs site.

--- a/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
+++ b/packages/docusaurus-theme/src/theme/CodeBlock/index.tsx
@@ -48,11 +48,15 @@ export default function CodeBlock({
     return <Demo {...props}>{children}</Demo>;
   }
 
+  // Don't show the fullscreen button for one-liner snippets
+  const isOneLiner =
+    typeof children === 'string' && !children.trim().includes('\n');
+
   return (
     <EuiCodeBlock
       {...props}
       fontSize="m"
-      overflowHeight={450}
+      overflowHeight={isOneLiner ? undefined : 450}
       language={language}
       isCopyable
       css={styles.codeBlock}


### PR DESCRIPTION
## Summary

Fixes #9731

`EuiCodeBlock`'s fullscreen button visibility is driven by `showFullScreenButton = !!overflowHeight` ([`code_block_full_screen.tsx`](https://github.com/elastic/eui/blob/main/packages/eui/src/components/code/code_block_full_screen.tsx#L36)). The docs site's `CodeBlock` theme wrapper always passes `overflowHeight={450}` to every snippet, so even one-liner commands (e.g. `yarn add @elastic/eui`) get a fullscreen button and extra reserved vertical space they don't need.

This detects when the snippet is a single line (no `\n` in the stringified children) and passes `overflowHeight={undefined}` in that case, which removes both the fullscreen button and the reserved height — matching the approach from the previous attempt at this ([#9745](https://github.com/elastic/eui/pull/9745), closed for inactivity, build had passed), independently re-verified against the current source.

### API Changes

N/A — docs site theme change only, no `@elastic/eui` public API affected.

## Screenshots

<!-- PLACEHOLDER: paste screenshots manually before marking ready for review -->
<!-- Local files: tmp/before-9731-installation.png and tmp/after-9731-installation.png in OSSHunt Command Center -->

| Before | After |
| ------ | ----- |
|  <img width="900" height="1000" alt="image" src="https://github.com/user-attachments/assets/2515a7df-0f17-4a2c-9b89-9feb34bb8df4" /> | <img width="900" height="1000" alt="image" src="https://github.com/user-attachments/assets/2d1e947c-4830-42c6-9cbc-1a9cb8be09d5" /> |

Verified multi-line snippets are unaffected (still retain their fullscreen button and `max-block-size: 450px`).

## Impact Assessment

- [ ] ~🔴 **Breaking changes**~
- [x] 💅 **Visual changes**
- [ ] ~🧪 **Test impact**~
- [ ] ~🔧 **Hard to integrate**~

**Impact level:** 🟢 None — docs site presentation only, no consumer-facing `@elastic/eui` change.

## Release Readiness

- [x] **Documentation:** [Getting started > Setup](https://eui.elastic.co/docs/getting-started/setup/)
- [ ] ~**Figma**~
- [ ] ~**Migration guide**~
- [ ] ~**Adoption plan**~

### QA instructions for reviewer

- [ ] Open [Getting started > Setup](https://eui.elastic.co/docs/getting-started/setup/) and confirm the one-liner `yarn add` snippets no longer show a fullscreen button
- [ ] Confirm a multi-line snippet elsewhere on the docs site still shows its fullscreen button

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [ ] ~**QA:** Tested light/dark modes, high contrast, mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~
- [ ] ~**QA:** Tested in CodeSandbox and Kibana~
- [x] **QA:** Tested docs changes
- [ ] ~**Tests:** Added/updated Jest, Cypress, and VRT~ (no test runner configured for `docusaurus-theme` package)
- [x] **Changelog:** Added changelog entry
- [ ] ~**Breaking changes**~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
