### PR TITLE
[Release CLI] Build only changed workspaces

### DIFF
--- a/packages/release-cli/src/release.ts
+++ b/packages/release-cli/src/release.ts
@@ -120,13 +120,13 @@ export const release = async (options: ReleaseOptions) => {
 
   const changedWorkspaces = await stepUpdateVersions(options, currentWorkspaces);
 
-  await stepBuildPackages(options);
+  await stepBuildPackages(options, changedWorkspaces);
 
-  await stepRunPreScripts(options);
+  await stepRunPreScripts(options, changedWorkspaces);
 
   const publishableWorkspaces = await stepCheckWorkspaces(options, changedWorkspaces);
 
   await stepPublish(options, publishableWorkspaces);
 
-  await stepRunPostScripts(options);
+  await stepRunPostScripts(options, changedWorkspaces);
 };

--- a/packages/release-cli/src/steps/build_packages.ts
+++ b/packages/release-cli/src/steps/build_packages.ts
@@ -9,6 +9,7 @@
 import { execSync } from 'node:child_process';
 
 import { type ReleaseOptions } from '../release';
+import { type YarnWorkspace } from '../yarn_utils';
 
 // A list of very specific packages to exclude when building
 // Should probably become a configuration option at some point
@@ -24,10 +25,18 @@ const workspacesToExclude = [
 ];
 
 /**
- * Install dependencies and run the `build` script in all workspaces
+ * Install dependencies and build released workspaces with their dependencies
  */
