### PR TITLE
[Chore] Add de-duplicate step to Kibana prep

### DIFF
--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -128,9 +128,12 @@ jobs:
             else
               echo "::warning::Skipping $pkg: Not found in either dependencies or devDependencies";
             fi'
-      - name: Run Kibana bootstrap scripts
+      - name: Run Kibana bootstrap script and normalize dependencies
         # language=bash
-        run: yarn kbn bootstrap
+        run: |
+          yarn kbn bootstrap
+          node scripts/yarn_deduplicate
+          yarn kbn bootstrap --force-install
       - name: Commit changed files
         # language=bash
         run: |


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Nightly builds work but https://github.com/elastic/kibana/pull/279387 failed on _Quick checks_ (https://buildkite.com/elastic/kibana-pull-request/builds/471740 ), specifically `/.buildkite/scripts/steps/checks/yarn_deduplicate.sh: 1m 8s`.

The fix is to add `yarn_deduplicate` step to the workflow.

We can only verify it works after merging to `main`.