### PR TITLE
[test-helpers] Skip the component guard when the element is absent

### DIFF
--- a/packages/test-helpers/changelogs/upcoming/9834.md
+++ b/packages/test-helpers/changelogs/upcoming/9834.md
@@ -1,0 +1,1 @@
+- Fixed the component-type guard timing out when calling a method (e.g. `clear()`) on an absent combo box; it now skips when the element is absent and verifies only when present

--- a/packages/test-helpers/src/playwright/base_object.spec.ts
+++ b/packages/test-helpers/src/playwright/base_object.spec.ts
@@ -50,6 +50,17 @@ test.describe('BaseObject component-type guard', () => {
     await expect(object.asyncMethod()).resolves.toBe('ran');
   });
 
+  test('skips the guard when the element is absent (does not block)', async ({
+    page,
+  }) => {
+    await page.setContent('<div></div>'); // no matching data-test-subj
+
+    const object = new TestObject(page, 'target', '.euiComboBox');
+
+    // Absent element is the method's concern; the guard must not throw or hang.
+    await expect(object.asyncMethod()).resolves.toBe('ran');
+  });
+
   test('sync methods pass through unguarded (keep their sync return)', async ({
     page,
   }) => {

--- a/packages/test-helpers/src/playwright/base_object.ts
+++ b/packages/test-helpers/src/playwright/base_object.ts
@@ -86,17 +86,20 @@ export abstract class BaseObject {
   /**
    * Throw if the element at `testSubj` isn't this component (a `data-test-subj`
    * isn't unique to a component type). Run automatically before every public
-   * method via the constructor's Proxy. Memoized and lazy — runs once per
-   * instance, not in the constructor, so it doesn't race initial render. No-op
-   * without a `componentSelector`.
+   * method via the constructor's Proxy. Memoized. Skips when the element is
+   * absent (that's the calling method's concern, not a misuse) and no-op without
+   * a `componentSelector`.
    */
   protected async assertComponent(): Promise<void> {
     if (this.componentVerified || !this.componentSelector) {
       return;
     }
-    // Wait for the element before checking its type, so the guard doesn't
-    // false-fail when a caller acts before render.
-    await this.root.first().waitFor({ state: 'attached' });
+    // Only verify when the element is present. An absent element isn't a misuse
+    // to flag — the calling method handles absence itself (e.g. clear() no-ops) —
+    // so skip rather than block waiting for something that may never appear.
+    if ((await this.root.count()) === 0) {
+      return;
+    }
     const matches = await this.root
       .and(this.scope.locator(this.componentSelector))
       .count();


### PR DESCRIPTION
## Summary

`BaseObject.assertComponent` (run before every public method via the constructor Proxy) waited for the element to attach before checking its type. So calling a *lenient* method on an **absent** combo — e.g. `clear()` on a combo that only renders after a later interaction — timed out (default timeout) instead of no-opping. This broke real Kibana tests that clear/reset combos defensively.

Fix: skip the guard when no element matches the `data-test-subj`. An absent element isn't a misuse to flag (the method handles absence itself — `clear()` no-ops, `getSelectedOptions()` returns `[]`); only verify the component type when an element is actually present. This also removes the blocking wait.

## Testing

`yarn --cwd packages/test-helpers test-e2e` — green, incl. a new base_object test that a method on an absent element resolves (no throw/hang). Verified end-to-end against the Kibana `uptime` `default_email_settings` test (clears a not-yet-rendered combo in its reset step): 3/3.
