### PR TITLE
[Chore] Use GraphQL query to find Nightly PR

### DIFF
--- a/.github/workflows/update_kibana_dependencies__open_pr.yml
+++ b/.github/workflows/update_kibana_dependencies__open_pr.yml
@@ -114,7 +114,29 @@ jobs:
             )"
 
             # Reuse the open PR for the fixed nightly branch.
-            existing_pr_url="$(gh api "repos/$base_repo/pulls?state=open&head=elastic:$PR_HEAD" --jq '.[0].html_url // ""')"
+            # The REST `head=owner:branch` filter cannot distinguish the base
+            # repository from a fork when both belong to the same organization.
+            existing_pr_url="$(
+              gh api graphql \
+                -f query='
+                  query ($owner: String!, $name: String!, $headRefName: String!) {
+                    repository(owner: $owner, name: $name) {
+                      pullRequests(first: 100, states: OPEN, headRefName: $headRefName) {
+                        nodes {
+                          url
+                          headRepository {
+                            nameWithOwner
+                          }
+                        }
+                      }
+                    }
+                  }' \
+                -f "owner=${base_repo%/*}" \
+                -f "name=${base_repo#*/}" \
+                -f "headRefName=$PR_HEAD" |
+                jq -r --arg head_repo "$head_repo" \
+                  '[.data.repository.pullRequests.nodes[] | select(.headRepository.nameWithOwner == $head_repo)] | first | .url // ""'
+            )"
             if [[ -n "$existing_pr_url" ]]; then
               gh pr edit "$existing_pr_url" --title "$PR_TITLE" --body "${PR_BODY:-}"
               if [[ "$(gh pr view "$existing_pr_url" --json isDraft --jq .isDraft)" != "true" ]]; then


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Fixed Nightly [Open PR job](https://github.com/elastic/eui/actions/runs/29801793921/job/88544149183) failing when the PR already exists.

GitHub REST `head=owner:branch` filter cannot distinguish same-organization forks. Replaced it with a targeted GraphQL query filtering by branch then verified the exact head repository.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

- [ ] You can run the previous query vs the new query and verify the [Nightly PR](https://github.com/elastic/kibana/pull/279387) is found

Previous query:
```bash
gh api 'repos/elastic/kibana/pulls?state=open&head=elastic%3Anightly%2Fupdate-dependencies' \
  --jq '.[0].html_url // ""'
```

New query:
```bash
gh api graphql \
  -f query='
    query ($owner: String!, $name: String!, $headRefName: String!) {
      repository(owner: $owner, name: $name) {
        pullRequests(first: 100, states: OPEN, headRefName: $headRefName) {
          nodes {
            url
            headRepository {
              nameWithOwner
            }
          }
        }
      }
    }' \
  -f owner=elastic \
  -f name=kibana \
  -f headRefName=nightly/update-dependencies |
  jq -r --arg head_repo elastic/eui-kibana \
    '[.data.repository.pullRequests.nodes[] | select(.headRepository.nameWithOwner == $head_repo)] | first | .url // ""'
```

To test the "not found" case, you can update `nightly/update-dependencies` to another, non-existing ref.