### PR TITLE
[EuiFilterSelectItem] Migrate to function component

### DIFF
--- a/packages/eui/changelogs/upcoming/9841.md
+++ b/packages/eui/changelogs/upcoming/9841.md
@@ -1,0 +1,1 @@
+- Migrated `EuiFilterSelectItem` to a function component while preserving its existing behavior

--- a/packages/eui/changelogs/upcoming/9841.md
+++ b/packages/eui/changelogs/upcoming/9841.md
@@ -1,1 +1,0 @@
-- Migrated `EuiFilterSelectItem` to a function component while preserving its existing behavior

--- a/packages/eui/src/components/filter_group/filter_select_item.test.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import React from 'react';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
 import { shouldRenderCustomStyles } from '../../test/internal';
@@ -22,15 +23,138 @@ describe('EuiFilterSelectItem', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
+  describe('selection state', () => {
+    it.each([
+      ['selected', 'on', 'true', 'check'],
+      ['excluded', 'off', 'false', 'cross'],
+      ['neutral', undefined, 'false', 'empty'],
+    ] as const)(
+      'renders a %s item',
+      (_state, checked, ariaSelected, iconType) => {
+        const { container, getByRole } = render(
+          <EuiFilterSelectItem checked={checked}>Item</EuiFilterSelectItem>
+        );
+
+        expect(getByRole('option')).toHaveAttribute(
+          'aria-selected',
+          ariaSelected
+        );
+        expect(
+          container.querySelector(`[data-euiicon-type="${iconType}"]`)
+        ).toBeInTheDocument();
+      }
+    );
+
+    it('can hide icons', () => {
+      const { container } = render(
+        <EuiFilterSelectItem checked="on" showIcons={false}>
+          Item
+        </EuiFilterSelectItem>
+      );
+
+      expect(container.querySelector('[data-euiicon-type]')).toBeNull();
+    });
+  });
+
+  describe('interaction behavior', () => {
+    it('does not select or offer a tooltip when disabled', () => {
+      const onClick = jest.fn();
+      const { getByRole, queryByRole } = render(
+        <EuiFilterSelectItem
+          disabled
+          onClick={onClick}
+          toolTipContent="Filter item tooltip"
+        >
+          <span>Item</span>
+        </EuiFilterSelectItem>
+      );
+      const option = getByRole('option');
+
+      fireEvent.click(option);
+
+      expect(option).toBeDisabled();
+      expect(option).toHaveAttribute('aria-disabled', 'true');
+      expect(onClick).not.toHaveBeenCalled();
+      expect(queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+
+    it('applies focused appearance and scrolls into view when focused', () => {
+      const scrollIntoView = jest.fn();
+      const { getByRole, rerender } = render(
+        <EuiFilterSelectItem isFocused={false}>Item</EuiFilterSelectItem>
+      );
+      const option = getByRole('option');
+      option.scrollIntoView = scrollIntoView;
+      const unfocusedClassName = option.className;
+
+      rerender(<EuiFilterSelectItem isFocused>Item</EuiFilterSelectItem>);
+
+      expect(option.className).not.toBe(unfocusedClassName);
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
+    });
+
+    it('forwards the button ref', () => {
+      const forwardRef = jest.fn();
+      const { getByRole, rerender, unmount } = render(
+        <EuiFilterSelectItem forwardRef={forwardRef}>Item</EuiFilterSelectItem>
+      );
+
+      expect(forwardRef).toHaveBeenCalledWith(getByRole('option'));
+      expect(forwardRef).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <EuiFilterSelectItem forwardRef={forwardRef}>Item</EuiFilterSelectItem>
+      );
+      expect(forwardRef).toHaveBeenCalledTimes(1);
+
+      unmount();
+      expect(forwardRef).toHaveBeenLastCalledWith(null);
+    });
+  });
+
+  describe('content behavior', () => {
+    it.each([
+      ['element content is absent', <span>Item</span>, undefined],
+      ['content cannot anchor the tooltip', 'Item', 'Filter item tooltip'],
+    ])(
+      'does not offer a tooltip when %s',
+      (_case, children, toolTipContent) => {
+        const { queryByRole } = render(
+          <EuiFilterSelectItem isFocused toolTipContent={toolTipContent}>
+            {children}
+          </EuiFilterSelectItem>
+        );
+
+        expect(queryByRole('tooltip')).not.toBeInTheDocument();
+      }
+    );
+
+    it.each([
+      ['enabled', true],
+      ['disabled', false],
+    ])('renders content truncation when %s', (_state, truncateContent) => {
+      const { getByText } = render(
+        <EuiFilterSelectItem truncateContent={truncateContent}>
+          Item
+        </EuiFilterSelectItem>
+      );
+
+      expect(getByText('Item')).toHaveClass(
+        'euiFilterSelectItem__content',
+        ...(truncateContent ? ['eui-textTruncate'] : [])
+      );
+      if (!truncateContent) {
+        expect(getByText('Item')).not.toHaveClass('eui-textTruncate');
+      }
+    });
+  });
+
   describe('tooltip behavior', () => {
     const tooltipProps = {
       toolTipContent: 'Filter item tooltip',
       toolTipProps: { 'data-test-subj': 'filterItemToolTip' },
     };
 
-    // `toggleToolTip` is called in `componentDidUpdate`; on initial mount `tooltipRef.current`
-    // is null because `EuiToolTip` hasn't committed its ref yet, so a re-render is required
-    // to trigger `showToolTip`/`hideToolTip`.
     it('shows tooltip when `isFocused` becomes true', () => {
       const { rerender, getByTestSubject } = render(
         <EuiFilterSelectItem {...tooltipProps} isFocused={false}>

--- a/packages/eui/src/components/filter_group/filter_select_item.test.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.test.tsx
@@ -114,7 +114,7 @@ describe('EuiFilterSelectItem', () => {
 
   describe('content behavior', () => {
     it.each([
-      ['element content is absent', <span>Item</span>, undefined],
+      ['tooltip content is absent', <span>Item</span>, undefined],
       ['content cannot anchor the tooltip', 'Item', 'Filter item tooltip'],
     ])(
       'does not offer a tooltip when %s',

--- a/packages/eui/src/components/filter_group/filter_select_item.tsx
+++ b/packages/eui/src/components/filter_group/filter_select_item.tsx
@@ -8,13 +8,15 @@
 
 import React, {
   ButtonHTMLAttributes,
-  Component,
-  createRef,
+  FunctionComponent,
   isValidElement,
+  useEffect,
+  useMemo,
+  useRef,
 } from 'react';
 import classNames from 'classnames';
 
-import { withEuiTheme, WithEuiThemeProps } from '../../services';
+import { useCombinedRefs, useEuiTheme } from '../../services';
 import { CommonProps } from '../common';
 
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
@@ -59,176 +61,138 @@ const resolveIconAndColor = (checked?: FilterChecked) => {
  *
  * @deprecated - Use EuiSelectable instead
  */
-export class EuiFilterSelectItemClass extends Component<
-  WithEuiThemeProps & EuiFilterSelectItemProps
-> {
-  static defaultProps = {
-    showIcons: true,
-    truncateContent: true,
-  };
+const EuiFilterSelectItemComponent: FunctionComponent<
+  EuiFilterSelectItemProps
+> = ({
+  children,
+  className,
+  disabled,
+  checked,
+  isFocused,
+  showIcons = true,
+  toolTipContent,
+  toolTipProps,
+  style,
+  truncateContent = true,
+  forwardRef,
+  ...rest
+}) => {
+  const theme = useEuiTheme();
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const tooltipRef = useRef<EuiToolTipRef>(null);
+  const combinedButtonRefs = useMemo(
+    () => [buttonRef, forwardRef],
+    [forwardRef]
+  );
+  const setButtonRef = useCombinedRefs(combinedButtonRefs);
+  const previousIsFocused = useRef(isFocused);
+  const isMounted = useRef(false);
 
-  buttonRef: HTMLButtonElement | null = null;
-  tooltipRef = createRef<EuiToolTipRef>();
+  const hasToolTip =
+    // we're using isValidElement here as EuiToolTipAnchor uses
+    // cloneElement to enhance the element with required attributes
+    isValidElement(children) && !disabled && toolTipContent;
 
-  state = {
-    hasFocus: false,
-  };
-
-  setButtonRef = (node: HTMLButtonElement | null) => {
-    this.buttonRef = node;
-    this.props.forwardRef?.(node);
-  };
-
-  focus = () => {
-    if (this.buttonRef) {
-      this.buttonRef.focus();
+  useEffect(() => {
+    if (isMounted.current && isFocused && !previousIsFocused.current) {
+      buttonRef.current?.scrollIntoView?.({ block: 'nearest' });
     }
-  };
 
-  toggleToolTip = (isFocused: boolean) => {
-    if (isFocused) {
-      this.tooltipRef?.current?.showToolTip();
-    } else {
-      this.tooltipRef?.current?.hideToolTip();
-    }
-  };
-
-  hasFocus = () => {
-    return this.state.hasFocus;
-  };
-
-  componentDidMount() {
-    const { isFocused, toolTipContent, disabled, children } = this.props;
-    if (isValidElement(children) && !disabled && toolTipContent) {
-      this.toggleToolTip(isFocused ?? false);
-    }
-  }
-
-  componentDidUpdate(
-    prevProps: Readonly<WithEuiThemeProps<{}> & EuiFilterSelectItemProps>
-  ) {
-    if (this.props.isFocused && !prevProps.isFocused) {
-      this.buttonRef?.scrollIntoView?.({ block: 'nearest' });
-    }
-    const { isFocused, toolTipContent, disabled, children } = this.props;
     if (
-      isValidElement(children) &&
-      !disabled &&
-      toolTipContent &&
-      isFocused !== prevProps.isFocused
+      hasToolTip &&
+      (!isMounted.current || isFocused !== previousIsFocused.current)
     ) {
-      this.toggleToolTip(isFocused ?? false);
+      if (isFocused) {
+        tooltipRef.current?.showToolTip();
+      } else {
+        tooltipRef.current?.hideToolTip();
+      }
     }
+
+    previousIsFocused.current = isFocused;
+    isMounted.current = true;
+  }, [hasToolTip, isFocused]);
+
+  const styles = euiFilterSelectItemStyles(theme);
+  const cssStyles = [styles.euiFilterSelectItem, isFocused && styles.isFocused];
+
+  const classes = classNames('euiFilterSelectItem', className);
+
+  let anchorProps = undefined;
+
+  if (hasToolTip) {
+    const anchorStyles = toolTipProps?.anchorProps?.style
+      ? { ...toolTipProps?.anchorProps?.style, ...style }
+      : style;
+
+    anchorProps = toolTipProps?.anchorProps
+      ? {
+          ...toolTipProps.anchorProps,
+          style: anchorStyles,
+        }
+      : { style };
   }
 
-  render() {
-    const {
-      theme,
-      children,
-      className,
-      disabled,
-      checked,
-      isFocused,
-      showIcons,
-      toolTipContent,
-      toolTipProps,
-      style,
-      truncateContent,
-      forwardRef,
-      ...rest
-    } = this.props;
+  let iconNode;
+  if (showIcons) {
+    const { icon, color } = resolveIconAndColor(checked);
+    iconNode = (
+      <EuiFlexItem grow={false}>
+        <EuiIcon color={color} type={icon} />
+      </EuiFlexItem>
+    );
+  }
 
-    const styles = euiFilterSelectItemStyles(theme);
-    const cssStyles = [
-      styles.euiFilterSelectItem,
-      isFocused && styles.isFocused,
-    ];
-
-    const classes = classNames('euiFilterSelectItem', className);
-
-    const hasToolTip =
-      // we're using isValidElement here as EuiToolTipAnchor uses
-      // cloneElement to enhance the element with required attributes
-      isValidElement(children) && !disabled && toolTipContent;
-
-    let anchorProps = undefined;
-
-    if (hasToolTip) {
-      const anchorStyles = toolTipProps?.anchorProps?.style
-        ? { ...toolTipProps?.anchorProps?.style, ...style }
-        : style;
-
-      anchorProps = toolTipProps?.anchorProps
-        ? {
-            ...toolTipProps.anchorProps,
-            style: anchorStyles,
-          }
-        : { style };
-    }
-
-    let iconNode;
-    if (showIcons) {
-      const { icon, color } = resolveIconAndColor(checked);
-      iconNode = (
-        <EuiFlexItem grow={false}>
-          <EuiIcon color={color} type={icon} />
-        </EuiFlexItem>
-      );
-    }
-
-    const optionItem = (
-      <button
-        ref={this.setButtonRef}
-        role="option"
-        type="button"
-        aria-selected={checked === 'on'}
-        className={classes}
-        css={cssStyles}
-        disabled={disabled}
-        aria-disabled={disabled}
-        style={!hasToolTip ? style : undefined}
-        {...rest}
+  const optionItem = (
+    <button
+      ref={setButtonRef}
+      role="option"
+      type="button"
+      aria-selected={checked === 'on'}
+      className={classes}
+      css={cssStyles}
+      disabled={disabled}
+      aria-disabled={disabled}
+      style={!hasToolTip ? style : undefined}
+      {...rest}
+    >
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="s"
+        component="span"
+        responsive={false}
       >
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="s"
+        {iconNode}
+        <EuiFlexItem
+          className={classNames(
+            'euiFilterSelectItem__content',
+            truncateContent && 'eui-textTruncate'
+          )}
           component="span"
-          responsive={false}
         >
-          {iconNode}
-          <EuiFlexItem
-            className={classNames(
-              'euiFilterSelectItem__content',
-              this.props.truncateContent && 'eui-textTruncate'
-            )}
-            component="span"
-          >
-            {children}
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </button>
-    );
+          {children}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </button>
+  );
 
-    return hasToolTip ? (
-      <EuiToolTip
-        ref={this.tooltipRef}
-        display="block"
-        content={toolTipContent}
-        position="left"
-        {...toolTipProps}
-        anchorProps={anchorProps}
-      >
-        {optionItem}
-      </EuiToolTip>
-    ) : (
-      optionItem
-    );
-  }
-}
+  return hasToolTip ? (
+    <EuiToolTip
+      ref={tooltipRef}
+      display="block"
+      content={toolTipContent}
+      position="left"
+      {...toolTipProps}
+      anchorProps={anchorProps}
+    >
+      {optionItem}
+    </EuiToolTip>
+  ) : (
+    optionItem
+  );
+};
 
 /**
  * @deprecated - Use EuiSelectable instead
  */
-export const EuiFilterSelectItem = withEuiTheme<EuiFilterSelectItemProps>(
-  EuiFilterSelectItemClass
-);
+export const EuiFilterSelectItem = EuiFilterSelectItemComponent;


### PR DESCRIPTION
## Summary

- Migrates `EuiFilterSelectItem` from a class component to a function component using hooks.
- Replaces `withEuiTheme` with `useEuiTheme`.
- Preserves focus, tooltip, scrolling, ref-forwarding, selection, and truncation behavior.
- Adds focused RTL coverage for the behavior described in the issue.

Fixes #9489.

### API Changes

None. The existing public API and behavior are preserved.

## Screenshots

Not applicable. This is an internal refactor with no intended visual changes.

## Impact Assessment

- [x] Test impact - Focused unit tests were added and existing snapshot behavior is preserved.

**Impact level:** Low

## Release Readiness

- ~~Documentation: Not applicable; there are no API or behavior changes.~~
- ~~Figma: Not applicable; there are no visual changes.~~
- ~~Migration guide: Not applicable; the public API is unchanged.~~
- ~~Adoption plan: Not applicable; this refactors an existing component.~~

### QA instructions for reviewer

- Run the focused test suite on React 17:
  `yarn test-unit src/components/filter_group/filter_select_item.test.tsx --runInBand --react-version=17`
- Run the focused test suite on React 18:
  `yarn test-unit src/components/filter_group/filter_select_item.test.tsx --runInBand --react-version=18`
- Confirm the selected, excluded, neutral, disabled, focused, tooltip, ref-forwarding, and truncation tests pass.
- Confirm `yarn tsc --noEmit` passes.

### Validation completed

- React 17 focused unit tests: 15 passed.
- React 18 focused unit tests: 15 passed.
- Changed-file test run: 9 suites and 131 tests passed.
- TypeScript: passed.
- Full lint: 0 errors (existing repository warnings remain).
- `git diff --check`: passed.

### Checklist before marking Ready for Review

- [x] Filled out all applicable sections above
- ~~QA: Broad browser, visual, mobile, keyboard, and screen-reader testing is not applicable because rendered behavior and markup are preserved.~~
- ~~QA: CodeSandbox and Kibana testing is not applicable for this internal refactor with no public API or visual changes.~~
- ~~QA: No documentation changes.~~
- [x] Tests: Added/updated focused Jest coverage
- [x] Changelog: Skipped per maintainer guidance because this is an internal change
- ~~Breaking changes: Not applicable.~~

### Reviewer checklist

- [ ] Approved **Impact Assessment** - Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** - Docs, Figma, and migration info are sufficient to ship.
