### PR TITLE
[Chore] Run VRT only for EUI packages and Storybook infra

### DIFF
--- a/.buildkite/scripts/deploy_docs/step_vrt.sh
+++ b/.buildkite/scripts/deploy_docs/step_vrt.sh
@@ -51,6 +51,7 @@ VRT_RELEVANT_PATHS=(
   '^\.yarn/'
   '^\.buildkite/pipelines/deploy_docs\.yml$'
   '^\.buildkite/scripts/deploy_docs/'
+  '^\.buildkite/scripts/common/'
 )
 
 # Sets the meta-data the downstream update-baselines step reads, then exits.

--- a/.buildkite/scripts/deploy_docs/step_vrt.sh
+++ b/.buildkite/scripts/deploy_docs/step_vrt.sh
@@ -37,12 +37,20 @@ export GH_TOKEN="${VAULT_GITHUB_TOKEN}"
 # VRT is skipped (allowing Storybook and the website to build & deploy) when any of
 # the following apply:
 # - The PR has the `skip-vrt` label.
-# - The PR's diff is contained entirely within `VRT_SKIP_PATHS` - paths that can't affect EUI's visual output.
+# - The PR's diff doesn't contain a path in `VRT_RELEVANT_PATHS`.
 #
-# To extend the path-based skip, add anchored regexps to `VRT_SKIP_PATHS`.
-VRT_SKIP_PATHS=(
-  '^packages/illustrations/'
-  '^packages/test-helpers/'
+# Keep this list limited to EUI's visual dependencies and the infrastructure
+# that builds or tests Storybook.
+VRT_RELEVANT_PATHS=(
+  '^packages/eui/'
+  '^packages/eui-theme-common/'
+  '^packages/eui-theme-borealis/'
+  '^package\.json$'
+  '^yarn\.lock$'
+  '^\.yarnrc\.yml$'
+  '^\.yarn/'
+  '^\.buildkite/pipelines/deploy_docs\.yml$'
+  '^\.buildkite/scripts/deploy_docs/'
 )
 
 # Sets the meta-data the downstream update-baselines step reads, then exits.
@@ -63,16 +71,16 @@ if [[ "${pr_labels}" == *",skip-vrt,"* ]]; then
   skip_vrt "PR #${BUILDKITE_PULL_REQUEST} has 'skip-vrt' label"
 fi
 
-# Skip: diff contained entirely within `VRT_SKIP_PATHS`.
-skip_paths_regexp="$(IFS='|'; echo "${VRT_SKIP_PATHS[*]}")"
+# Skip: diff doesn't contain a path that can affect EUI's visual output.
+relevant_paths_regexp="$(IFS='|'; echo "${VRT_RELEVANT_PATHS[*]}")"
 base_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-main}"
 
 if git fetch --no-tags --quiet origin "${base_branch}" 2>/dev/null \
   && merge_base="$(git merge-base "origin/${base_branch}" HEAD 2>/dev/null)" \
   && changed="$(git diff --name-only "${merge_base}" HEAD 2>/dev/null)" \
   && [[ -n "${changed}" ]] \
-  && ! echo "${changed}" | grep -qvE "${skip_paths_regexp}"; then
-  skip_vrt "Only VRT-skippable paths changed"
+  && ! echo "${changed}" | grep -qE "${relevant_paths_regexp}"; then
+  skip_vrt "No VRT-relevant paths changed"
 fi
 
 ############################################################


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Noticed on https://github.com/elastic/eui/pull/9827 and https://github.com/elastic/eui/pull/9826

Changed VRT path filtering from a skip list to an **allowlist** of EUI packages and VRT workflow paths.

This prevents unrelated package changes, such as release-cli, from running VRT.

This also helps minimize having to use `skip-vrt` and normalizing it.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

- [ ] Confirm this PR runs VRT because it changes VRT workflow files
- [ ] Confirm EUI/theme changes match `VRT_RELEVANT_PATHS`
- [ ] Confirm unrelated paths such as `packages/release-cli/` do not match
- [ ] Confirm `skip-vrt` label behavior remains unchanged

**Note:** this PR cannot test the skipping in CI because it modifies the VRT workflow itself.