### PR TITLE
[test-helpers] Auto-guard Component Object methods via a Proxy

### DIFF
--- a/packages/test-helpers/changelogs/upcoming/9828.md
+++ b/packages/test-helpers/changelogs/upcoming/9828.md
@@ -1,0 +1,1 @@
+- Updated Component Objects to run the component-type check automatically before every public method (via a `Proxy` in `BaseObject`), instead of per-method calls

--- a/packages/test-helpers/src/playwright/base_object.spec.ts
+++ b/packages/test-helpers/src/playwright/base_object.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from './base_object';
+
+// Concrete subclass that requires a component selector so the guard is active.
+// `assertComponent` is protected, so expose it for the test.
+class TestObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string, componentSelector: string) {
+    super(scope, testSubj, componentSelector);
+  }
+
+  verifyComponent(): Promise<void> {
+    return this.assertComponent();
+  }
+}
+
+test.describe('BaseObject component-type guard', () => {
+  test('rejects an element that does not match the component selector', async ({
+    page,
+  }) => {
+    await page.setContent('<div data-test-subj="target"></div>');
+
+    const object = new TestObject(page, 'target', '.euiComboBox');
+
+    await expect(object.verifyComponent()).rejects.toThrow(
+      /Are you using the right Component Object/i
+    );
+  });
+
+  test('resolves when the element matches the component selector', async ({
+    page,
+  }) => {
+    await page.setContent(
+      '<div class="euiComboBox" data-test-subj="target"></div>'
+    );
+
+    const object = new TestObject(page, 'target', '.euiComboBox');
+
+    await expect(object.verifyComponent()).resolves.toBeUndefined();
+  });
+});

--- a/packages/test-helpers/src/playwright/base_object.spec.ts
+++ b/packages/test-helpers/src/playwright/base_object.spec.ts
@@ -10,40 +10,54 @@ import { test, expect } from '@playwright/test';
 
 import { BaseObject, type ObjectScope } from './base_object';
 
