### PR TITLE
[ESLint] Add callout usage rules

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -157,6 +157,44 @@ Ensure that all radio input components (`EuiRadio`, `EuiRadioGroup`) have a `nam
 
 Ensure that `EuiCallOut` components rendered conditionally have the `announceOnMount` prop for better accessibility. When callouts appear dynamically (e.g., after user interactions, form validation errors, or status changes), screen readers may not announce their content to users. The `announceOnMount` prop ensures these messages are properly announced to users with assistive technologies.
 
+### `@elastic/eui/callout-prefer-props-for-content`
+
+Enforce correct usage of `EuiCallOut` `text` and `actionProps` props and discourage using `children` for content.
+
+`EuiCallOut` accepts dedicated `text` and `actionProps` props introduced to standardize callout content:
+
+- **Text content** (plain text, `<p>`, `<span>`, `<strong>`, etc. or EUI text components like `EuiText`) should be passed via the `text` prop.
+- **Action elements** (buttons and non-inline links) should be passed via `actionProps`, which renders standardized primary and secondary action buttons.
+
+The rule warns (rather than errors) to allow incremental migration from the `children` pattern.
+
+#### Examples
+
+```tsx
+// ✗ Flagged — text content via children
+<EuiCallOut title="Title">
+  <p>Callout body text.</p>
+</EuiCallOut>
+
+// ✓ Good
+<EuiCallOut title="Title" text={<p>Callout body text.</p>} />
+```
+
+```tsx
+// ✗ Flagged — action button via children
+<EuiCallOut title="Title">
+  <EuiButton onClick={onClick}>Take action</EuiButton>
+</EuiCallOut>
+
+// ✓ Good
+<EuiCallOut
+  title="Title"
+  actionProps={{ primary: { children: 'Take action', onClick: onClick } }}
+/>
+```
+
+The rule traverses fragments (`<>`, `<React.Fragment>`, `<Fragment>`), layout containers (`EuiFlexGroup`, `EuiFlexGrid`, `EuiFlexItem`, `div`), and conditional/logical expressions. It does not traverse custom component children, since their content cannot be statically analyzed.
+
 ### `@elastic/eui/no-unnamed-interactive-element`
 
 Ensure that appropriate aria-attributes are set for `EuiBetaBadge`, `EuiButtonIcon`, `EuiComboBox`, `EuiSelect`, `EuiSelectWithWidth`,`EuiSuperSelect`,`EuiPagination`, `EuiTreeView`, `EuiBreadcrumbs`. Without this rule, screen reader users lose context, keyboard navigation can be confusing.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -195,6 +195,19 @@ The rule warns (rather than errors) to allow incremental migration from the `chi
 
 The rule traverses fragments (`<>`, `<React.Fragment>`, `<Fragment>`), layout containers (`EuiFlexGroup`, `EuiFlexGrid`, `EuiFlexItem`, `div`), and conditional/logical expressions. It does not traverse custom component children, since their content cannot be statically analyzed.
 
+#### Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `components` | `string[]` | `['EuiCallOut']` | Component names to check. Replaces the default — include `'EuiCallOut'` explicitly if you also want to keep checking it. |
+
+```js
+// .eslintrc.js
+'@elastic/eui/callout-prefer-props-for-content': ['warn', {
+  components: ['EuiCallOut', 'KbnWarningCallout'],
+}]
+```
+
 ### `@elastic/eui/no-unnamed-interactive-element`
 
 Ensure that appropriate aria-attributes are set for `EuiBetaBadge`, `EuiButtonIcon`, `EuiComboBox`, `EuiSelect`, `EuiSelectWithWidth`,`EuiSuperSelect`,`EuiPagination`, `EuiTreeView`, `EuiBreadcrumbs`. Without this rule, screen reader users lose context, keyboard navigation can be confusing.

--- a/packages/eslint-plugin/changelogs/upcoming/9821.md
+++ b/packages/eslint-plugin/changelogs/upcoming/9821.md
@@ -1,0 +1,1 @@
+- Added `callout-prefer-props-for-content` rule

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -8,6 +8,7 @@
 
 import { AccessibleInteractiveElements } from './rules/a11y/accessible_interactive_element';
 import { CallOutAnnounceOnMount } from './rules/a11y/callout_announce_on_mount';
+import { CallOutPreferPropsForContent } from './rules/callout_prefer_props_for_content';
 import { ConsistentIsInvalidProps } from './rules/a11y/consistent_is_invalid_props';
 import { HrefOnClick } from './rules/href_or_on_click';
 import { RequireHrefForLink } from './rules/require_href_for_link';
