### PR TITLE
[Release CLI] Fix adding all modified package.json files

### DIFF
--- a/packages/release-cli/src/git_utils.ts
+++ b/packages/release-cli/src/git_utils.ts
@@ -54,6 +54,11 @@ export const stageFiles = async (files: string[]) => {
   return execPromise(`git add ${files.join(' ')}`);
 };
 
+export const getModifiedFiles = async () => {
+  const result = await execPromise('git diff HEAD --name-only');
+  return result.stdout.split(/\r?\n/).filter(Boolean);
+};
+
 export const commitFiles = async (message: string, files: string[]) => {
   // This isn't the best at handling unusual formatting like messages with quotes
   return execPromise(`git commit ${files.join(' ')} -m "${message}"`);

--- a/packages/release-cli/src/steps/update_versions.ts
+++ b/packages/release-cli/src/steps/update_versions.ts
@@ -25,7 +25,12 @@ import {
   getUpcomingVersion,
   getVersionTypeFromChangelog,
 } from '../version';
-import { commitFiles, isFileAddedToGit, stageFiles } from '../git_utils';
+import {
+  commitFiles,
+  getModifiedFiles,
+  isFileAddedToGit,
+  stageFiles,
+} from '../git_utils';
 
 /**
  * Update version numbers and yearly changelogs based on workspace
@@ -110,16 +115,24 @@ export const stepUpdateVersions = async (
   }
 
   if (options.type !== 'snapshot') {
+    // Yarn also updates dependency ranges in `package.json` files for workspaces
+    // that are not being released.
+    const modifiedPackageJsonFiles = (await getModifiedFiles())
+      .filter((file) => path.basename(file) === 'package.json')
+      .map((file) => path.resolve(rootWorkspaceDir, file));
+    filesToCommit.push(...modifiedPackageJsonFiles);
+
     // Stage yarn.lock changes
     const yarnLockPath = path.join(rootWorkspaceDir, 'yarn.lock');
     filesToCommit.push(yarnLockPath);
     await stageFiles([yarnLockPath]);
 
     // Stage updated package.json files
-    await stageFiles(filesToCommit);
+    const uniqueFilesToCommit = [...new Set(filesToCommit)];
+    await stageFiles(uniqueFilesToCommit);
 
     // Commit all package.json files and yarn.lock
-    await commitFiles('chore: update package versions [skip ci]', filesToCommit);
+    await commitFiles('chore: update package versions [skip ci]', uniqueFilesToCommit);
   }
 
   return changedWorkspaces;


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Releasing `docusaurus-theme` also updates the version in `docusaurus-preset/package.json`. The release CLI previously committed only packages with changelogs, leaving this generated change uncommitted.

This updates the CLI to include all modified `package.json` files in the release commit.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Run a dry-run major release of `docusaurus-theme`.

- [x] Confirm `docusaurus-preset/package.json` is included in the release commit
- [x] Confirm the theme peer dependency is updated
- [x] Confirm `git status --short` is clean