### PR TITLE
[Release CLI] Fix changelog check stuck

### DIFF
--- a/packages/release-cli/src/steps/update_versions.ts
+++ b/packages/release-cli/src/steps/update_versions.ts
@@ -132,7 +132,7 @@ export const stepUpdateVersions = async (
     await stageFiles(uniqueFilesToCommit);
 
     // Commit all package.json files and yarn.lock
-    await commitFiles('chore: update package versions [skip ci]', uniqueFilesToCommit);
+    await commitFiles('chore: update package versions', uniqueFilesToCommit);
   }
 
   return changedWorkspaces;


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Noticed on https://github.com/elastic/eui/pull/9825

Removes `[skip ci]` from release version bump commit message. Otherwise, GitHub skips the required changelog workflow but the check is there (the workflow is not prompted). It forces you to merge with bypass on release PRs.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Not manually testable. CI validates that the required changelog check runs.