@@ -31,6 +32,7 @@ const config = {
   rules: {
     'accessible-interactive-element': AccessibleInteractiveElements,
     'callout-announce-on-mount': CallOutAnnounceOnMount,
+    'callout-prefer-props-for-content': CallOutPreferPropsForContent,
     'consistent-is-invalid-props': ConsistentIsInvalidProps,
     'href-or-on-click': HrefOnClick,
     'no-css-color': NoCssColor,
@@ -57,6 +59,7 @@ const config = {
       rules: {
         '@elastic/eui/accessible-interactive-element': 'warn',
         '@elastic/eui/callout-announce-on-mount': 'warn',
+        '@elastic/eui/callout-prefer-props-for-content': 'warn',
         '@elastic/eui/consistent-is-invalid-props': 'warn',
         '@elastic/eui/href-or-on-click': 'warn',
         '@elastic/eui/no-css-color': 'warn',

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
@@ -464,6 +464,58 @@ ruleTester.run(
         languageOptions,
         errors: [{ messageId: 'childrenHavePlainText' }],
       },
+      // Template literals
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            {\`Plain text content.\`}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHavePlainText' }],
+      },
+      {
+        code: dedent`
+        const MyComponent = ({ name }) => (
+          <EuiCallOut title="Callout title">
+            {\`Hello \${name}!\`}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHavePlainText' }],
+      },
+      // Array expressions
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            {[<p key="1">Text</p>]}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+      },
+      // i18n FormattedMessage
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <FormattedMessage id="my.message" defaultMessage="Callout body text." />
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'FormattedMessage' },
+          },
+        ],
+      },
     ],
   }
 );

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
@@ -166,19 +166,6 @@ ruleTester.run(
         code: dedent`
         const MyComponent = () => (
           <EuiCallOut title="Callout title">
-            <>
-              <p>Fragment wrapped text.</p>
-            </>
-          </EuiCallOut>
-        )
-      `,
-        languageOptions,
-        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
-      },
-      {
-        code: dedent`
-        const MyComponent = () => (
-          <EuiCallOut title="Callout title">
             Some plain text content.
           </EuiCallOut>
         )
@@ -401,7 +388,7 @@ ruleTester.run(
           },
         ],
       },
-      // EuiFlexGrid is a transparent layout wrapper, traverse its children
+      // Fragments
       {
         code: dedent`
         const MyComponent = () => (
@@ -426,7 +413,19 @@ ruleTester.run(
           },
         ],
       },
-      // React.Fragment (named form) — children must be traversed
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <>
+              <p>Fragment wrapped text.</p>
+            </>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+      },
       {
         code: dedent`
         const MyComponent = () => (
@@ -434,6 +433,19 @@ ruleTester.run(
             <React.Fragment>
               <p>Fragment wrapped text.</p>
             </React.Fragment>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <Fragment>
+              <p>Fragment wrapped text.</p>
+            </Fragment>
           </EuiCallOut>
         )
       `,

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
@@ -499,6 +499,18 @@ ruleTester.run(
         languageOptions,
         errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
       },
+      // MemberExpression (e.g. i18n string references)
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            {i18n.NO_DIFF_AVAILABLE_CALLOUT}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHavePlainText' }],
+      },
       // i18n FormattedMessage
       {
         code: dedent`

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
@@ -94,6 +94,29 @@ ruleTester.run(
       `,
         languageOptions,
       },
+      {
+        // Custom component is not flagged if not listed in the config
+        code: dedent`
+        const MyComponent = () => (
+          <KbnWarningCallout title="Callout title">
+            <p>Text content</p>
+          </KbnWarningCallout>
+        )
+      `,
+        languageOptions,
+      },
+      {
+        // EuiCallOut is not flagged when the components option replaces the default
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <p>Text content</p>
+          </EuiCallOut>
+        )
+      `,
+        options: [{ components: ['KbnWarningCallout'] }],
+        languageOptions,
+      },
     ],
     invalid: [
       // `text` prop
@@ -106,7 +129,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
+        ],
       },
       {
         code: dedent`
@@ -118,7 +146,10 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'span' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'span', componentName: 'EuiCallOut' },
+          },
         ],
       },
       {
@@ -131,7 +162,10 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'strong' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'strong', componentName: 'EuiCallOut' },
+          },
         ],
       },
       {
@@ -144,7 +178,10 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'EuiText' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'EuiText', componentName: 'EuiCallOut' },
+          },
         ],
       },
       {
@@ -157,7 +194,10 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'EuiText' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'EuiText', componentName: 'EuiCallOut' },
+          },
         ],
       },
       {
@@ -170,7 +210,10 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'EuiCode' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'EuiCode', componentName: 'EuiCallOut' },
+          },
         ],
       },
       {
@@ -185,6 +228,7 @@ ruleTester.run(
         errors: [
           {
             messageId: 'childrenHavePlainText',
+            data: { componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -200,10 +244,13 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'p' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButton' },
+            data: { elementName: 'EuiButton', componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -219,7 +266,7 @@ ruleTester.run(
         errors: [
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButton' },
+            data: { elementName: 'EuiButton', componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -235,7 +282,10 @@ ruleTester.run(
         errors: [
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButtonEmpty' },
+            data: {
+              elementName: 'EuiButtonEmpty',
+              componentName: 'EuiCallOut',
+            },
           },
         ],
       },
@@ -251,7 +301,7 @@ ruleTester.run(
         errors: [
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButtonIcon' },
+            data: { elementName: 'EuiButtonIcon', componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -268,7 +318,10 @@ ruleTester.run(
         errors: [
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButtonGroup' },
+            data: {
+              elementName: 'EuiButtonGroup',
+              componentName: 'EuiCallOut',
+            },
           },
         ],
       },
@@ -282,7 +335,10 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveActions', data: { elementName: 'button' } },
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'button', componentName: 'EuiCallOut' },
+          },
         ],
       },
       {
@@ -297,7 +353,7 @@ ruleTester.run(
         errors: [
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiLink' },
+            data: { elementName: 'EuiLink', componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -311,7 +367,10 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveActions', data: { elementName: 'a' } },
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'a', componentName: 'EuiCallOut' },
+          },
         ],
       },
       // Logical expressions
@@ -324,7 +383,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
+        ],
       },
       // Conditional expressions
       {
@@ -336,7 +400,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
+        ],
       },
       {
         code: dedent`
@@ -350,7 +419,7 @@ ruleTester.run(
         errors: [
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButton' },
+            data: { elementName: 'EuiButton', componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -372,10 +441,13 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'p' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButton' },
+            data: { elementName: 'EuiButton', componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -392,10 +464,13 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'p' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButton' },
+            data: { elementName: 'EuiButton', componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -417,10 +492,13 @@ ruleTester.run(
       `,
         languageOptions,
         errors: [
-          { messageId: 'childrenHaveText', data: { elementName: 'p' } },
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
           {
             messageId: 'childrenHaveActions',
-            data: { elementName: 'EuiButton' },
+            data: { elementName: 'EuiButton', componentName: 'EuiCallOut' },
           },
         ],
       },
@@ -435,7 +513,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
+        ],
       },
       {
         code: dedent`
@@ -448,7 +531,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
+        ],
       },
       {
         code: dedent`
@@ -461,7 +549,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
+        ],
       },
       // String literal in JSX expression container
       {
@@ -473,7 +566,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHavePlainText' }],
+        errors: [
+          {
+            messageId: 'childrenHavePlainText',
+            data: { componentName: 'EuiCallOut' },
+          },
+        ],
       },
       // Template literals
       {
@@ -485,7 +583,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHavePlainText' }],
+        errors: [
+          {
+            messageId: 'childrenHavePlainText',
+            data: { componentName: 'EuiCallOut' },
+          },
+        ],
       },
       {
         code: dedent`
@@ -496,7 +599,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHavePlainText' }],
+        errors: [
+          {
+            messageId: 'childrenHavePlainText',
+            data: { componentName: 'EuiCallOut' },
+          },
+        ],
       },
       // Array expressions
       {
@@ -508,7 +616,59 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
+        ],
+      },
+      // `components` option
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <KbnWarningCallout title="Callout title">
+            <p>Text content</p>
+          </KbnWarningCallout>
+        )
+      `,
+        options: [{ components: ['KbnWarningCallout'] }],
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'KbnWarningCallout' },
+          },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <>
+            <EuiCallOut title="Callout title">
+              <p>Text content</p>
+            </EuiCallOut>
+            <KbnWarningCallout title="Callout title">
+              <EuiButton onClick={onClick}>Button</EuiButton>
+            </KbnWarningCallout>
+          </>
+        )
+      `,
+        options: [{ components: ['EuiCallOut', 'KbnWarningCallout'] }],
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveText',
+            data: { elementName: 'p', componentName: 'EuiCallOut' },
+          },
+          {
+            messageId: 'childrenHaveActions',
+            data: {
+              elementName: 'EuiButton',
+              componentName: 'KbnWarningCallout',
+            },
+          },
+        ],
       },
       // i18n MemberExpression
       {
@@ -520,7 +680,12 @@ ruleTester.run(
         )
       `,
         languageOptions,
-        errors: [{ messageId: 'childrenHavePlainText' }],
+        errors: [
+          {
+            messageId: 'childrenHavePlainText',
+            data: { componentName: 'EuiCallOut' },
+          },
+        ],
       },
       // i18n FormattedMessage
       {
@@ -535,7 +700,10 @@ ruleTester.run(
         errors: [
           {
             messageId: 'childrenHaveText',
-            data: { elementName: 'FormattedMessage' },
+            data: {
+              elementName: 'FormattedMessage',
+              componentName: 'EuiCallOut',
+            },
           },
         ],
       },

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
@@ -59,6 +59,17 @@ ruleTester.run(
         languageOptions,
       },
       {
+        // Non-i18n MemberExpression: ambiguous (simple text or complex content)
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            {config.description}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+      },
+      {
         // Nested text inside a custom component: It's acceptable as we don't know what's inside the custom component
         code: dedent`
         const MyComponent = () => (
@@ -499,7 +510,7 @@ ruleTester.run(
         languageOptions,
         errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
       },
-      // MemberExpression (e.g. i18n string references)
+      // i18n MemberExpression
       {
         code: dedent`
         const MyComponent = () => (

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.test.ts
@@ -1,0 +1,457 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { CallOutPreferPropsForContent } from './callout_prefer_props_for_content';
+
+const languageOptions = {
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+};
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(
+  'callout-prefer-props-for-content',
+  CallOutPreferPropsForContent,
+  {
+    valid: [
+      {
+        // `text` prop used correctly
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title" text={<p>Callout text content</p>} />
+        )
+      `,
+        languageOptions,
+      },
+      {
+        // `actionProps` used correctly
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut
+            title="Callout title"
+            actionProps={{ primary: { children: 'Primary action', onClick: onClick } }}
+          />
+        )
+      `,
+        languageOptions,
+      },
+      {
+        // Custom non-text content: It's acceptable as we don't know what's the content
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <MyComplexWidget data={someData} />
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+      },
+      {
+        // Nested text inside a custom component: It's acceptable as we don't know what's inside the custom component
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <ComplexLayout>
+              <p>Nested text inside complex content</p>
+            </ComplexLayout>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+      },
+      {
+        // Other components are not flagged
+        code: dedent`
+        const MyComponent = () => (
+          <EuiPanel>
+            <p>Text content</p>
+            <EuiButton>Action</EuiButton>
+          </EuiPanel>
+        )
+      `,
+        languageOptions,
+      },
+    ],
+    invalid: [
+      // `text` prop
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <p>Callout text content</p>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <span>Callout text content</span>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'span' } },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <strong>Callout text content</strong>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'strong' } },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiText>Callout text content</EuiText>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'EuiText' } },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiText><p>Callout text content</p></EuiText>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'EuiText' } },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiCode>Callout content</EuiCode>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'EuiCode' } },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <>
+              <p>Fragment wrapped text.</p>
+            </>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            Some plain text content.
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHavePlainText',
+          },
+        ],
+      },
+      // `actionProps` prop
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <p>Some text.</p>
+            <EuiButton onClick={onClick}>Do it</EuiButton>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'p' } },
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButton' },
+          },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiButton onClick={onClick}>Button</EuiButton>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButton' },
+          },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiButtonEmpty onClick={onClick}>Button</EuiButtonEmpty>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButtonEmpty' },
+          },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiButtonIcon onClick={onClick}>Button</EuiButtonIcon>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButtonIcon' },
+          },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+        
+          <EuiCallOut title="Callout title">
+            <EuiButtonGroup options={options} onChange={onClick}>Button</EuiButtonGroup>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButtonGroup' },
+          },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <button type="button" onClick={onClick}>Button</button>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveActions', data: { elementName: 'button' } },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiLink href="/">Link</EuiLink>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiLink' },
+          },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <a href="/">Link</a>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveActions', data: { elementName: 'a' } },
+        ],
+      },
+      // Logical expressions
+      {
+        code: dedent`
+        const MyComponent = ({ show }) => (
+          <EuiCallOut title="Callout title">
+            {show && <p>Conditionally shown text.</p>}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+      },
+      // Conditional expressions
+      {
+        code: dedent`
+        const MyComponent = ({ condition }) => (
+          <EuiCallOut title="Callout title">
+            {condition ? <p>Text when true.</p> : null}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+      },
+      {
+        code: dedent`
+        const MyComponent = ({ condition }) => (
+          <EuiCallOut title="Callout title">
+            {condition ? null : <EuiButton onClick={onClick}>Button</EuiButton>}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButton' },
+          },
+        ],
+      },
+      // Nested text & actions
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiFlexGroup>
+              <EuiFlexItem>
+                <p>Callout text content</p>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton onClick={onClick}>Button</EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'p' } },
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButton' },
+          },
+        ],
+      },
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <div>
+              <p>Callout text content</p>
+              <EuiButton onClick={onClick}>Button</EuiButton>
+            </div>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'p' } },
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButton' },
+          },
+        ],
+      },
+      // EuiFlexGrid is a transparent layout wrapper, traverse its children
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <EuiFlexGrid columns={2}>
+              <EuiFlexItem>
+                <p>Callout text content</p>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton onClick={onClick}>Button</EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGrid>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [
+          { messageId: 'childrenHaveText', data: { elementName: 'p' } },
+          {
+            messageId: 'childrenHaveActions',
+            data: { elementName: 'EuiButton' },
+          },
+        ],
+      },
+      // React.Fragment (named form) — children must be traversed
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            <React.Fragment>
+              <p>Fragment wrapped text.</p>
+            </React.Fragment>
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHaveText', data: { elementName: 'p' } }],
+      },
+      // String literal in JSX expression container
+      {
+        code: dedent`
+        const MyComponent = () => (
+          <EuiCallOut title="Callout title">
+            {'Plain text content.'}
+          </EuiCallOut>
+        )
+      `,
+        languageOptions,
+        errors: [{ messageId: 'childrenHavePlainText' }],
+      },
+    ],
+  }
+);

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
@@ -15,6 +15,7 @@ import {
   EUI_TEXT_COMPONENTS,
   HTML_ACTION_ELEMENTS,
   CALLOUT_LAYOUT_CONTAINERS,
+  I18N_TEXT_COMPONENTS,
 } from '../utils/constants';
 import { getElementName } from '../utils/get_element_name';
 
