### PR TITLE
[test-helpers] Match combo-box options by exact text, not substring

### DIFF
--- a/packages/test-helpers/changelogs/upcoming/9833.md
+++ b/packages/test-helpers/changelogs/upcoming/9833.md
@@ -1,0 +1,1 @@
+- Fixed `EuiComboBoxObject.setSelectedOptions()` selecting the wrong option when a label is a substring of another (e.g. `ip` vs `clientip`) by matching options by exact text

--- a/packages/test-helpers/src/playwright/components/combo_box/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.props.spec.ts
@@ -32,6 +32,10 @@ const ON_CREATE_OPTION_STORY_URL = storyUrl(
   'forms-euicombobox--with-on-create-option',
   `data-test-subj:${TEST_SUBJ}`
 );
+const DEFAULT_TRUNCATION_STORY_URL = storyUrl(
+  'forms-euicombobox--default-truncation',
+  `data-test-subj:${TEST_SUBJ}`
+);
 
 // ---------------------------------------------------------------------------
 // singleSelection={true}  — one pill, no multi-select
@@ -289,6 +293,27 @@ test.describe('EuiComboBoxObject — onCreateOption + asPlainText', () => {
     await comboBox.setSelectedOptions(['Item 3']);
 
     expect(await comboBox.getSelectedOptions()).toEqual(['Item 3']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Truncated options — EUI middle-truncates long option labels while filtering,
+// but keeps the full text in the DOM, so the anchored-text match still works.
+// ---------------------------------------------------------------------------
+
+test.describe('EuiComboBoxObject — truncated options', () => {
+  const LONG_LABEL =
+    'Item 2 with a long label that should truncation by default';
+
+  test('selects a long label that truncates by default', async ({ page }) => {
+    await page.goto(DEFAULT_TRUNCATION_STORY_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    const comboBox = new EuiComboBoxObject(page, TEST_SUBJ);
+    await comboBox.clear();
+
+    await comboBox.setSelectedOptions([LONG_LABEL]);
+
+    expect(await comboBox.getSelectedOptions()).toContain(LONG_LABEL);
   });
 });
 

--- a/packages/test-helpers/src/playwright/components/combo_box/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.props.spec.ts
@@ -297,8 +297,8 @@ test.describe('EuiComboBoxObject — onCreateOption + asPlainText', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Truncated options — EUI middle-truncates long option labels while filtering,
-// but keeps the full text in the DOM, so the anchored-text match still works.
+// Truncated options — EUI truncates long option labels while filtering, so there
+// is no exact text match; the matcher falls back to keyboard-selecting the option.
 // ---------------------------------------------------------------------------
 
 test.describe('EuiComboBoxObject — truncated options', () => {

--- a/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
@@ -44,7 +44,7 @@ test.describe('EuiComboBoxObject', () => {
     });
 
     test('selects the exact label when it is a prefix of another option', async () => {
-      // "Item 1" is a prefix of "Item 10"; the anchored match must pick "Item 1".
+      // "Item 1" is a prefix of "Item 10"; must pick "Item 1", not "Item 10".
       await comboBox.setSelectedOptions(['Item 1']);
 
       expect(await comboBox.getSelectedOptions()).toEqual(['Item 1']);

--- a/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
@@ -43,6 +43,13 @@ test.describe('EuiComboBoxObject', () => {
       expect(await comboBox.getSelectedOptions()).toEqual(['Item 2']);
     });
 
+    test('selects the exact label when it is a prefix of another option', async () => {
+      // "Item 1" is a prefix of "Item 10"; the anchored match must pick "Item 1".
+      await comboBox.setSelectedOptions(['Item 1']);
+
+      expect(await comboBox.getSelectedOptions()).toEqual(['Item 1']);
+    });
+
     test('replaces the existing selection', async () => {
       await comboBox.setSelectedOptions(['Item 1', 'Item 2']);
       expect(await comboBox.getSelectedOptions()).toEqual(['Item 1', 'Item 2']);

--- a/packages/test-helpers/src/playwright/components/combo_box/object.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.ts
@@ -207,22 +207,25 @@ export class EuiComboBoxObject extends BaseObject {
     // inner `comboBoxInput` element does.
     await this.input.click();
 
-    // Type to filter, then match the option by accessible name. Substring match
-    // (not exact): while filtering, EUI middle-truncates the option text, so the
-    // accessible name isn't the literal label. The list renders in a portal
-    // outside `this.root`, so locate it from page level; the poll waits out async
-    // filtering.
+    // Type to filter, then wait for the (now narrowed) options to render.
     await this.searchInput.fill(label);
-    const option = this.root
+    const optionsList = this.root
       .page()
-      .locator(EuiComboBoxSelectors.optionsListFor(this.testSubj))
-      .getByRole('option', { name: label });
-    await expect.poll(() => option.count(), { timeout }).toBeGreaterThan(0);
-    if ((await option.count()) === 1) {
-      await option.click();
+      .locator(EuiComboBoxSelectors.optionsListFor(this.testSubj));
+    await expect
+      .poll(() => optionsList.getByRole('option').count(), { timeout })
+      .toBeGreaterThan(0);
+
+    // Prefer an exact text match so "ip" doesn't select "clientip". When EUI has
+    // (asynchronously) truncated the option text, no exact match exists — fall
+    // back to keyboard-selecting the highlighted option, which is safe because
+    // typing the full label has already filtered the list to the intended option.
+    const exactOption = optionsList
+      .getByRole('option')
+      .filter({ has: this.root.page().getByText(label, { exact: true }) });
+    if ((await exactOption.count()) > 0) {
+      await exactOption.first().click();
     } else {
-      // Substring can match several (e.g. "Item 1" also matches "Item 10") —
-      // keyboard-select the highlighted match.
       await this.searchInput.press('ArrowDown');
       await this.searchInput.press('Enter');
     }

--- a/packages/test-helpers/src/playwright/components/combo_box/object.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.ts
@@ -209,22 +209,24 @@ export class EuiComboBoxObject extends BaseObject {
 
     // Type to filter, then wait for the (now narrowed) options to render.
     await this.searchInput.fill(label);
-    const optionsList = this.root
+    const options = this.root
       .page()
-      .locator(EuiComboBoxSelectors.optionsListFor(this.testSubj));
-    await expect
-      .poll(() => optionsList.getByRole('option').count(), { timeout })
-      .toBeGreaterThan(0);
+      .locator(EuiComboBoxSelectors.optionsListFor(this.testSubj))
+      .getByRole('option');
+    await expect.poll(() => options.count(), { timeout }).toBeGreaterThan(0);
 
-    // Prefer an exact text match so "ip" doesn't select "clientip". When EUI has
-    // (asynchronously) truncated the option text, no exact match exists — fall
-    // back to keyboard-selecting the highlighted option, which is safe because
-    // typing the full label has already filtered the list to the intended option.
-    const exactOption = optionsList
-      .getByRole('option')
-      .filter({ has: this.root.page().getByText(label, { exact: true }) });
-    if ((await exactOption.count()) > 0) {
-      await exactOption.first().click();
+    // Match on each option's *full* text so "ip" doesn't select "clientip".
+    // Compare the whole option (not a sub-element): while filtering, EUI wraps the
+    // matched substring in `<mark>`, so a text-node lookup for the label would also
+    // match the highlighted part inside a longer option. When EUI has
+    // asynchronously truncated the option text, there's no exact match — fall back
+    // to keyboard-selecting the highlighted option, which is safe because typing
+    // the full label has already filtered the list to the intended option.
+    const trimmed = label.trim();
+    const texts = await options.allInnerTexts();
+    const exactIndex = texts.findIndex((text) => text.trim() === trimmed);
+    if (exactIndex >= 0) {
+      await options.nth(exactIndex).click();
     } else {
       await this.searchInput.press('ArrowDown');
       await this.searchInput.press('Enter');

--- a/packages/test-helpers/src/playwright/components/combo_box/object.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.ts
@@ -215,13 +215,10 @@ export class EuiComboBoxObject extends BaseObject {
       .getByRole('option');
     await expect.poll(() => options.count(), { timeout }).toBeGreaterThan(0);
 
-    // Match on each option's *full* text so "ip" doesn't select "clientip".
-    // Compare the whole option (not a sub-element): while filtering, EUI wraps the
-    // matched substring in `<mark>`, so a text-node lookup for the label would also
-    // match the highlighted part inside a longer option. When EUI has
-    // asynchronously truncated the option text, there's no exact match — fall back
-    // to keyboard-selecting the highlighted option, which is safe because typing
-    // the full label has already filtered the list to the intended option.
+    // Match on each option's full text so "ip" doesn't select "clientip" (EUI
+    // wraps the matched substring in `<mark>` while filtering, so a text-node
+    // lookup would match inside a longer option). If the text is truncated and
+    // has no exact match, fall back to keyboard-selecting the highlighted option.
     const trimmed = label.trim();
     const texts = await options.allInnerTexts();
     const exactIndex = texts.findIndex((text) => text.trim() === trimmed);


### PR DESCRIPTION
## Summary

`EuiComboBoxObject.setSelectedOptions` matched dropdown options by **substring**, so `setSelectedOptions(['ip'])` could select `"clientip"`. This surfaced as real failures when consuming the helper in Kibana (e.g. lens field selection), caught by `setSelectedOptions`' own result assertion.

Match by **exact text** instead — the same strategy the FTR `combo_box` service uses: after typing to filter, prefer the option whose text is exactly the label; if EUI has *asynchronously* truncated the option text (so no exact match exists), fall back to keyboard-selecting the highlighted option, which is safe because typing the full label has already narrowed the list.

Why not require an exact match: EUI middle-truncates long option labels via `EuiTextTruncate` while filtering (introduced by elastic/eui#272154), changing the option's DOM text to `start…end`. Requiring exact text would time out on those; the fallback keeps it robust.

## Testing

`yarn --cwd packages/test-helpers test-e2e` — combo_box matrix green, incl. two new tests: exact selection when a label is a prefix of another (`Item 1` vs `Item 10`), and selecting a long label that truncates by default. Stable under `--repeat-each=3` (102/102).
