### PR TITLE
[Chore] Harden release auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,8 +175,8 @@ jobs:
           fetch-depth: 0
       - name: Configure git
         run: |
-          git config --global user.name 'EUI Machine'
-          git config --global user.email 'tkajtoch@users.noreply.github.com'
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -300,8 +300,8 @@ jobs:
           fi
       - name: Configure git
         run: |
-          git config --global user.name 'EUI Machine'
-          git config --global user.email 'tkajtoch@users.noreply.github.com'
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       release_ref:
-        description: Upstream git ref to create the release from
+        description: Git ref or commit SHA to create the release from
         required: true
         type: string
       type:
@@ -99,15 +99,67 @@ jobs:
         run: yarn workspaces foreach --all --parallel --topological-dev --exclude @elastic/eui-website --exclude @elastic/eui-monorepo --exclude @elastic/eui-docgen run build
       - name: Cypress tests
         run: yarn workspaces foreach --all --parallel --topological-dev --exclude @elastic/eui-website --exclude @elastic/eui-monorepo --exclude @elastic/eui-docgen run test-cypress
+  verify_release_source:
+    name: Verify release source
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      requires_approval: ${{ steps.verify.outputs.requires_approval }}
+      review_url: ${{ steps.verify.outputs.review_url }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify release source
+        id: verify
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIBANA_INTEGRATION: ${{ inputs.kibana_integration }}
+          NIGHTLY: ${{ inputs.kibana_nightly }}
+          NPM_TAG: ${{ inputs.npm_tag }}
+          RELEASE_REF: ${{ inputs.release_ref }}
+          RELEASE_TYPE: ${{ inputs.type }}
+          SKIP_TESTS: ${{ inputs.skip_tests }}
+          SOURCE_PR_NUMBER: ${{ inputs.kibana_source_pr_number }}
+          WORKSPACES: ${{ inputs.workspaces }}
+        run: bash scripts/verify_release_source.sh
+  approve_snapshot:
+    name: Approve snapshot release
+    runs-on: ubuntu-slim
+    environment:
+      name: npm-snapshot
+      url: ${{ needs.verify_release_source.outputs.review_url }}
+    if: |
+      always() &&
+      inputs.type == 'snapshot' &&
+      needs.verify_release_source.result == 'success' &&
+      needs.verify_release_source.outputs.requires_approval == 'true' &&
+      (needs.lint_and_unit_tests.result == 'success' || needs.lint_and_unit_tests.result == 'skipped') &&
+      (needs.cypress_tests.result == 'success' || needs.cypress_tests.result == 'skipped')
+    needs: [ lint_and_unit_tests, cypress_tests, verify_release_source ]
+    steps:
+      - run: echo "Snapshot release approved"
   release_snapshot:
     name: Create a snapshot release
     runs-on: ubuntu-latest
     if: |
       always() &&
       inputs.type == 'snapshot' &&
+      needs.verify_release_source.result == 'success' &&
+      (
+        (needs.verify_release_source.outputs.requires_approval == 'true' &&
+          needs.approve_snapshot.result == 'success') ||
+        (needs.verify_release_source.outputs.requires_approval == 'false' &&
+          needs.approve_snapshot.result == 'skipped')
+      ) &&
       (needs.lint_and_unit_tests.result == 'success' || needs.lint_and_unit_tests.result == 'skipped') &&
       (needs.cypress_tests.result == 'success' || needs.cypress_tests.result == 'skipped')
-    needs: [ lint_and_unit_tests, cypress_tests ]
+    needs: [ lint_and_unit_tests, cypress_tests, verify_release_source, approve_snapshot ]
     permissions:
       id-token: write # Required for OIDC (npm trusted publishing)
       contents: read
@@ -220,9 +272,11 @@ jobs:
       contents: read
     if: |
       inputs.type == 'official' &&
+      needs.verify_release_source.result == 'success' &&
+      needs.verify_release_source.outputs.requires_approval == 'false' &&
       needs.lint_and_unit_tests.result == 'success' &&
       needs.cypress_tests.result == 'success'
-    needs: [ lint_and_unit_tests, cypress_tests ]
+    needs: [ lint_and_unit_tests, cypress_tests, verify_release_source ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,6 @@ concurrency:
   cancel-in-progress: false
   queue: max
 permissions:
-  id-token: write # Required for OIDC
   contents: read
 
 jobs:
@@ -216,6 +215,9 @@ jobs:
   release_official:
     name: Create an official release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC (npm trusted publishing)
+      contents: read
     if: |
       inputs.type == 'official' &&
       needs.lint_and_unit_tests.result == 'success' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       release_ref:
-        description: Git ref or commit SHA to create the release from
+        description: Full commit SHA to create the release from
         required: true
         type: string
       type:
@@ -131,6 +131,7 @@ jobs:
   approve_snapshot:
     name: Approve snapshot release
     runs-on: ubuntu-slim
+    permissions: {}
     environment:
       name: npm-snapshot
       url: ${{ needs.verify_release_source.outputs.review_url }}
@@ -168,6 +169,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.release_ref }}
+          persist-credentials: false
           # This is needed for yarn version to work properly, but it increases fetch time.
           # We can change this back to "1" if we replace yarn version with something else
           fetch-depth: 0
