### PR TITLE
[Illustrations] Remove sourcemaps

### DIFF
--- a/packages/illustrations/changelogs/upcoming/9824.md
+++ b/packages/illustrations/changelogs/upcoming/9824.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed missing source file warnings by removing sourcemaps from the published ESM build

--- a/packages/illustrations/tsconfig.esm.json
+++ b/packages/illustrations/tsconfig.esm.json
@@ -8,7 +8,6 @@
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",
     "declaration": true,
-    "sourceMap": true,
     "incremental": true,
     "esModuleInterop": true,
     "strict": true,


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Removes `"sourceMap": true` from illustrations package TS config. This causes missing source warnings in consumers. The fix could be adding `src` to `files` in `package.json` but adding sourcemaps gives little debugging value.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

In EUI:

```bash
yarn workspace @elastic/eui-illustrations build-pack
```

In AutoOps:

```bash
cd cloud-ui/autoops
npm install --no-save "file:/absolute/path/elastic-eui-illustrations-1.0.0.tgz"
npm run build
```