### PR TITLE
[Chore] Use pull_request_target for Kibana integration

### DIFF
--- a/.github/workflows/update_kibana_dependencies.yml
+++ b/.github/workflows/update_kibana_dependencies.yml
@@ -1,7 +1,7 @@
 name: Update Kibana dependencies
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
   workflow_dispatch:
     inputs:
@@ -26,7 +26,7 @@ jobs:
   trigger_release:
     name: Trigger snapshot release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:regression-integration-test-kibana' }}
+    if: ${{ github.event_name != 'pull_request_target' || github.event.label.name == 'ci:regression-integration-test-kibana' }}
     permissions:
       actions: write
       contents: read
@@ -35,7 +35,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
-          RELEASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.release_ref }}
+          RELEASE_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || inputs.release_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           INPUT_PR_TITLE: ${{ inputs.pr_title }}
@@ -50,7 +50,7 @@ jobs:
             "-f" "kibana_integration=true"
           )
 
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
             # Triggered by label - use PR context
             workflow_args+=(
               "-f" "kibana_pr_title=[DO NOT MERGE] EUI Regression Integration Test - elastic/eui#$PR_NUMBER"


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Used `pull_request_target` instead of `pull_request` so that Kibana regression labeling works on fork PRs.

Fork PRs get a read-only `GITHUB_TOKEN` on `pull_request` so dispatching `release.yml` fails with 403 ([run](https://github.com/elastic/eui/actions/runs/29257480064/job/86841579496?pr=9660)). `pull_request_target` runs with base repo permissions. This job only reads PR metadata.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Cannot be tested until merged to `main`.