### PR TITLE
[Chore] Fix dispatch failing with "not a git repository"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release packages
-run-name: "Create ${{ inputs.type }} release from ${{ github.ref_name }} (${{ inputs.release_ref }}) by ${{ github.actor }}"
+run-name: "Create ${{ inputs.type }} release from ${{ inputs.release_ref }} by ${{ github.actor }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           if [[ -n "${SOURCE_PR_NUMBER:-}" ]]; then
             args+=( -f "source_pr_number=$SOURCE_PR_NUMBER" )
           fi
-          gh workflow run update_kibana_dependencies__prepare_changes.yml "${args[@]}"
+          gh workflow run update_kibana_dependencies__prepare_changes.yml --repo "$GITHUB_REPOSITORY" "${args[@]}"
   release_official:
     name: Create an official release
     runs-on: ubuntu-latest

--- a/.github/workflows/update_kibana_dependencies.yml
+++ b/.github/workflows/update_kibana_dependencies.yml
@@ -64,4 +64,4 @@ jobs:
             )
           fi
 
-          gh workflow run release.yml "${workflow_args[@]}"
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" "${workflow_args[@]}"

--- a/.github/workflows/update_kibana_dependencies__open_pr.yml
+++ b/.github/workflows/update_kibana_dependencies__open_pr.yml
@@ -87,8 +87,8 @@ jobs:
                 ] | @tsv'
           )
 
-          if [[ -n "$err_msg" ]]; then
-            echo "::error::$err_msg" >&2
+          if [[ -z "$pr_url" ]]; then
+            echo "::error::${err_msg:-Failed to create pull request}" >&2
             {
               echo "### Failed to create pull request"
               echo ""


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Closes https://github.com/elastic/eui-private/issues/719

During testing of https://github.com/elastic/eui/pull/9782, noticed on https://github.com/elastic/eui/pull/9660 ([build](https://github.com/elastic/eui/actions/runs/29242150836/job/86790512279?pr=9660)).

The dispatch-based Kibana regression pipeline fails immediately because `gh workflow run` infers the target repo from the local git remote but the `trigger_release` job has no `actions/checkout` step.

This passes `--repo "$GITHUB_REPOSITORY"` explicitly so `gh` no longer depends on git context.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Labeling this PR won't test it because `pull_request` events always use the workflow file from the base branch (`main`).

`workflow_dispatch` though does test it. `update_kibana_dependencies.yml` has a `workflow_dispatch` trigger and manual dispatch runs the workflow from the ref I choose.

It's a real run (`type=snapshot`, `dry_run=false`) so it will actually publish a snapshot and open a real Kibana PR, same side effects as the label path. No `dry-run` option on that entry workflow.

**Verify:**

- [x] manually dispatch workflow succeeds ([run](https://github.com/elastic/eui/actions/runs/29242945934))
- [x] create snapshot release suceeeds ([run](https://github.com/elastic/eui/actions/runs/29242951469))
- [x] open draft PR in Kibana succeeds ([run](https://github.com/elastic/eui/actions/runs/29244150082), [PR](https://github.com/elastic/kibana/pull/277713))
    - **NOTE:** [CI failed](https://github.com/elastic/eui/actions/runs/29244462518/job/86797926266) but Kibana PR was opened successfully, the fix is on https://github.com/elastic/eui/pull/9799/commits/8ef19df986c291d0e60b0edfcf49496c9fd688a2
- [ ] ~post a comment on the original PR - this one (comment)~
    - **NOTE:** All post-open PR jobs were skipped

https://github.com/elastic/eui/pull/9799/commits/0c7fc4586a3800a16e48a68b34dfb57a150c7210 changed the workflow dispatched from this branch ☝🏻 but `open_pr` (https://github.com/elastic/eui/pull/9799/commits/8ef19df986c291d0e60b0edfcf49496c9fd688a2) is dispatched from `main` so it won't be picked up until merged.