### PR TITLE
[Chore] Use github.token with write permission

### DIFF
--- a/.github/workflows/update_kibana_dependencies__open_pr.yml
+++ b/.github/workflows/update_kibana_dependencies__open_pr.yml
@@ -25,7 +25,9 @@ on:
         description: Source PR number that triggered this workflow
         type: number
 permissions:
+  contents: read
   id-token: write
+  pull-requests: write
 
 jobs:
   open_pr:
@@ -140,7 +142,7 @@ jobs:
         if: ${{ inputs.source_pr_number }}
         uses: ./.github/actions/pr_bot_comment
         with:
-          gh_token: ${{ steps.ephemeral_token.outputs.token }}
+          gh_token: ${{ github.token }}
           pr_number: ${{ inputs.source_pr_number }}
           marker: 'kibana-regression-integration-test'
           comment_body: |
@@ -249,16 +251,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Fetch GitHub token
-        id: ephemeral_token
-        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3
-        with:
-          vault-instance: ci-prod
-          vault-role: token-policy-6becee3e5a43
       - name: Compose comment body
         id: compose_comment_body
         env:
-          GH_TOKEN: ${{ steps.ephemeral_token.outputs.token }}
           KIBANA_PR_URL: ${{ needs.open_pr.outputs.pr_url }}
           PR_HEAD: ${{ inputs.pr_head }}
           CHECK_1_RESULT: ${{ needs.check_ci_status_1.result }}
@@ -290,7 +285,7 @@ jobs:
       - name: Add a comment
         uses: ./.github/actions/pr_bot_comment
         with:
-          gh_token: ${{ steps.ephemeral_token.outputs.token }}
+          gh_token: ${{ github.token }}
           pr_number: ${{ inputs.source_pr_number }}
           marker: 'kibana-regression-integration-test'
           comment_body: ${{ steps.compose_comment_body.outputs.comment_body }}


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Post-open PR jobs failing: https://github.com/elastic/eui/actions/runs/29411808573/job/87340464631

Was to overeager on the last one: https://github.com/elastic/eui/pull/9802 Hopefully this solves the 403.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Not testable until it gets to `main` because of `pull_request_target` trigger.

Disregard the linked integration test PR, I dispatched it manually to test the `eui-team` membership check.