### PR TITLE
Use runtime React version for renderHook

### DIFF
--- a/packages/eui/changelogs/upcoming/9805.md
+++ b/packages/eui/changelogs/upcoming/9805.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `renderHook` test utility requiring `@testing-library/react-hooks` in consumer environments running React 18+

--- a/packages/eui/src/components/flyout/use_flyout_resizable.test.ts
+++ b/packages/eui/src/components/flyout/use_flyout_resizable.test.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
+import { renderHook, renderHookAct as act } from '../../test/rtl/render_hook';
 import { useEuiFlyoutResizable } from './use_flyout_resizable';
 
 describe('useEuiFlyoutResizable', () => {

--- a/packages/eui/src/services/window_event/hooks.test.ts
+++ b/packages/eui/src/services/window_event/hooks.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { renderHook } from '@testing-library/react';
+import { renderHook } from '../../test/rtl/render_hook';
 
 import { useEuiWindowEvent } from './hooks';
 

--- a/packages/eui/src/test/rtl/render_hook.ts
+++ b/packages/eui/src/test/rtl/render_hook.ts
@@ -9,15 +9,24 @@
 import type {
   renderHook as renderHookType,
   act as actType,
-} from '@testing-library/react-hooks';
+} from '@testing-library/react';
 
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+/**
+ * `@testing-library/react` ships `renderHook`/`act` from v13.1+ (React 18+),
+ * so consumers on React 18 never need `@testing-library/react-hooks`.
+ * React 17 setups resolve an older `@testing-library/react` without
+ * `renderHook` and fall back accordingly.
+ */
+const rtl = require('@testing-library/react');
+
 let renderHook: typeof renderHookType;
 let renderHookAct: typeof actType;
-if (process.env.REACT_VERSION === '18') {
-  renderHook = require('@testing-library/react').renderHook;
-  renderHookAct = require('@testing-library/react').act;
+
+if (typeof rtl.renderHook === 'function') {
+  renderHook = rtl.renderHook;
+  renderHookAct = rtl.act;
 } else {
   renderHook = require('@testing-library/react-hooks/dom').renderHook;
   renderHookAct = require('@testing-library/react-hooks/dom').act;


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Closes https://github.com/elastic/eui/issues/8739

`@elastic/eui`'s `render_hook` test util required the dependency based on`REACT_VERSION` env var. That var is unset in consumers (e.g. Kibana), so it fell back to requiring `@testing-library/react-hooks`, which React 18 consumers don't install. This causes `Cannot find module '@testing-library/react-hooks/dom'` test failures.

Now the React major version is detected at runtime using `React.version`.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

- [x] CI passes both for React 17 and React 18
