### PR TITLE
[Chore] Capture raw GraphQL response

### DIFF
--- a/.github/workflows/update_kibana_dependencies__open_pr.yml
+++ b/.github/workflows/update_kibana_dependencies__open_pr.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Check status
         id: check_status
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.ephemeral_token.outputs.token }}
           PR_URL: ${{ needs.open_pr.outputs.pr_url }}
         # language=bash
         run: |
@@ -209,7 +209,7 @@ jobs:
           vault-role: token-policy-6becee3e5a43
       - name: Check status
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.ephemeral_token.outputs.token }}
           PR_URL: ${{ needs.open_pr.outputs.pr_url }}
         # language=bash
         run: |

--- a/.github/workflows/update_kibana_dependencies__open_pr.yml
+++ b/.github/workflows/update_kibana_dependencies__open_pr.yml
@@ -61,7 +61,7 @@ jobs:
           base_repo_id="$(gh api "repos/$base_repo" --jq .node_id)"
           head_repo_id="$(gh api "repos/$head_repo" --jq .node_id)"
 
-          IFS=$'\t' read -r err_msg pr_url pr_number < <(
+          response="$(
             gh api graphql \
               -f query='mutation ($input: CreatePullRequestInput!) {
                 createPullRequest(input: $input) {
@@ -79,13 +79,11 @@ jobs:
               -F "input[body]=${PR_BODY:-}" \
               -F "input[draft]=${PR_DRAFT:-true}" \
               -F "input[maintainerCanModify]=false" \
-              -q 'def pr: .data.createPullRequest.pullRequest;
-                [
-                  ((.errors // []) | .[0].message // ""),
-                  (pr | if . then .url else "" end),
-                  (pr | if . then (.number | tostring) else "" end)
-                ] | @tsv'
-          )
+              || true
+          )"
+
+          pr_url="$(jq -r '.data.createPullRequest.pullRequest.url // empty' <<< "${response:-}")"
+          err_msg="$(jq -r '(.errors // []) | .[0].message // empty' <<< "${response:-}")"
 
           if [[ -z "$pr_url" ]]; then
             echo "::error::${err_msg:-Failed to create pull request}" >&2


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

[Post-open PR](https://github.com/elastic/eui/actions/runs/29260862835/job/86853513497) job failed.

- `gh api graphql` returns the created PR's URL inside `errors[0].message`, so the step treated a successful creation as a failure. Parse `data.createPullRequest.pullRequest.url` directly to decide success instead of the fragile tab-split that also shifted the URL/number.

- Fixed the token used by the "[Check CI status](https://github.com/elastic/eui/actions/runs/29260862835/job/86853895804)" jobs: `gh pr checks` targets the Kibana PR but `github.token` is scoped to `elastic/eui` and can't read it. Used the cross-repo ephemeral token (already fetched) instead.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

I did a smoke-test by manually running the workflow.

