### PR TITLE
[test-helpers] Don't blur an asPlainText combo after selecting

### DIFF
--- a/packages/test-helpers/changelogs/upcoming/9836.md
+++ b/packages/test-helpers/changelogs/upcoming/9836.md
@@ -1,0 +1,1 @@
+- Fixed `EuiComboBoxObject.setSelectedOptions()` intermittently failing to select an option in an `asPlainText` combo box by not blurring after selection (the blur could race the consumer's `onChange` commit and discard the value)

--- a/packages/test-helpers/src/playwright/components/combo_box/object.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.ts
@@ -65,14 +65,21 @@ export class EuiComboBoxObject extends BaseObject {
       await this.addOption(label, timeout);
     }
 
-    if (targetLabels.length > 0) {
+    if (targetLabels.length > 0 && !(await this.isPlainText())) {
       // Blur the input to close the dropdown. Using blur() rather than a
       // keyboard event avoids bubbling Escape to page-level handlers
-      // (modal/flyout close listeners) on the consumer page.
+      // (modal/flyout close listeners) on the consumer page. Skipped for
+      // asPlainText: picking an option there already commits and closes the
+      // dropdown, and an extra blur can race the (often parent-controlled)
+      // selectedOptions update and discard the just-picked value.
       await this.searchInput.blur();
     }
 
-    expect([...(await this.getSelectedOptions())].sort()).toEqual(sortedTarget);
+    // Poll rather than assert once: an asPlainText selection is committed via
+    // the consumer's onChange, which can land a tick after the click.
+    await expect
+      .poll(() => this.getSelectedOptions().then((options) => [...options].sort()), { timeout })
+      .toEqual(sortedTarget);
   }
 
   /**


### PR DESCRIPTION
## Summary

`EuiComboBoxObject.setSelectedOptions()` could intermittently fail to select an option in an **`singleSelection={{ asPlainText: true }}`** combo box, reading the selection back as empty.

An asPlainText combo has no pills — the selection lives in the input, committed through the consumer's `onChange` handler. When `selectedOptions` is controlled by parent React state, that commit can land a tick after the option click. The `blur()` that `setSelectedOptions` ran to close the dropdown could fire inside that window, and EUI then treats the input as unconfirmed search text and clears it — so the value reads back empty and the selection assertion fails.

This was reproduced against Kibana's Observability custom-threshold rule form (a parent-controlled asPlainText field picker): the selection was lost on ~3 of 4 runs. It does not reproduce in the Storybook stories where `selectedOptions` is local component state that commits synchronously.

### What changed
- Skip `blur()` for asPlainText combos: picking an option already commits and closes the dropdown there, so the extra blur only adds a race. Non-plain-text combos still blur to close their dropdown.
- Verify the resulting selection with `expect.poll` instead of a single read, tolerating a slightly-late `onChange` commit.

### Testing
- EUI: `combo_box` Playwright specs pass (32/32), including all asPlainText coverage.
- Kibana: the previously-flaky Observability custom-threshold Scout spec passes reliably (5×repeatEach with only an unrelated index-reuse fixture collision; 3 clean single runs green).