@@ -73,7 +74,8 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
 
       if (
         HTML_TEXT_ELEMENTS.has(elementName) ||
-        EUI_TEXT_COMPONENTS.has(elementName)
+        EUI_TEXT_COMPONENTS.has(elementName) ||
+        I18N_TEXT_COMPONENTS.has(elementName)
       ) {
         context.report({
           node,
@@ -104,6 +106,16 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
         checkNode(child, context);
       }
 
+      break;
+    }
+    case 'TemplateLiteral': {
+      context.report({ node, messageId: 'childrenHavePlainText' });
+      break;
+    }
+    case 'ArrayExpression': {
+      for (const element of (node as TSESTree.ArrayExpression).elements) {
+        if (element) checkNode(element, context);
+      }
       break;
     }
     case 'JSXExpressionContainer': {

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { type TSESTree, ESLintUtils } from '@typescript-eslint/utils';
+
+import { INTERACTIVE_EUI_COMPONENTS } from '../utils/constants';
+
+const COMPONENT_NAME = 'EuiCallOut';
+
+const HTML_TEXT_ELEMENTS = new Set([
+  'p',
+  'span',
+  'strong',
+  'em',
+  'b',
+  'i',
+  'small',
+  'code',
+]);
+const EUI_TEXT_COMPONENTS = new Set([
+  'EuiText',
+  'EuiTextColor',
+  'EuiTextAlign',
+  'EuiCode',
+  'EuiMark',
+  'EuiHighlight',
+]);
+const HTML_ACTION_ELEMENTS = new Set(['button', 'a']);
+const EUI_ACTION_COMPONENTS = new Set(
+  INTERACTIVE_EUI_COMPONENTS.filter(
+    (c) => c.startsWith('EuiButton') || c === 'EuiLink'
+  )
+);
+
+// Layout container components that should be traversed for text/action elements.
+const LAYOUT_CONTAINERS = new Set(['EuiFlexGroup', 'EuiFlexGrid', 'EuiFlexItem', 'div']);
+
+type RuleContext = Parameters<
+  Parameters<typeof ESLintUtils.RuleCreator.withoutDocs>[0]['create']
+>[0];
+
+function getElementName(
+  openingElement: TSESTree.JSXOpeningElement
+): string | null {
+  const { name } = openingElement;
+
+  if (name.type === 'JSXIdentifier') return name.name;
+
+  return null;
+}
+
+/**
+ * Recursively checks a node for text or action elements that should not be in EuiCallOut children.
+ * It unwraps fragments, layout containers, conditional expressions, and logical expressions.
+ * It does NOT traverse into custom/complex component children.
+ */
+function checkNode(node: TSESTree.Node, context: RuleContext): void {
+  switch (node.type) {
+    case 'JSXText': {
+      // Plain string content
+      if ((node as TSESTree.JSXText).value.trim().length > 0) {
+        context.report({ node, messageId: 'childrenHavePlainText' });
+      }
+      break;
+    }
+    case 'Literal': {
+      const { value } = node as TSESTree.Literal;
+
+      if (typeof value === 'string' && value.trim().length > 0) {
+        context.report({ node, messageId: 'childrenHavePlainText' });
+      }
+      break;
+    }
+    case 'JSXElement': {
+      const el = node as TSESTree.JSXElement;
+      const { name } = el.openingElement;
+
+      if (
+        name.type === 'JSXMemberExpression' &&
+        name.object.type === 'JSXIdentifier' &&
+        name.object.name === 'React' &&
+        name.property.type === 'JSXIdentifier' &&
+        name.property.name === 'Fragment'
+      ) {
+        for (const child of el.children) {
+          checkNode(child, context);
+        }
+        break;
+      }
+
+      const elementName = getElementName(el.openingElement);
+
+      if (!elementName) return;
+
+      if (
+        HTML_TEXT_ELEMENTS.has(elementName) ||
+        EUI_TEXT_COMPONENTS.has(elementName)
+      ) {
+        context.report({
+          node,
+          messageId: 'childrenHaveText',
+          data: { elementName },
+        });
+      } else if (
+        HTML_ACTION_ELEMENTS.has(elementName) ||
+        EUI_ACTION_COMPONENTS.has(elementName)
+      ) {
+        context.report({
+          node,
+          messageId: 'childrenHaveActions',
+          data: { elementName },
+        });
+      } else if (LAYOUT_CONTAINERS.has(elementName)) {
+        // Transparent layout wrapper, traverse its children
+        for (const child of el.children) {
+          checkNode(child, context);
+        }
+      }
+
+      // Custom/complex component, don't traverse its children
+      break;
+    }
+    case 'JSXFragment': {
+      for (const child of (node as TSESTree.JSXFragment).children) {
+        checkNode(child, context);
+      }
+
+      break;
+    }
+    case 'JSXExpressionContainer': {
+      const { expression } = node as TSESTree.JSXExpressionContainer;
+
+      if (expression.type !== 'JSXEmptyExpression') {
+        checkNode(expression, context);
+      }
+
+      break;
+    }
+    case 'LogicalExpression': {
+      const { left, right } = node as TSESTree.LogicalExpression;
+
+      checkNode(left, context);
+      checkNode(right, context);
+
+      break;
+    }
+    case 'ConditionalExpression': {
+      // e.g. {condition ? <p>text</p> : null}
+      const { consequent, alternate } = node as TSESTree.ConditionalExpression;
+
+      checkNode(consequent, context);
+      checkNode(alternate, context);
+
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+export const CallOutPreferPropsForContent = ESLintUtils.RuleCreator.withoutDocs(
+  {
+    create(context) {
+      return {
+        JSXElement(node) {
+          const { openingElement, children } = node;
+
+          if (
+            openingElement.name.type !== 'JSXIdentifier' ||
+            openingElement.name.name !== COMPONENT_NAME
+          ) {
+            return;
+          }
+
+          for (const child of children) {
+            checkNode(child, context);
+          }
+        },
+      };
+    },
+    meta: {
+      type: 'suggestion',
+      docs: {
+        description: [
+          `Enforce correct usage of ${COMPONENT_NAME} \`text\` and \`actionProps\` props and discourage using \`children\` for content.`,
+          'Text elements should be passed via the `text` prop.',
+          'Action elements (buttons, links) should be passed via `actionProps` instead.',
+        ].join(' '),
+      },
+      schema: [],
+      messages: {
+        childrenHavePlainText: [
+          'Plain text passed as `children` of `EuiCallOut` should be moved to the `text` prop instead.',
+          'Example:',
+          '  <EuiCallOut title="Callout title" text="Callout text content" />',
+        ].join('\n'),
+        childrenHaveText: [
+          '`<{{elementName}}>` passed as `children` of `EuiCallOut` should be moved to the `text` prop instead.',
+          'The `text` prop accepts string text, block text elements (e.g. `<p>`) or inline elements (e.g. `<span>`, `<strong>`, `<em>`).',
+          'Use `children` only for complex non-text content that cannot be expressed via `text`.',
+          'Example:',
+          '  <EuiCallOut title="Callout title" text={<p>Callout text content</p>} />',
+        ].join('\n'),
+        childrenHaveActions: [
+          '`<{{elementName}}>` passed as `children` of `EuiCallOut` should be moved to the `actionProps` prop instead.',
+          'Use `actionProps` to render standardized primary or secondary action buttons, including buttons-as-links via `href`.',
+          'If a link is part of inline copy, move the surrounding content to the `text` prop instead.',
+          'Example:',
+          '  <EuiCallOut',
+          '    title="Callout title"',
+          '    actionProps={{ primary: { children: "Primary action", onClick: onClick }, secondary: { children: "Secondary action", href: "/"} }}',
+          '  />',
+        ].join('\n'),
+      },
+    },
+    defaultOptions: [],
+  }
+);

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
@@ -19,7 +19,7 @@ import {
 } from '../utils/constants';
 import { getElementName } from '../utils/get_element_name';
 
-const COMPONENT_NAME = 'EuiCallOut';
+const DEFAULT_COMPONENTS = ['EuiCallOut'];
 
 const EUI_ACTION_COMPONENTS = new Set(
   INTERACTIVE_EUI_COMPONENTS.filter(
@@ -27,19 +27,27 @@ const EUI_ACTION_COMPONENTS = new Set(
   )
 );
 
-type MessageIds = 'childrenHavePlainText' | 'childrenHaveText' | 'childrenHaveActions';
+type MessageIds =
+  | 'childrenHavePlainText'
+  | 'childrenHaveText'
+  | 'childrenHaveActions';
+type Options = [{ components?: string[] }];
 
 /**
- * Recursively checks a node for text or action elements that should not be in EuiCallOut children.
+ * Recursively checks a node for text or action elements that should not be in callout children.
  * It unwraps fragments, layout containers, conditional expressions, and logical expressions.
  * It does NOT traverse into custom/complex component children.
  */
-function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): void {
+function checkNode(
+  node: TSESTree.Node,
+  context: RuleContext<MessageIds, Options>,
+  componentName: string
+): void {
   switch (node.type) {
     case 'JSXText': {
       // Plain string content
       if ((node as TSESTree.JSXText).value.trim().length > 0) {
-        context.report({ node, messageId: 'childrenHavePlainText' });
+        context.report({ node, messageId: 'childrenHavePlainText', data: { componentName } });
       }
       break;
     }
@@ -47,7 +55,7 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
       const { value } = node as TSESTree.Literal;
 
       if (typeof value === 'string' && value.trim().length > 0) {
-        context.report({ node, messageId: 'childrenHavePlainText' });
+        context.report({ node, messageId: 'childrenHavePlainText', data: { componentName } });
       }
       break;
     }
@@ -63,7 +71,7 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
         name.property.name === 'Fragment'
       ) {
         for (const child of el.children) {
-          checkNode(child, context);
+          checkNode(child, context, componentName);
         }
         break;
       }
@@ -80,7 +88,7 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
         context.report({
           node,
           messageId: 'childrenHaveText',
-          data: { elementName },
+          data: { elementName, componentName },
         });
       } else if (
         HTML_ACTION_ELEMENTS.has(elementName) ||
@@ -89,12 +97,12 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
         context.report({
           node,
           messageId: 'childrenHaveActions',
-          data: { elementName },
+          data: { elementName, componentName },
         });
       } else if (CALLOUT_LAYOUT_CONTAINERS.has(elementName)) {
         // Transparent layout wrapper, traverse its children
         for (const child of el.children) {
-          checkNode(child, context);
+          checkNode(child, context, componentName);
         }
       }
 
@@ -103,7 +111,7 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
     }
     case 'JSXFragment': {
       for (const child of (node as TSESTree.JSXFragment).children) {
-        checkNode(child, context);
+        checkNode(child, context, componentName);
       }
 
       break;
@@ -112,17 +120,17 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
       const { object } = node as TSESTree.MemberExpression;
 
       if (object.type === 'Identifier' && object.name === 'i18n') {
-        context.report({ node, messageId: 'childrenHavePlainText' });
+        context.report({ node, messageId: 'childrenHavePlainText', data: { componentName } });
       }
       break;
     }
     case 'TemplateLiteral': {
-      context.report({ node, messageId: 'childrenHavePlainText' });
+      context.report({ node, messageId: 'childrenHavePlainText', data: { componentName } });
       break;
     }
     case 'ArrayExpression': {
       for (const element of (node as TSESTree.ArrayExpression).elements) {
-        if (element) checkNode(element, context);
+        if (element) checkNode(element, context, componentName);
       }
       break;
     }
@@ -130,7 +138,7 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
       const { expression } = node as TSESTree.JSXExpressionContainer;
 
       if (expression.type !== 'JSXEmptyExpression') {
-        checkNode(expression, context);
+        checkNode(expression, context, componentName);
       }
 
       break;
@@ -138,8 +146,8 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
     case 'LogicalExpression': {
       const { left, right } = node as TSESTree.LogicalExpression;
 
-      checkNode(left, context);
-      checkNode(right, context);
+      checkNode(left, context, componentName);
+      checkNode(right, context, componentName);
 
       break;
     }
@@ -147,8 +155,8 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
       // e.g. {condition ? <p>text</p> : null}
       const { consequent, alternate } = node as TSESTree.ConditionalExpression;
 
-      checkNode(consequent, context);
-      checkNode(alternate, context);
+      checkNode(consequent, context, componentName);
+      checkNode(alternate, context, componentName);
 
       break;
     }
@@ -157,22 +165,26 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
   }
 }
 
-export const CallOutPreferPropsForContent = ESLintUtils.RuleCreator.withoutDocs(
+export const CallOutPreferPropsForContent = ESLintUtils.RuleCreator.withoutDocs<Options, MessageIds>(
   {
     create(context) {
+      const components = new Set(
+        context.options[0]?.components ?? DEFAULT_COMPONENTS
+      );
+
       return {
         JSXElement(node) {
           const { openingElement, children } = node;
 
           if (
             openingElement.name.type !== 'JSXIdentifier' ||
-            openingElement.name.name !== COMPONENT_NAME
+            !components.has(openingElement.name.name)
           ) {
             return;
           }
 
           for (const child of children) {
-            checkNode(child, context);
+            checkNode(child, context, openingElement.name.name);
           }
         },
       };
@@ -181,37 +193,49 @@ export const CallOutPreferPropsForContent = ESLintUtils.RuleCreator.withoutDocs(
       type: 'suggestion',
       docs: {
         description: [
-          `Enforce correct usage of ${COMPONENT_NAME} \`text\` and \`actionProps\` props and discourage using \`children\` for content.`,
+          'Enforce correct usage of `text` and `actionProps` props and discourage using `children` for content.',
           'Text elements should be passed via the `text` prop.',
           'Action elements (buttons, links) should be passed via `actionProps` instead.',
         ].join(' '),
       },
-      schema: [],
+      schema: [
+        {
+          type: 'object',
+          properties: {
+            components: {
+              type: 'array',
+              items: { type: 'string', minLength: 1 },
+              minItems: 1,
+            },
+          },
+          additionalProperties: false,
+        },
+      ],
       messages: {
         childrenHavePlainText: [
-          'Plain text passed as `children` of `EuiCallOut` should be moved to the `text` prop instead.',
+          'Plain text passed as `children` of `{{componentName}}` should be moved to the `text` prop instead.',
           'Example:',
-          '  <EuiCallOut title="Callout title" text="Callout text content" />',
+          '  <{{componentName}} title="Callout title" text="Callout text content" />',
         ].join('\n'),
         childrenHaveText: [
-          '`<{{elementName}}>` passed as `children` of `EuiCallOut` should be moved to the `text` prop instead.',
+          '`<{{elementName}}>` passed as `children` of `{{componentName}}` should be moved to the `text` prop instead.',
           'The `text` prop accepts string text, block text elements (e.g. `<p>`) or inline elements (e.g. `<span>`, `<strong>`, `<em>`).',
           'Use `children` only for complex non-text content that cannot be expressed via `text`.',
           'Example:',
-          '  <EuiCallOut title="Callout title" text={<p>Callout text content</p>} />',
+          '  <{{componentName}} title="Callout title" text={<p>Callout text content</p>} />',
         ].join('\n'),
         childrenHaveActions: [
-          '`<{{elementName}}>` passed as `children` of `EuiCallOut` should be moved to the `actionProps` prop instead.',
+          '`<{{elementName}}>` passed as `children` of `{{componentName}}` should be moved to the `actionProps` prop instead.',
           'Use `actionProps` to render standardized primary or secondary action buttons, including buttons-as-links via `href`.',
           'If a link is part of inline copy, move the surrounding content to the `text` prop instead.',
           'Example:',
-          '  <EuiCallOut',
+          '  <{{componentName}}',
           '    title="Callout title"',
           '    actionProps={{ primary: { children: "Primary action", onClick: onClick }, secondary: { children: "Secondary action", href: "/"} }}',
           '  />',
         ].join('\n'),
       },
     },
-    defaultOptions: [],
+    defaultOptions: [{}],
   }
 );

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
@@ -38,7 +38,7 @@ const EUI_ACTION_COMPONENTS = new Set(
 );
 
 // Layout container components that should be traversed for text/action elements.
-const LAYOUT_CONTAINERS = new Set(['EuiFlexGroup', 'EuiFlexGrid', 'EuiFlexItem', 'div']);
+const LAYOUT_CONTAINERS = new Set(['Fragment', 'EuiFlexGroup', 'EuiFlexGrid', 'EuiFlexItem', 'div']);
 
 type RuleContext = Parameters<
   Parameters<typeof ESLintUtils.RuleCreator.withoutDocs>[0]['create']

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
@@ -108,6 +108,10 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
 
       break;
     }
+    case 'MemberExpression': {
+      context.report({ node, messageId: 'childrenHavePlainText' });
+      break;
+    }
     case 'TemplateLiteral': {
       context.report({ node, messageId: 'childrenHavePlainText' });
       break;

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
@@ -109,7 +109,11 @@ function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): v
       break;
     }
     case 'MemberExpression': {
-      context.report({ node, messageId: 'childrenHavePlainText' });
+      const { object } = node as TSESTree.MemberExpression;
+
+      if (object.type === 'Identifier' && object.name === 'i18n') {
+        context.report({ node, messageId: 'childrenHavePlainText' });
+      }
       break;
     }
     case 'TemplateLiteral': {

--- a/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
+++ b/packages/eslint-plugin/src/rules/callout_prefer_props_for_content.ts
@@ -7,59 +7,33 @@
  */
 
 import { type TSESTree, ESLintUtils } from '@typescript-eslint/utils';
+import { type RuleContext } from '@typescript-eslint/utils/ts-eslint';
 
-import { INTERACTIVE_EUI_COMPONENTS } from '../utils/constants';
+import {
+  INTERACTIVE_EUI_COMPONENTS,
+  HTML_TEXT_ELEMENTS,
+  EUI_TEXT_COMPONENTS,
+  HTML_ACTION_ELEMENTS,
+  CALLOUT_LAYOUT_CONTAINERS,
+} from '../utils/constants';
+import { getElementName } from '../utils/get_element_name';
 
 const COMPONENT_NAME = 'EuiCallOut';
 
-const HTML_TEXT_ELEMENTS = new Set([
-  'p',
-  'span',
-  'strong',
-  'em',
-  'b',
-  'i',
-  'small',
-  'code',
-]);
-const EUI_TEXT_COMPONENTS = new Set([
-  'EuiText',
-  'EuiTextColor',
-  'EuiTextAlign',
-  'EuiCode',
-  'EuiMark',
-  'EuiHighlight',
-]);
-const HTML_ACTION_ELEMENTS = new Set(['button', 'a']);
 const EUI_ACTION_COMPONENTS = new Set(
   INTERACTIVE_EUI_COMPONENTS.filter(
     (c) => c.startsWith('EuiButton') || c === 'EuiLink'
   )
 );
 
-// Layout container components that should be traversed for text/action elements.
-const LAYOUT_CONTAINERS = new Set(['Fragment', 'EuiFlexGroup', 'EuiFlexGrid', 'EuiFlexItem', 'div']);
-
-type RuleContext = Parameters<
-  Parameters<typeof ESLintUtils.RuleCreator.withoutDocs>[0]['create']
->[0];
-
-function getElementName(
-  openingElement: TSESTree.JSXOpeningElement
-): string | null {
-  const { name } = openingElement;
-
-  if (name.type === 'JSXIdentifier') return name.name;
-
-  return null;
-}
+type MessageIds = 'childrenHavePlainText' | 'childrenHaveText' | 'childrenHaveActions';
 
 /**
  * Recursively checks a node for text or action elements that should not be in EuiCallOut children.
  * It unwraps fragments, layout containers, conditional expressions, and logical expressions.
  * It does NOT traverse into custom/complex component children.
  */
-function checkNode(node: TSESTree.Node, context: RuleContext): void {
+function checkNode(node: TSESTree.Node, context: RuleContext<MessageIds, []>): void {
   switch (node.type) {
     case 'JSXText': {
       // Plain string content
@@ -115,7 +89,7 @@ function checkNode(node: TSESTree.Node, context: RuleContext): void {
           messageId: 'childrenHaveActions',
           data: { elementName },
         });
-      } else if (LAYOUT_CONTAINERS.has(elementName)) {
+      } else if (CALLOUT_LAYOUT_CONTAINERS.has(elementName)) {
         // Transparent layout wrapper, traverse its children
         for (const child of el.children) {
           checkNode(child, context);

--- a/packages/eslint-plugin/src/utils/constants.ts
+++ b/packages/eslint-plugin/src/utils/constants.ts
@@ -166,3 +166,10 @@ export const CALLOUT_LAYOUT_CONTAINERS = new Set([
   'EuiFlexItem',
   'div',
 ]);
+
+/**
+ * Third-party i18n components that render plain text and are common in EUI consumers
+ * (e.g. `FormattedMessage` from react-intl used extensively in Kibana).
+ * Rules treat these the same as `HTML_TEXT_ELEMENTS` / `EUI_TEXT_COMPONENTS`.
+ */
+export const I18N_TEXT_COMPONENTS = new Set(['FormattedMessage']);

--- a/packages/eslint-plugin/src/utils/constants.ts
+++ b/packages/eslint-plugin/src/utils/constants.ts
@@ -132,3 +132,37 @@ export const CONDITIONALLY_INTERACTIVE_EUI_COMPONENTS = [
   'EuiBetaBadge',
   'EuiCard',
 ];
+
+export const HTML_TEXT_ELEMENTS = new Set([
+  'p',
+  'span',
+  'strong',
+  'em',
+  'b',
+  'i',
+  'small',
+  'code',
+]);
+
+export const EUI_TEXT_COMPONENTS = new Set([
+  'EuiText',
+  'EuiTextColor',
+  'EuiTextAlign',
+  'EuiCode',
+  'EuiMark',
+  'EuiHighlight',
+]);
+
+export const HTML_ACTION_ELEMENTS = new Set(['button', 'a']);
+
+/**
+ * Transparent layout wrappers inside `EuiCallOut` children that the rule should
+ * traverse rather than treat as opaque custom components.
+ */
+export const CALLOUT_LAYOUT_CONTAINERS = new Set([
+  'Fragment',
+  'EuiFlexGroup',
+  'EuiFlexGrid',
+  'EuiFlexItem',
+  'div',
+]);

--- a/packages/eslint-plugin/src/utils/get_element_name.ts
+++ b/packages/eslint-plugin/src/utils/get_element_name.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { type TSESTree } from '@typescript-eslint/utils';
+
+export function getElementName(
+  openingElement: TSESTree.JSXOpeningElement
+): string | null {
+  const { name } = openingElement;
+
+  if (name.type === 'JSXIdentifier') return name.name;
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- **What:** Adds a `EuiCallOut` specific ESLint rule `callout-prefer-props-for-content` to `@elastic/eslint-plugin-eui`.
- **Why:** To help consumers to migrate from the legacy slot usage via `children` to move towards using dedicated props `text` and `actionProps` after updates done in https://github.com/elastic/eui/pull/9642
- **How:** Adds a new rule `callout-prefer-props-for-content` which checks for usages of text and action elements in `children` and flags them. It's set to `warn` to not become a bottleneck while migrating.


### API Changes

⚪ No API changes.

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


<img width="363" height="183" alt="Screenshot 2026-07-20 at 16 28 34" src="https://github.com/user-attachments/assets/5c5c0a08-ece9-4095-9578-f1188b69724c" />
<img width="1208" height="404" alt="Screenshot 2026-07-20 at 16 28 54" src="https://github.com/user-attachments/assets/2a9c2b0a-4b23-4ee9-b5fe-c076ce3a6bcf" />
<img width="1063" height="206" alt="Screenshot 2026-07-20 at 16 29 00" src="https://github.com/user-attachments/assets/b83a11c6-a811-46ab-830d-9186547775b5" />


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [ ] CI is green
- [ ] confirm the new ESLint rule is picked up in EUI and applied for legacy usages, e.g. 
   ```tsx
   <EuiCallOut title="Callout title">
      <p>Callout body</p>
    </EuiCallOut>

    <EuiCallOut title="Callout title">
      <p>Callout body</p>
      <EuiButton>Callout button</EuiButton>
    </EuiCallOut>
   ```

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
