### PR TITLE
[Chore] Pass bot name explicitly

### DIFF
--- a/.github/actions/pr_bot_comment/action.yml
+++ b/.github/actions/pr_bot_comment/action.yml
@@ -13,6 +13,9 @@ inputs:
   marker:
     description: Unique marker string to identify this comment and allow updating it programmatically
     required: true
+  comment_author:
+    description: Login of the comment author; inferred from the token when omitted
+    required: false
   comment_body:
     description: The comment body content (marker will be prepended automatically)
     required: true
@@ -31,11 +34,11 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         PR_NUMBER: ${{ inputs.pr_number }}
         MARKER: ${{ inputs.marker }}
+        COMMENT_AUTHOR: ${{ inputs.comment_author }}
         COMMENT_BODY: ${{ inputs.comment_body }}
       # language=bash
       run: |
-        # Get bot user name
-        user=$(gh api user --jq '.login')
+        user="${COMMENT_AUTHOR:-$(gh api user --jq '.login')}"
 
         # Prepend magic marker to comment body
         marker_str="<!-- comment-marker: $MARKER -->"

--- a/.github/workflows/update_kibana_dependencies__open_pr.yml
+++ b/.github/workflows/update_kibana_dependencies__open_pr.yml
@@ -145,6 +145,7 @@ jobs:
           gh_token: ${{ github.token }}
           pr_number: ${{ inputs.source_pr_number }}
           marker: 'kibana-regression-integration-test'
+          comment_author: 'github-actions[bot]'
           comment_body: |
             ## Kibana Regression Integration Test
 
@@ -288,4 +289,5 @@ jobs:
           gh_token: ${{ github.token }}
           pr_number: ${{ inputs.source_pr_number }}
           marker: 'kibana-regression-integration-test'
+          comment_author: 'github-actions[bot]'
           comment_body: ${{ steps.compose_comment_body.outputs.comment_body }}


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

The workflow failed because the `pr_bot_comment` action called `gh api user` to determine the comment author but that endpoint does not support installation tokens (`github.token`) and returned HTTP 403.

Now, the action accepts an optional `comment_author`. Both workflow calls pass `github-actions[bot]` avoiding the unsupported API request while preserving automatic author lookup for other token types.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

[Test run](https://github.com/elastic/eui/actions/runs/29437114911/job/87426442232)

Before the fix, calling `gh api user` to get the bot name failed:

<img width="1309" height="448" alt="Screenshot 2026-07-15 at 19 48 55" src="https://github.com/user-attachments/assets/67ad0461-4946-42be-b74f-eac050881c15" />

After the fix it passes:

<img width="1318" height="547" alt="Screenshot 2026-07-15 at 19 49 06" src="https://github.com/user-attachments/assets/cca201b2-b2ee-499d-a2b8-66fbf54839b4" />
