### PR TITLE
[test-helpers] Don't clear an asPlainText combo before selecting

### DIFF
--- a/packages/test-helpers/changelogs/upcoming/9835.md
+++ b/packages/test-helpers/changelogs/upcoming/9835.md
@@ -1,0 +1,1 @@
+- Fixed `EuiComboBoxObject.setSelectedOptions()` failing on an `asPlainText` combo whose empty state is a non-clearable default value; it no longer clears before selecting (asPlainText replaces the selection on select)

--- a/packages/test-helpers/src/playwright/components/combo_box/object.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.ts
@@ -57,9 +57,14 @@ export class EuiComboBoxObject extends BaseObject {
       return;
     }
 
-    // Naive replace — clear, then add each. A diff-based approach would do
-    // less DOM work but require a per-pill remove primitive we don't ship yet.
-    await this.clear();
+    // Naive replace — clear, then add each. Exception: asPlainText single-select
+    // replaces its selection when a new option is picked, so clearing first is
+    // unnecessary — and its input can hold a non-clearable default (a placeholder
+    // rendered as the value) that clear() can't empty. Still clear when the target
+    // is empty (nothing to select would leave the old selection in place).
+    if (targetLabels.length === 0 || !(await this.isPlainText())) {
+      await this.clear();
+    }
 
     for (const label of targetLabels) {
       await this.addOption(label, timeout);


### PR DESCRIPTION
## Summary

`setSelectedOptions` cleared the current selection before adding the new one. For an `asPlainText` single-select combo this is unnecessary (selecting a new option replaces the current) and can fail: the input may hold a **non-clearable default** rendered as its value (e.g. "No default model"), which `clear()`'s `deleteSearchInput()` can never empty — so it timed out on `toHaveValue('')`.

Fix: skip the clear for `asPlainText` when there are options to select (selecting replaces). Still clear when the target is empty.

## Testing

`yarn --cwd packages/test-helpers test-e2e` — green incl. all asPlainText paths (repeat-each 2, 64/64). Verified end-to-end against the Kibana `search_inference_endpoints` feature-settings combo (whose empty state is a non-clearable default).