@@ -281,13 +283,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.release_ref }}
+          persist-credentials: false
           # This is needed for yarn version to work properly, but it increases fetch time.
           # We can change this back to "1" if we replace yarn version with something else
           fetch-depth: 0
       - name: Verify release commit is tagged
+        env:
+          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
-          tag=$(git tag --points-at ${{ inputs.release_ref }})
-          if [[ "$?" -ne 0 ]] || [[ -z "$tag" ]]; then
+          tag="$(git tag --points-at "$RELEASE_REF")"
+          if [[ -z "$tag" ]]; then
             echo "::error:: Release ref does not point to any tag. Please tag the merge commit of the release PR and try again"
             exit 1
           else

--- a/packages/eui-docgen/package.json
+++ b/packages/eui-docgen/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkajtoch/eui.git",
+    "url": "https://github.com/elastic/eui.git",
     "directory": "packages/eui-docgen"
   },
   "private": true,

--- a/packages/release-cli/package.json
+++ b/packages/release-cli/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/tkajtoch/eui.git",
+    "url": "https://github.com/elastic/eui.git",
     "directory": "packages/release-cli"
   },
   "devDependencies": {

--- a/scripts/verify_release_source.sh
+++ b/scripts/verify_release_source.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Verifies a release source and emits approval-gate outputs.
+
+set -euo pipefail
+
+error() {
+  echo "::error::${1//[$'\r\n']/ }" >&2
+  exit 1
+}
+
+verify_commit_exists() {
+  git rev-parse --verify --quiet "$RELEASE_REF^{commit}" > /dev/null ||
+    error "Release ref $RELEASE_REF is not available in $GITHUB_REPOSITORY"
+}
+
+verify_main_commit() {
+  verify_commit_exists
+  git merge-base --is-ancestor "$RELEASE_REF" HEAD ||
+    error "Release ref $RELEASE_REF is not contained in $GITHUB_REPOSITORY:main"
+}
+
+if [[ "$NIGHTLY" == 'true' ]]; then
+  [[ "$RELEASE_TYPE" == 'snapshot' && "$GITHUB_ACTOR" == 'github-actions[bot]' ]] ||
+    error 'Nightly releases must be automated snapshots'
+
+  verify_main_commit
+
+  [[ "$DRY_RUN" == 'false' &&
+    "$KIBANA_INTEGRATION" == 'true' &&
+    -z "$NPM_TAG" &&
+    "$SKIP_TESTS" == 'false' &&
+    -z "$SOURCE_PR_NUMBER" &&
+    -z "$WORKSPACES" ]] ||
+    error 'Nightly snapshot inputs do not match the automated configuration'
+
+  echo 'requires_approval=false' >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+if [[ "$RELEASE_TYPE" == 'official' ]]; then
+  verify_commit_exists
+  echo 'requires_approval=false' >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+[[ "$RELEASE_TYPE" == 'snapshot' ]] ||
+  error "Unsupported release type: $RELEASE_TYPE"
+
+main_sha="$(git rev-parse HEAD)"
+review_url="https://github.com/$GITHUB_REPOSITORY/compare/$main_sha...$RELEASE_REF"
+
+if [[ -n "$SOURCE_PR_NUMBER" ]]; then
+  [[ "$SOURCE_PR_NUMBER" =~ ^[1-9][0-9]*$ ]] ||
+    error "Invalid snapshot source PR number: $SOURCE_PR_NUMBER"
+
+  pull_request="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$SOURCE_PR_NUMBER")"
+  base_repository="$(jq -r '.base.repo.full_name' <<< "$pull_request")"
+  base_ref="$(jq -r '.base.ref' <<< "$pull_request")"
+  base_sha="$(jq -r '.base.sha' <<< "$pull_request")"
+  head_repository="$(jq -r '.head.repo.full_name // empty' <<< "$pull_request")"
+  head_sha="$(jq -r '.head.sha' <<< "$pull_request")"
+
+  [[ "$base_repository" == "$GITHUB_REPOSITORY" && "$base_ref" == 'main' ]] ||
+    error "Source PR must target $GITHUB_REPOSITORY:main"
+  [[ "$head_sha" == "$RELEASE_REF" ]] ||
+    error "Source PR head $head_sha does not match release ref $RELEASE_REF"
+  [[ -n "$head_repository" ]] ||
+    error 'Source PR head repository is unavailable'
+
+  review_url="https://github.com/$head_repository/compare/$base_sha...$head_sha"
+fi
+
+{
+  echo 'requires_approval=true'
+  echo "review_url=$review_url"
+} >> "$GITHUB_OUTPUT"