-export const stepBuildPackages = async (options: ReleaseOptions) => {
+export const stepBuildPackages = async (
+  options: ReleaseOptions,
+  workspaces: YarnWorkspace[]
+) => {
   const { logger } = options;
+  const workspaceNames = workspaces.map(({ name }) => name);
+  const workspacePattern =
+    workspaceNames.length === 1
+      ? workspaceNames[0]
+      : `{${workspaceNames.join(',')}}`;
 
   logger.info('Installing dependencies and building packages');
 
@@ -41,8 +50,9 @@ export const stepBuildPackages = async (options: ReleaseOptions) => {
     // in topological order
     '--topological-dev',
 
-    // include all local workspaces
-    '--all',
+    // include released workspaces and their local dependencies
+    '--recursive',
+    `--from '${workspacePattern}'`,
 
     // exclude selected independent and fully private workspaces
     workspacesToExclude.map((name) => `--exclude ${name}`).join(' '),

--- a/packages/release-cli/src/steps/build_packages.ts
+++ b/packages/release-cli/src/steps/build_packages.ts
@@ -9,7 +9,7 @@
 import { execSync } from 'node:child_process';
 
 import { type ReleaseOptions } from '../release';
-import { type YarnWorkspace } from '../yarn_utils';
+import { getWorkspacePattern, type YarnWorkspace } from '../yarn_utils';
 
 // A list of very specific packages to exclude when building
 // Should probably become a configuration option at some point
@@ -32,11 +32,7 @@ export const stepBuildPackages = async (
   workspaces: YarnWorkspace[]
 ) => {
   const { logger } = options;
-  const workspaceNames = workspaces.map(({ name }) => name);
-  const workspacePattern =
-    workspaceNames.length === 1
-      ? workspaceNames[0]
-      : `{${workspaceNames.join(',')}}`;
+  const workspacePattern = getWorkspacePattern(workspaces);
 
   logger.info('Installing dependencies and building packages');
 
@@ -52,7 +48,7 @@ export const stepBuildPackages = async (
 
     // include released workspaces and their local dependencies
     '--recursive',
-    `--from '${workspacePattern}'`,
+    `--from "${workspacePattern}"`,
 
     // exclude selected independent and fully private workspaces
     workspacesToExclude.map((name) => `--exclude ${name}`).join(' '),

--- a/packages/release-cli/src/steps/run_pre_post_scripts.ts
+++ b/packages/release-cli/src/steps/run_pre_post_scripts.ts
@@ -7,28 +7,34 @@
  */
 
 import { type ReleaseOptions } from '../release';
-import { runScriptOnAllWorkspaces } from '../yarn_utils';
+import { runScriptOnWorkspaces, type YarnWorkspace } from '../yarn_utils';
 
 /**
- * Runs the `prerelease` script in all workspaces that define it in their
+ * Runs the `prerelease` script in released workspaces that define it in their
  * package.json `scripts` section.
  */
-export const stepRunPreScripts = async (options: ReleaseOptions) => {
+export const stepRunPreScripts = async (
+  options: ReleaseOptions,
+  workspaces: YarnWorkspace[]
+) => {
   const { logger } = options;
 
   logger.info('Running pre release scripts');
 
-  await runScriptOnAllWorkspaces('prerelease');
-}
+  await runScriptOnWorkspaces('prerelease', workspaces);
+};
 
 /**
- * Runs the `postrelease` script in all workspaces that define it in their
+ * Runs the `postrelease` script in released workspaces that define it in their
  * package.json `scripts` section.
  */
-export const stepRunPostScripts = async (options: ReleaseOptions) => {
+export const stepRunPostScripts = async (
+  options: ReleaseOptions,
+  workspaces: YarnWorkspace[]
+) => {
   const { logger } = options;
 
   logger.info('Running post release scripts');
 
-  await runScriptOnAllWorkspaces('postrelease');
-}
+  await runScriptOnWorkspaces('postrelease', workspaces);
+};

--- a/packages/release-cli/src/yarn_utils.ts
+++ b/packages/release-cli/src/yarn_utils.ts
@@ -30,7 +30,7 @@ export const getYarnWorkspaces = async (includeRoot: boolean = false) => {
   return workspaces.filter((workspace) => workspace.location !== '.');
 };
 
-const getWorkspacePattern = (workspaces: YarnWorkspace[]) => {
+export const getWorkspacePattern = (workspaces: YarnWorkspace[]) => {
   const workspaceNames = workspaces.map(({ name }) => name);
   return workspaceNames.length === 1
     ? workspaceNames[0]
@@ -43,7 +43,7 @@ export const runScriptOnWorkspaces = async (
 ) => {
   const workspacePattern = getWorkspacePattern(workspaces);
   return execPromise(
-    `yarn workspaces foreach --all --include '${workspacePattern}' run ${script}`
+    `yarn workspaces foreach --all --include "${workspacePattern}" run ${script}`
   );
 };
 

--- a/packages/release-cli/src/yarn_utils.ts
+++ b/packages/release-cli/src/yarn_utils.ts
@@ -30,8 +30,21 @@ export const getYarnWorkspaces = async (includeRoot: boolean = false) => {
   return workspaces.filter((workspace) => workspace.location !== '.');
 };
 
-export const runScriptOnAllWorkspaces = async (script: string) => {
-  return execPromise(`yarn workspaces foreach --all run ${script}`);
+const getWorkspacePattern = (workspaces: YarnWorkspace[]) => {
+  const workspaceNames = workspaces.map(({ name }) => name);
+  return workspaceNames.length === 1
+    ? workspaceNames[0]
+    : `{${workspaceNames.join(',')}}`;
+};
+
+export const runScriptOnWorkspaces = async (
+  script: string,
+  workspaces: YarnWorkspace[]
+) => {
+  const workspacePattern = getWorkspacePattern(workspaces);
+  return execPromise(
+    `yarn workspaces foreach --all --include '${workspacePattern}' run ${script}`
+  );
 };
 
 export const updateWorkspaceVersion = async (workspace: string, version: string) => {


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Noticed on https://github.com/elastic/eui/pull/9825

Release CLI builds ALL workspaces, no matter what workspaces we're releasing and what their dependencies are. This:

1) makes the release process longer,
2) creates workspace-specific artifacts that are pushed to a wrong release PR (e.g. i18n token changes).

This PR:

- scopes release builds to changed workspaces and their local dependencies,
- scopes `prerelease` and `postrelease` scripts to changed workspaces,
- prevents independent releases such as `@elastic/eui-illustrations` from building EUI and modifying i18n files,
- preserves recursive dependency builds when releasing `@elastic/eui`.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

- [x] Run `yarn workspace @elastic/eui-release-cli build` - it should succeed
- [x] Run `yarn workspaces foreach -R --topological-dev --from '@elastic/eui-illustrations' -n run build` - confirm only `packages/illustrations` is selected
- [x] Run `yarn workspaces foreach -R --topological-dev --from '@elastic/eui' -n run build` - confirm EUI and its local dependencies are selected
- [x] Confirm an illustrations release does not run EUI `prerelease` script or modify i18n files