-// Concrete subclass that requires a component selector so the guard is active.
-// `assertComponent` is protected, so expose it for the test.
+// `asyncMethod` deliberately does NOT call the guard itself, so its behavior
+// proves the Proxy applies it. `syncMethod` proves sync methods pass through
+// unguarded (and keep their sync return type).
 class TestObject extends BaseObject {
   constructor(scope: ObjectScope, testSubj: string, componentSelector: string) {
     super(scope, testSubj, componentSelector);
   }
 
-  verifyComponent(): Promise<void> {
-    return this.assertComponent();
+  async asyncMethod(): Promise<string> {
+    return 'ran';
+  }
+
+  syncMethod(): string {
+    return 'sync';
   }
 }
 
 test.describe('BaseObject component-type guard', () => {
-  test('rejects an element that does not match the component selector', async ({
+  test('the Proxy guards async methods that do not call the guard themselves', async ({
     page,
   }) => {
     await page.setContent('<div data-test-subj="target"></div>');
 
     const object = new TestObject(page, 'target', '.euiComboBox');
 
-    await expect(object.verifyComponent()).rejects.toThrow(
+    await expect(object.asyncMethod()).rejects.toThrow(
       /Are you using the right Component Object/i
     );
   });
 
-  test('resolves when the element matches the component selector', async ({
-    page,
-  }) => {
+  test('async methods run once the element matches', async ({ page }) => {
     await page.setContent(
       '<div class="euiComboBox" data-test-subj="target"></div>'
     );
 
     const object = new TestObject(page, 'target', '.euiComboBox');
 
-    await expect(object.verifyComponent()).resolves.toBeUndefined();
+    await expect(object.asyncMethod()).resolves.toBe('ran');
+  });
+
+  test('sync methods pass through unguarded (keep their sync return)', async ({
+    page,
+  }) => {
+    await page.setContent('<div data-test-subj="target"></div>');
+
+    const object = new TestObject(page, 'target', '.euiComboBox');
+
+    // No await, no reject — returns synchronously despite the wrong element.
+    expect(object.syncMethod()).toBe('sync');
   });
 });

--- a/packages/test-helpers/src/playwright/base_object.ts
+++ b/packages/test-helpers/src/playwright/base_object.ts
@@ -49,10 +49,9 @@ export abstract class BaseObject {
     this.testSubj = testSubj;
     this.componentSelector = componentSelector;
 
-    // Run assertComponent before every public method. This is the guard we'd
-    // want in the constructor, but it's async and constructors can't be, so a
-    // Proxy applies it lazily per call. Methods are invoked with `target` (not
-    // the proxy) as `this`, so internal/private calls don't re-enter the trap.
+    // Guard every public method. A constructor can't be async, so instead of
+    // checking there, a Proxy awaits assertComponent() before each call.
+    // Methods run with `target` as `this`, so internal calls don't re-guard.
     return new Proxy(this, {
       get(target, prop) {
         const value = Reflect.get(target, prop, target);

--- a/packages/test-helpers/src/playwright/base_object.ts
+++ b/packages/test-helpers/src/playwright/base_object.ts
@@ -49,16 +49,17 @@ export abstract class BaseObject {
     this.testSubj = testSubj;
     this.componentSelector = componentSelector;
 
-    // Guard every public method. A constructor can't be async, so instead of
-    // checking there, a Proxy awaits assertComponent() before each call.
+    // Guard every async public method. A constructor can't be async, so instead
+    // of checking there, a Proxy awaits assertComponent() before each call. Only
+    // async methods are wrapped — the guard is async, so sync methods can't be
+    // guarded and pass through untouched (keeping their sync return type).
     // Methods run with `target` as `this`, so internal calls don't re-guard.
     return new Proxy(this, {
       get(target, prop) {
         const value = Reflect.get(target, prop, target);
         const isGuardable =
           typeof value === 'function' &&
-          typeof prop === 'string' &&
-          prop !== 'constructor' &&
+          value.constructor.name === 'AsyncFunction' &&
           prop !== 'assertComponent' &&
           !(prop in Object.prototype);
 
@@ -68,7 +69,7 @@ export abstract class BaseObject {
 
         return async (...args: unknown[]) => {
           await target.assertComponent();
-          return (value as (...a: unknown[]) => unknown).apply(target, args);
+          return Reflect.apply(value, target, args);
         };
       },
     });

--- a/packages/test-helpers/src/playwright/base_object.ts
+++ b/packages/test-helpers/src/playwright/base_object.ts
@@ -48,6 +48,31 @@ export abstract class BaseObject {
     this.root = this.scope.getByTestId(testSubj);
     this.testSubj = testSubj;
     this.componentSelector = componentSelector;
+
+    // Run assertComponent before every public method. This is the guard we'd
+    // want in the constructor, but it's async and constructors can't be, so a
+    // Proxy applies it lazily per call. Methods are invoked with `target` (not
+    // the proxy) as `this`, so internal/private calls don't re-enter the trap.
+    return new Proxy(this, {
+      get(target, prop) {
+        const value = Reflect.get(target, prop, target);
+        const isGuardable =
+          typeof value === 'function' &&
+          typeof prop === 'string' &&
+          prop !== 'constructor' &&
+          prop !== 'assertComponent' &&
+          !(prop in Object.prototype);
+
+        if (!isGuardable) {
+          return value;
+        }
+
+        return async (...args: unknown[]) => {
+          await target.assertComponent();
+          return (value as (...a: unknown[]) => unknown).apply(target, args);
+        };
+      },
+    });
   }
 
   /**
@@ -60,9 +85,10 @@ export abstract class BaseObject {
 
   /**
    * Throw if the element at `testSubj` isn't this component (a `data-test-subj`
-   * isn't unique to a component type). Call at the top of public methods.
-   * Memoized and lazy — runs once per instance, not in the constructor, so it
-   * doesn't race initial render. No-op without a `componentSelector`.
+   * isn't unique to a component type). Run automatically before every public
+   * method via the constructor's Proxy. Memoized and lazy — runs once per
+   * instance, not in the constructor, so it doesn't race initial render. No-op
+   * without a `componentSelector`.
    */
   protected async assertComponent(): Promise<void> {
     if (this.componentVerified || !this.componentSelector) {

--- a/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
@@ -95,34 +95,19 @@ test.describe('EuiComboBoxObject', () => {
 });
 
 test.describe('EuiComboBoxObject component-type guard', () => {
-  // Every public method must reject when pointed at the wrong element. Add new
-  // public methods here so they're covered too.
-  const PUBLIC_METHODS = [
-    'setSelectedOptions',
-    'setCustomSelectedOptions',
-    'getSelectedOptions',
-    'getAllVisibleOptions',
-    'clear',
-  ] as const;
+  // The guard runs before every public method (via BaseObject's Proxy), so any
+  // call on a wrong target rejects. `comboBoxSearchInput` exists on the page but
+  // is the inner input, not the outer `.euiComboBox` root — a different element
+  // sharing a `data-test-subj`. (The guard mechanism itself is covered in
+  // base_object.spec.ts.)
+  test('rejects a non-EuiComboBox target', async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId('comboBoxSearchInput').waitFor({ state: 'visible' });
 
-  // The guard runs first in each method, so the call rejects before it reads its
-  // arguments — calling with none is fine. `comboBoxSearchInput` exists on the
-  // page but is the inner input, not the outer `.euiComboBox` root: it stands in
-  // for pointing the helper at a different component that shares a `data-test-subj`.
-  for (const method of PUBLIC_METHODS) {
-    test(`${method} throws when the data-test-subj is not an EuiComboBox`, async ({
-      page,
-    }) => {
-      await page.goto(PLAYGROUND_URL);
-      await page
-        .getByTestId('comboBoxSearchInput')
-        .waitFor({ state: 'visible' });
+    const comboBox = new EuiComboBoxObject(page, 'comboBoxSearchInput');
 
-      const wrongTarget = new EuiComboBoxObject(page, 'comboBoxSearchInput');
-
-      await expect(
-        (wrongTarget[method] as () => Promise<unknown>)()
-      ).rejects.toThrow(/Are you using the right Component Object/i);
-    });
-  }
+    await expect(comboBox.getSelectedOptions()).rejects.toThrow(
+      /Are you using the right Component Object/i
+    );
+  });
 });

--- a/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
@@ -95,11 +95,9 @@ test.describe('EuiComboBoxObject', () => {
 });
 
 test.describe('EuiComboBoxObject component-type guard', () => {
-  // The guard runs before every public method (via BaseObject's Proxy), so any
-  // call on a wrong target rejects. `comboBoxSearchInput` exists on the page but
-  // is the inner input, not the outer `.euiComboBox` root — a different element
-  // sharing a `data-test-subj`. (The guard mechanism itself is covered in
-  // base_object.spec.ts.)
+  // Wiring test: a real method on a wrong target rejects. `comboBoxSearchInput`
+  // is the inner input, not the `.euiComboBox` root. (Guard mechanism itself is
+  // unit-tested in base_object.spec.ts.)
   test('rejects a non-EuiComboBox target', async ({ page }) => {
     await page.goto(PLAYGROUND_URL);
     await page.getByTestId('comboBoxSearchInput').waitFor({ state: 'visible' });

--- a/packages/test-helpers/src/playwright/components/combo_box/object.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.ts
@@ -41,7 +41,6 @@ export class EuiComboBoxObject extends BaseObject {
     labels: string[],
     { timeout = 2_500 }: { timeout?: number } = {}
   ): Promise<void> {
-    await this.assertComponent();
     // Dedupe while preserving order.
     const targetLabels = [...new Set(labels)];
     // `[...arr].sort()` (not `arr.sort()`) — sort mutates in place; the copy
@@ -86,7 +85,6 @@ export class EuiComboBoxObject extends BaseObject {
     labels: string[],
     { timeout = 2_500 }: { timeout?: number } = {}
   ): Promise<void> {
-    await this.assertComponent();
     for (const label of labels) {
       await this.input.click();
       await this.searchInput.fill(label);
@@ -106,7 +104,6 @@ export class EuiComboBoxObject extends BaseObject {
    * guaranteed to be every option.
    */
   async getAllVisibleOptions(): Promise<string[]> {
-    await this.assertComponent();
     await this.input.click();
     const optionsList = this.root
       .page()
@@ -128,7 +125,6 @@ export class EuiComboBoxObject extends BaseObject {
    * options list).
    */
   async clear(): Promise<void> {
-    await this.assertComponent();
     if ((await this.getSelectedOptions()).length === 0) {
       return;
     }
@@ -155,7 +151,6 @@ export class EuiComboBoxObject extends BaseObject {
    * - Nothing selected → `[]`.
    */
   async getSelectedOptions(): Promise<string[]> {
-    await this.assertComponent();
     if (await this.hasPills()) {
       return this.pills.allInnerTexts();
     }


### PR DESCRIPTION
## Summary

Follow-up to #9809. The component-type guard (`assertComponent`) was called manually at the top of every public method. This moves it into a `Proxy` set up in `BaseObject`'s constructor, so it runs automatically before every public method call — the guard we'd want in the constructor but can't put there (`assertComponent` is async, constructors can't be).

Why: relying on each method to call the guard is easy to forget and duplicates the intent. With the Proxy it's structural — every current and future public method is guarded with no boilerplate and nothing to enumerate in a test.

## How it behaves (measured)

Methods are invoked with the raw `target` as `this`, so internal/private calls (`this.hasPills()`, `this.addOption()`, …) don't re-enter the trap. The check is memoized, so the DOM work runs once per instance. Instrumented a realistic flow (`setSelectedOptions` → `getSelectedOptions` → `clear`):

- **1 trap per external public call** (3 calls → 3 traps), despite `setSelectedOptions` internally calling `clear`/`getSelectedOptions`/`hasPills`/`addOption` many times → **0 extra traps**.
- **Real DOM guard check ran once** (~7ms), memoized thereafter.

So no repeated calls, no accumulating delay.

## Changes

- `BaseObject` constructor returns a `Proxy` that wraps guardable methods (functions on the prototype, excluding `constructor`/`assertComponent`/Object built-ins) to await `assertComponent()` first.
- Remove the 5 per-method `assertComponent()` calls from `EuiComboBoxObject`.
- Tests: replace the hardcoded per-method guard loop with a `BaseObject` guard test (`base_object.spec.ts`) + one `EuiComboBoxObject` wiring test.

## Testing

`yarn --cwd packages/test-helpers test-e2e` — green (combo_box matrix + new base_object guard tests). tsc clean.
