### PR TITLE
[test-helpers] Fix EuiComboBoxObject option selection and guard edge cases

### DIFF
--- a/packages/test-helpers/changelogs/upcoming/9838.md
+++ b/packages/test-helpers/changelogs/upcoming/9838.md
@@ -1,0 +1,4 @@
+- Fixed `EuiComboBoxObject.setSelectedOptions()` selecting the wrong option when a label is a substring of another (e.g. `ip` vs `clientip`) by matching options by exact text
+- Fixed `EuiComboBoxObject` timing out when its target element is absent by skipping the component-type guard in that case
+- Fixed `EuiComboBoxObject.setSelectedOptions()` on `asPlainText` combo boxes by not clearing the input before selecting (the replacement is implicit and the input can hold a non-clearable default)
+- Fixed `EuiComboBoxObject.setSelectedOptions()` intermittently losing an `asPlainText` selection by not blurring after selection (the blur could race the consumer's `onChange` commit)

--- a/packages/test-helpers/src/playwright/base_object.spec.ts
+++ b/packages/test-helpers/src/playwright/base_object.spec.ts
@@ -50,6 +50,17 @@ test.describe('BaseObject component-type guard', () => {
     await expect(object.asyncMethod()).resolves.toBe('ran');
   });
 
+  test('skips the guard when the element is absent (does not block)', async ({
+    page,
+  }) => {
+    await page.setContent('<div></div>'); // no matching data-test-subj
+
+    const object = new TestObject(page, 'target', '.euiComboBox');
+
+    // Absent element is the method's concern; the guard must not throw or hang.
+    await expect(object.asyncMethod()).resolves.toBe('ran');
+  });
+
   test('sync methods pass through unguarded (keep their sync return)', async ({
     page,
   }) => {

--- a/packages/test-helpers/src/playwright/base_object.ts
+++ b/packages/test-helpers/src/playwright/base_object.ts
@@ -86,17 +86,20 @@ export abstract class BaseObject {
   /**
    * Throw if the element at `testSubj` isn't this component (a `data-test-subj`
    * isn't unique to a component type). Run automatically before every public
-   * method via the constructor's Proxy. Memoized and lazy — runs once per
-   * instance, not in the constructor, so it doesn't race initial render. No-op
-   * without a `componentSelector`.
+   * method via the constructor's Proxy. Memoized. Skips when the element is
+   * absent (that's the calling method's concern, not a misuse) and no-op without
+   * a `componentSelector`.
    */
   protected async assertComponent(): Promise<void> {
     if (this.componentVerified || !this.componentSelector) {
       return;
     }
-    // Wait for the element before checking its type, so the guard doesn't
-    // false-fail when a caller acts before render.
-    await this.root.first().waitFor({ state: 'attached' });
+    // Only verify when the element is present. An absent element isn't a misuse
+    // to flag — the calling method handles absence itself (e.g. clear() no-ops) —
+    // so skip rather than block waiting for something that may never appear.
+    if ((await this.root.count()) === 0) {
+      return;
+    }
     const matches = await this.root
       .and(this.scope.locator(this.componentSelector))
       .count();

--- a/packages/test-helpers/src/playwright/components/combo_box/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.props.spec.ts
@@ -32,6 +32,10 @@ const ON_CREATE_OPTION_STORY_URL = storyUrl(
   'forms-euicombobox--with-on-create-option',
   `data-test-subj:${TEST_SUBJ}`
 );
+const DEFAULT_TRUNCATION_STORY_URL = storyUrl(
+  'forms-euicombobox--default-truncation',
+  `data-test-subj:${TEST_SUBJ}`
+);
 
 // ---------------------------------------------------------------------------
 // singleSelection={true}  — one pill, no multi-select
@@ -289,6 +293,27 @@ test.describe('EuiComboBoxObject — onCreateOption + asPlainText', () => {
     await comboBox.setSelectedOptions(['Item 3']);
 
     expect(await comboBox.getSelectedOptions()).toEqual(['Item 3']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Truncated options — EUI truncates long option labels while filtering, so there
+// is no exact text match; the matcher falls back to keyboard-selecting the option.
+// ---------------------------------------------------------------------------
+
+test.describe('EuiComboBoxObject — truncated options', () => {
+  const LONG_LABEL =
+    'Item 2 with a long label that should truncation by default';
+
+  test('selects a long label that truncates by default', async ({ page }) => {
+    await page.goto(DEFAULT_TRUNCATION_STORY_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    const comboBox = new EuiComboBoxObject(page, TEST_SUBJ);
+    await comboBox.clear();
+
+    await comboBox.setSelectedOptions([LONG_LABEL]);
+
+    expect(await comboBox.getSelectedOptions()).toContain(LONG_LABEL);
   });
 });
 

--- a/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.spec.ts
@@ -43,6 +43,13 @@ test.describe('EuiComboBoxObject', () => {
       expect(await comboBox.getSelectedOptions()).toEqual(['Item 2']);
     });
 
+    test('selects the exact label when it is a prefix of another option', async () => {
+      // "Item 1" is a prefix of "Item 10"; must pick "Item 1", not "Item 10".
+      await comboBox.setSelectedOptions(['Item 1']);
+
+      expect(await comboBox.getSelectedOptions()).toEqual(['Item 1']);
+    });
+
     test('replaces the existing selection', async () => {
       await comboBox.setSelectedOptions(['Item 1', 'Item 2']);
       expect(await comboBox.getSelectedOptions()).toEqual(['Item 1', 'Item 2']);

--- a/packages/test-helpers/src/playwright/components/combo_box/object.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.ts
@@ -57,22 +57,34 @@ export class EuiComboBoxObject extends BaseObject {
       return;
     }
 
-    // Naive replace — clear, then add each. A diff-based approach would do
-    // less DOM work but require a per-pill remove primitive we don't ship yet.
-    await this.clear();
+    // Naive replace — clear, then add each. Exception: asPlainText single-select
+    // replaces its selection when a new option is picked, so clearing first is
+    // unnecessary — and its input can hold a non-clearable default (a placeholder
+    // rendered as the value) that clear() can't empty. Still clear when the target
+    // is empty (nothing to select would leave the old selection in place).
+    if (targetLabels.length === 0 || !(await this.isPlainText())) {
+      await this.clear();
+    }
 
     for (const label of targetLabels) {
       await this.addOption(label, timeout);
     }
 
-    if (targetLabels.length > 0) {
+    if (targetLabels.length > 0 && !(await this.isPlainText())) {
       // Blur the input to close the dropdown. Using blur() rather than a
       // keyboard event avoids bubbling Escape to page-level handlers
-      // (modal/flyout close listeners) on the consumer page.
+      // (modal/flyout close listeners) on the consumer page. Skipped for
+      // asPlainText: picking an option there already commits and closes the
+      // dropdown, and an extra blur can race the (often parent-controlled)
+      // selectedOptions update and discard the just-picked value.
       await this.searchInput.blur();
     }
 
-    expect([...(await this.getSelectedOptions())].sort()).toEqual(sortedTarget);
+    // Poll rather than assert once: an asPlainText selection is committed via
+    // the consumer's onChange, which can land a tick after the click.
+    await expect
+      .poll(() => this.getSelectedOptions().then((options) => [...options].sort()), { timeout })
+      .toEqual(sortedTarget);
   }
 
   /**
@@ -207,22 +219,24 @@ export class EuiComboBoxObject extends BaseObject {
     // inner `comboBoxInput` element does.
     await this.input.click();
 
-    // Type to filter, then match the option by accessible name. Substring match
-    // (not exact): while filtering, EUI middle-truncates the option text, so the
-    // accessible name isn't the literal label. The list renders in a portal
-    // outside `this.root`, so locate it from page level; the poll waits out async
-    // filtering.
+    // Type to filter, then wait for the (now narrowed) options to render.
     await this.searchInput.fill(label);
-    const option = this.root
+    const options = this.root
       .page()
       .locator(EuiComboBoxSelectors.optionsListFor(this.testSubj))
-      .getByRole('option', { name: label });
-    await expect.poll(() => option.count(), { timeout }).toBeGreaterThan(0);
-    if ((await option.count()) === 1) {
-      await option.click();
+      .getByRole('option');
+    await expect.poll(() => options.count(), { timeout }).toBeGreaterThan(0);
+
+    // Match on each option's full text so "ip" doesn't select "clientip" (EUI
+    // wraps the matched substring in `<mark>` while filtering, so a text-node
+    // lookup would match inside a longer option). If the text is truncated and
+    // has no exact match, fall back to keyboard-selecting the highlighted option.
+    const trimmed = label.trim();
+    const texts = await options.allInnerTexts();
+    const exactIndex = texts.findIndex((text) => text.trim() === trimmed);
+    if (exactIndex >= 0) {
+      await options.nth(exactIndex).click();
     } else {
-      // Substring can match several (e.g. "Item 1" also matches "Item 10") —
-      // keyboard-select the highlighted match.
       await this.searchInput.press('ArrowDown');
       await this.searchInput.press('Enter');
     }


### PR DESCRIPTION
## Summary

Four small, related fixes to the Playwright `EuiComboBoxObject` component object, all surfaced by consuming the published helper across Kibana's Scout combo-box suite. Grouped into one PR as they touch the same component object.

1. **Match options by exact text, not substring.** `setSelectedOptions(['ip'])` could select `clientip` because the accessible-name match was a substring. Now matches on each option's full text, with a keyboard-selection fallback for labels truncated while filtering (`EuiTextTruncate`, #272154).
2. **Skip the component-type guard when the element is absent.** A Component Object for a conditionally-rendered combo box timed out in the guard instead of proceeding.
3. **Don't clear an asPlainText combo before selecting.** Picking a new option already replaces the value there, and the input can hold a non-clearable default that `clear()` can't empty.
4. **Don't blur an asPlainText combo after selecting.** The selection commits via the consumer's `onChange`, which can land a tick after the click; the post-select `blur()` could race it and discard the value. Skipped for asPlainText, and the result is verified with a poll.

No behavior change for non-plain-text, present, substring-free combos.

### Testing
- EUI: `combo_box` + `base_object` Playwright specs pass, with added coverage for the substring/prefix, absent-guard, and truncation cases.
- Kibana: the five previously-failing Scout specs (dashboard / uptime / observability / inference) all pass reliably against a local build of this branch.