--- a/scripts/verify_release_source.sh
+++ b/scripts/verify_release_source.sh
@@ -20,6 +20,27 @@ verify_main_commit() {
     error "Release ref $RELEASE_REF is not contained in $GITHUB_REPOSITORY:main"
 }
 
+validate_release_arguments() {
+  local workspace
+  local -a workspaces
+
+  if [[ -n "$NPM_TAG" && ! "$NPM_TAG" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]]; then
+    error "Invalid npm tag: $NPM_TAG"
+  fi
+
+  if [[ -n "$WORKSPACES" ]]; then
+    IFS=',' read -r -a workspaces <<< "$WORKSPACES"
+    for workspace in "${workspaces[@]}"; do
+      [[ "$workspace" != -* && "$workspace" =~ ^[a-zA-Z0-9@._/-]+$ ]] ||
+        error "Invalid workspace: $workspace"
+    done
+  fi
+}
+
+RELEASE_REF="$(tr '[:upper:]' '[:lower:]' <<< "$RELEASE_REF")"
+[[ "$RELEASE_REF" =~ ^[0-9a-f]{40}$ ]] ||
+  error 'release_ref must be a full 40-character commit SHA'
+
 if [[ "$NIGHTLY" == 'true' ]]; then
   [[ "$RELEASE_TYPE" == 'snapshot' && "$GITHUB_ACTOR" == 'github-actions[bot]' ]] ||
     error 'Nightly releases must be automated snapshots'
@@ -37,6 +58,8 @@ if [[ "$NIGHTLY" == 'true' ]]; then
   echo 'requires_approval=false' >> "$GITHUB_OUTPUT"
   exit 0
 fi
+
+validate_release_arguments
 
 if [[ "$RELEASE_TYPE" == 'official' ]]; then
   verify_commit_exists
@@ -69,6 +92,8 @@ if [[ -n "$SOURCE_PR_NUMBER" ]]; then
     error 'Source PR head repository is unavailable'
 
   review_url="https://github.com/$head_repository/compare/$base_sha...$head_sha"
+else
+  verify_commit_exists
 fi
 
 {


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

- Scope OIDC permissions to npm publishing jobs.
- Verify nightlies are automated from `elastic/eui/main`.
- Verify official releases point at an existing commit in `elastic/eui` including backports from release branches.
- Require protected-environment approval for all other snapshots. _Environment added already, review from EUI team, no self-review, admin bypass._
- Harden release inputs and checkout credentials.
- Replace the legacy release Git identity and personal-fork repository URLs.

### Behavior

- Nightly snapshots remain automated from `main`.
- Official releases remain automated, including backports (commit must exist in `elastic/eui` and point at a tag).
- Other snapshots require @elastic/eui-team approval with a pinned source diff (`base SHA...head SHA`).
- Label-triggered Kibana integration snapshots (`ci:regression-integration-test-kibana`) now wait for environment approval before publishing and opening the Kibana PR.
- `dry_run: true` snapshots also wait for approval.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Cannot be tested until merged.