### PR TITLE
[Docs] Show a gray favicon in dev mode

### DIFF
--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -18,10 +18,11 @@ const SSPL_LICENSE_URL =
 
 const baseUrl = process.env.DOCS_BASE_URL || '/';
 const googleTagManagerId = process.env.DOCS_GOOGLE_TAG_MANAGER_ID || undefined;
+const isDevelopment = process.env.NODE_ENV === 'development';
 
 let storybookBaseUrl: string = 'https://eui.elastic.co/storybook';
 
-if (process.env.NODE_ENV === 'development') {
+if (isDevelopment) {
   storybookBaseUrl = 'http://localhost:6006';
 } else if (process.env.STORYBOOK_BASE_URL) {
   storybookBaseUrl = process.env.STORYBOOK_BASE_URL;
@@ -30,7 +31,7 @@ if (process.env.NODE_ENV === 'development') {
 const config: Config = {
   title: 'Elastic UI Framework',
   tagline: 'The framework powering the Elastic Stack',
-  favicon: 'favicon.ico',
+  favicon: isDevelopment ? 'favicon-dev.svg' : 'favicon.ico',
   trailingSlash: true,
 
   // Set the production url of your site here

--- a/packages/website/static/favicon-dev.svg
+++ b/packages/website/static/favicon-dev.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="none" viewBox="0 0 32 32">
+  <defs>
+    <filter id="grayscale">
+      <feColorMatrix type="saturate" values="0"/>
+    </filter>
+  </defs>
+  <g filter="url(#grayscale)">
+    <path fill="#FF957D" d="M18 25c-.5-5.5-5.5-10.5-11-11l7-7c.5 5.5 5.5 10.5 11 11l-7 7z"/>
+    <circle cx="7" cy="7" r="7" fill="#F04E98"/>
+    <circle cx="25" cy="25" r="7" fill="#FEC514"/>
+    <path fill="#00BFB3" d="M31 14c-7.18 0-13-5.82-13-13h13v13z"/>
+    <path fill="#1BA9F5" d="M1 18c7.18 0 13 5.82 13 13H1V18z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Fixes #9732

`packages/website/docusaurus.config.ts` hardcoded `favicon: 'favicon.ico'`, so the local dev site shows the same colored favicon as production. With the dev server and `eui.elastic.co` open in adjacent tabs, it's easy to lose track of which one you're looking at.

This adds a `favicon-dev.svg`, a desaturated version of the existing EUI mark (`static/images/eui_logo.svg`) using an SVG `feColorMatrix` grayscale filter on the original colored paths rather than a single flat gray fill — this preserves the relative luminance/contrast between the four shapes, so the mark stays recognizable at favicon size instead of reading as a flat blob. `docusaurus.config.ts` now picks `favicon-dev.svg` when `NODE_ENV === 'development'` (reusing the same env check already used one line above for `storybookBaseUrl`), falling back to the existing `favicon.ico` otherwise.

Note: the reference screenshot originally attached to this issue (`user-attachments/assets/47241641-...`) is dead (404, confirmed authenticated) — this was independently verified against source and by comparing a flat-gray vs. grayscale-filter render side by side.

### API Changes

N/A — docs site theme change only, no `@elastic/eui` public API affected.

## Screenshots

<!-- PLACEHOLDER: paste screenshots manually before marking ready for review -->
<!-- Favicons are browser-tab chrome, not page content, so these can't be captured by automated tooling — real browser screenshots pasted by the maintainer of this fork. -->

| Before (prod, colored) | After (dev, gray) |
| ------ | ----- |
| <img width="199" height="26" alt="image" src="https://github.com/user-attachments/assets/4cf73f4e-d3c9-4a47-85da-43a563227456" />  | <img width="203" height="33" alt="image" src="https://github.com/user-attachments/assets/ad7d2ccd-c8b9-47e7-a038-0662dc28fc5c" /> |

Functionally verified: `yarn build` (prod) resolves `<link rel="icon" href="/favicon.ico">`; `yarn start` (dev) resolves `<link rel="icon" href="/favicon-dev.svg">`.

## Impact Assessment

- [ ] ~🔴 **Breaking changes**~
- [x] 💅 **Visual changes**
- [ ] ~🧪 **Test impact**~
- [ ] ~🔧 **Hard to integrate**~

**Impact level:** 🟢 None — local dev-only, no consumer-facing or production change.

## Release Readiness

- [ ] ~**Documentation**~
- [ ] ~**Figma**~
- [ ] ~**Migration guide**~
- [ ] ~**Adoption plan**~

### QA instructions for reviewer

- [ ] Run the docs site locally (`yarn start`) and confirm the browser tab shows the gray favicon
- [ ] Confirm a production build (`yarn build`) still resolves the colored `favicon.ico`

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [ ] ~**QA:** Tested light/dark modes, high contrast, mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~
- [ ] ~**QA:** Tested in CodeSandbox and Kibana~
- [x] **QA:** Tested docs changes
- [ ] ~**Tests:** Added/updated Jest, Cypress, and VRT~
- [ ] ~**Changelog:** Added changelog entry~ (docs-only change per [changelogs.md](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md) — requesting `skip-changelog` label in a comment, no permission to self-apply)
- [ ] ~**Breaking changes**~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
