### PR TITLE
refactor(EuiCopy): migrate from class to function component

### DIFF
--- a/packages/eui/changelogs/upcoming/9860.md
+++ b/packages/eui/changelogs/upcoming/9860.md
@@ -1,1 +1,0 @@
-- Updated `EuiCopy` to be a function component

--- a/packages/eui/changelogs/upcoming/9860.md
+++ b/packages/eui/changelogs/upcoming/9860.md
@@ -1,0 +1,1 @@
+- Updated `EuiCopy` to be a function component

--- a/packages/eui/src/components/copy/copy.test.tsx
+++ b/packages/eui/src/components/copy/copy.test.tsx
@@ -189,6 +189,7 @@ describe('EuiCopy', () => {
       fireEvent.click(getByTestSubject('copyButton'));
       expect(getByRole('tooltip')).toHaveTextContent(afterMessage);
     });
+
     it('tooltipProps', () => {
       const tooltipProps = {
         'data-test-subj': 'customTooltip',
@@ -241,7 +242,9 @@ describe('EuiCopy', () => {
       unmount();
 
       // Consumers may hold onto the render prop `copy` callback (e.g. in a
-      // debounced handler). Calling it post-unmount must be a no-op.
+      // debounced handler). Calling it post-unmount still writes to the
+      // clipboard; what must not happen is a state update on the unmounted
+      // component, which React 17 surfaces as a warning and React 18 ignores.
       expect(() => copyFn?.()).not.toThrow();
 
       expect(consoleErrorSpy).not.toHaveBeenCalled();

--- a/packages/eui/src/components/copy/copy.test.tsx
+++ b/packages/eui/src/components/copy/copy.test.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { fireEvent } from '@testing-library/react';
 import { render } from '../../test/rtl';
 import { requiredProps } from '../../test';
+import { EuiToolTip } from '../tool_tip';
 
 import { EuiCopy } from './copy';
 
@@ -112,6 +113,82 @@ describe('EuiCopy', () => {
       expect(hasAnnouncement).toBe(true);
     });
 
+    it('reverts from `afterMessage` back to `beforeMessage` on mouse out', () => {
+      const beforeMessage = 'copy this';
+      const afterMessage = 'successfully copied';
+      const { getByRole, queryByRole } = render(
+        <EuiCopy
+          textToCopy="some text"
+          beforeMessage={beforeMessage}
+          afterMessage={afterMessage}
+        >
+          {(copy) => (
+            <button onClick={copy} onMouseOver={() => {}} onFocus={() => {}}>
+              Click to copy input text
+            </button>
+          )}
+        </EuiCopy>
+      );
+
+      fireEvent.mouseOver(getByRole('button'));
+      expect(getByRole('tooltip')).toHaveTextContent(beforeMessage);
+
+      fireEvent.click(getByRole('button'));
+      expect(getByRole('tooltip')).toHaveTextContent(afterMessage);
+
+      // Moving the pointer away resets back to the `beforeMessage`
+      fireEvent.mouseOut(getByRole('button'));
+      expect(queryByRole('tooltip')).not.toBeInTheDocument();
+
+      fireEvent.mouseOver(getByRole('button'));
+      expect(getByRole('tooltip')).toHaveTextContent(beforeMessage);
+    });
+
+    it('shows the `afterMessage` tooltip again on a repeat copy', () => {
+      const afterMessage = 'successfully copied';
+      const { getAllByRole, getByRole, queryByRole, getByTestSubject } = render(
+        <>
+          <EuiCopy textToCopy="some text" afterMessage={afterMessage}>
+            {(copy) => (
+              <button
+                data-test-subj="copyButton"
+                onClick={copy}
+                onMouseOver={() => {}}
+                onFocus={() => {}}
+              >
+                Click to copy input text
+              </button>
+            )}
+          </EuiCopy>
+          <EuiToolTip content="other tooltip">
+            <button
+              data-test-subj="otherButton"
+              onMouseOver={() => {}}
+              onFocus={() => {}}
+            >
+              Other anchor
+            </button>
+          </EuiToolTip>
+        </>
+      );
+
+      fireEvent.click(getByTestSubject('copyButton'));
+      expect(getByRole('tooltip')).toHaveTextContent(afterMessage);
+
+      // Only one tooltip may be visible at a time, so showing an unrelated
+      // tooltip hides the copy tooltip without `EuiCopy` being told about it.
+      fireEvent.mouseOver(getByTestSubject('otherButton'));
+      expect(getAllByRole('tooltip')).toHaveLength(1);
+      expect(getByRole('tooltip')).toHaveTextContent('other tooltip');
+
+      fireEvent.mouseOut(getByTestSubject('otherButton'));
+      expect(queryByRole('tooltip')).not.toBeInTheDocument();
+
+      // Copying again must show the tooltip again, even though the copied
+      // state itself has not changed since the previous copy.
+      fireEvent.click(getByTestSubject('copyButton'));
+      expect(getByRole('tooltip')).toHaveTextContent(afterMessage);
+    });
     it('tooltipProps', () => {
       const tooltipProps = {
         'data-test-subj': 'customTooltip',
@@ -139,6 +216,55 @@ describe('EuiCopy', () => {
       expect(tooltip).toBeInTheDocument();
       expect(tooltip?.className).toContain('myTooltipClass');
       fireEvent.mouseOut(getByRole('button'));
+    });
+  });
+
+  describe('unmounting', () => {
+    it('does not update state or warn if `copy` is called after unmount', () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const consoleWarnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {});
+
+      let copyFn: (() => void) | undefined;
+      const { unmount } = render(
+        <EuiCopy textToCopy="some text">
+          {(copy) => {
+            copyFn = copy;
+            return <button onClick={copy}>Click to copy input text</button>;
+          }}
+        </EuiCopy>
+      );
+
+      unmount();
+
+      // Consumers may hold onto the render prop `copy` callback (e.g. in a
+      // debounced handler). Calling it post-unmount must be a no-op.
+      expect(() => copyFn?.()).not.toThrow();
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('does not leave a visible tooltip behind after unmount', () => {
+      const afterMessage = 'successfully copied';
+      const { getByRole, unmount } = render(
+        <EuiCopy textToCopy="some text" afterMessage={afterMessage}>
+          {(copy) => <button onClick={copy}>Click to copy input text</button>}
+        </EuiCopy>
+      );
+
+      fireEvent.click(getByRole('button'));
+      expect(getByRole('tooltip')).toHaveTextContent(afterMessage);
+
+      unmount();
+
+      expect(document.querySelector('[role="tooltip"]')).toBeNull();
     });
   });
 });

--- a/packages/eui/src/components/copy/copy.tsx
+++ b/packages/eui/src/components/copy/copy.tsx
@@ -56,6 +56,16 @@ export const EuiCopy: FunctionComponent<EuiCopyProps> = ({
 }) => {
   const tooltipRef = useRef<EuiToolTipRef>(null);
 
+  // Consumers can hold onto the render prop `copy` callback and invoke it after
+  // this component has unmounted (e.g. from a debounced handler). Setting state
+  // then is a no-op that React 17 additionally warns about, so skip it.
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   // Counts successful copies instead of storing a boolean, so that every copy
   // re-runs the effect below - the tooltip may have been hidden in between
   // copies (e.g. by another tooltip being shown) and needs showing again.
@@ -64,13 +74,16 @@ export const EuiCopy: FunctionComponent<EuiCopyProps> = ({
   const tooltipText = isCopied ? afterMessage : beforeMessage;
 
   const copy = useCallback(() => {
-    if (copyToClipboard(textToCopy)) {
+    const copied = copyToClipboard(textToCopy);
+    if (copied && isMountedRef.current) {
       setCopyCount((count) => count + 1);
     }
   }, [textToCopy]);
 
   const resetTooltipText = useCallback(() => {
-    setCopyCount(0);
+    if (isMountedRef.current) {
+      setCopyCount(0);
+    }
   }, []);
 
   // `EuiToolTip` suppresses showing when content is empty, so `EuiCopy`

--- a/packages/eui/src/components/copy/copy.tsx
+++ b/packages/eui/src/components/copy/copy.tsx
@@ -6,7 +6,15 @@
  * Side Public License, v 1.
  */
 
-import React, { Component, createRef, ReactElement, ReactNode } from 'react';
+import React, {
+  FunctionComponent,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { CommonProps } from '../common';
 import { copyToClipboard } from '../../services';
 import { EuiScreenReaderOnly } from '../accessibility';
@@ -39,83 +47,67 @@ export interface EuiCopyProps extends CommonProps {
   >;
 }
 
-interface EuiCopyState {
-  tooltipText: ReactNode;
-  isCopied: boolean;
-}
+export const EuiCopy: FunctionComponent<EuiCopyProps> = ({
+  textToCopy,
+  beforeMessage,
+  afterMessage = 'Copied',
+  children,
+  tooltipProps,
+}) => {
+  const tooltipRef = useRef<EuiToolTipRef>(null);
 
-export class EuiCopy extends Component<EuiCopyProps, EuiCopyState> {
-  static defaultProps = {
-    afterMessage: 'Copied',
-  };
+  // Counts successful copies instead of storing a boolean, so that every copy
+  // re-runs the effect below - the tooltip may have been hidden in between
+  // copies (e.g. by another tooltip being shown) and needs showing again.
+  const [copyCount, setCopyCount] = useState(0);
+  const isCopied = copyCount > 0;
+  const tooltipText = isCopied ? afterMessage : beforeMessage;
 
-  private tooltipRef = createRef<EuiToolTipRef>();
-
-  constructor(props: EuiCopyProps) {
-    super(props);
-
-    this.state = {
-      tooltipText: this.props.beforeMessage,
-      isCopied: false,
-    };
-  }
-
-  copy = () => {
-    const isCopied = copyToClipboard(this.props.textToCopy);
-    if (isCopied) {
-      this.setState(
-        {
-          tooltipText: this.props.afterMessage,
-          isCopied: true,
-        },
-        // `EuiToolTip` suppresses showing when content is empty, so `EuiCopy`
-        // imperatively shows the tooltip after the post-copy state update.
-        () => {
-          this.tooltipRef.current?.showToolTip();
-        }
-      );
+  const copy = useCallback(() => {
+    if (copyToClipboard(textToCopy)) {
+      setCopyCount((count) => count + 1);
     }
-  };
+  }, [textToCopy]);
 
-  resetTooltipText = () => {
-    this.setState({
-      tooltipText: this.props.beforeMessage,
-      isCopied: false,
-    });
-  };
+  const resetTooltipText = useCallback(() => {
+    setCopyCount(0);
+  }, []);
 
-  render() {
-    const { children, tooltipProps, afterMessage } = this.props;
-    const { tooltipText, isCopied } = this.state;
+  // `EuiToolTip` suppresses showing when content is empty, so `EuiCopy`
+  // imperatively shows the tooltip after the post-copy state update.
+  useEffect(() => {
+    if (copyCount > 0) {
+      tooltipRef.current?.showToolTip();
+    }
+  }, [copyCount]);
 
-    return (
-      <>
-        {/* See `src/components/tool_tip/tool_tip_anchor.tsx` for explanation of below eslint-disable */}
-        {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}
-        <EuiToolTip
-          ref={this.tooltipRef}
-          content={tooltipText}
-          onMouseOut={this.resetTooltipText}
-          {...tooltipProps}
-          onBlur={() => {
-            tooltipProps?.onBlur?.();
-            if (isCopied) this.resetTooltipText();
-          }}
-          disableScreenReaderOutput={
-            isCopied || !!tooltipProps?.disableScreenReaderOutput
-          }
-        >
-          {children(this.copy)}
-        </EuiToolTip>
-        {/* Stable `aria-live` region so VoiceOver/Safari announces reliably.
+  return (
+    <>
+      {/* See `src/components/tool_tip/tool_tip_anchor.tsx` for explanation of below eslint-disable */}
+      {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}
+      <EuiToolTip
+        ref={tooltipRef}
+        content={tooltipText}
+        onMouseOut={resetTooltipText}
+        {...tooltipProps}
+        onBlur={() => {
+          tooltipProps?.onBlur?.();
+          if (isCopied) resetTooltipText();
+        }}
+        disableScreenReaderOutput={
+          isCopied || !!tooltipProps?.disableScreenReaderOutput
+        }
+      >
+        {children(copy)}
+      </EuiToolTip>
+      {/* Stable `aria-live` region so VoiceOver/Safari announces reliably.
        `EuiScreenReaderLive` alternates `aria-live` between "off" and active which
         Safari ignores when attribute and content change in the same render. */}
-        <EuiScreenReaderOnly>
-          <div aria-live="assertive" aria-atomic="true">
-            {isCopied ? afterMessage : ''}
-          </div>
-        </EuiScreenReaderOnly>
-      </>
-    );
-  }
-}
+      <EuiScreenReaderOnly>
+        <div aria-live="assertive" aria-atomic="true">
+          {isCopied ? afterMessage : ''}
+        </div>
+      </EuiScreenReaderOnly>
+    </>
+  );
+};


### PR DESCRIPTION
Closes #9466.

Picking this up after #9608 was closed as stale with the note that another external contributor could take it up.

## What changed

`EuiCopy` becomes a function component. The rendered DOM is unchanged — the existing snapshot passes untouched.

Two details worth review attention:

**Re-triggering the tooltip on a repeat copy.** The class relied on `setState`'s completion callback to call `showToolTip()` imperatively. Hooks have no equivalent, so state is now a `copyCount` counter and a `useEffect` keyed on it fires the imperative call. Using a boolean `isCopied` instead would not re-fire on a second copy — there's a test covering exactly that (see the negative control below).

**Callback identity.** `copy` and `resetTooltipText` are wrapped in `useCallback` so the render-prop callbacks stay as stable as the class methods were.

Preserved verbatim: the `EuiToolTip` ref/content/`onMouseOut`/`onBlur` wiring, `tooltipProps` spread order, `disableScreenReaderOutput` logic, and the `EuiScreenReaderOnly` `aria-live="assertive" aria-atomic="true"` region.

## Consequences of dropping the class

Neither is part of the documented API, but flagging both explicitly:

1. `static defaultProps = { afterMessage: 'Copied' }` becomes a destructured default. Runtime behaviour is identical, but `EuiCopy.defaultProps` is no longer readable or overridable at runtime. This matches how the merged EuiAccordion conversion (#9558) handled defaults.
2. A consumer could previously attach a `ref` and reach the instance methods. Function components have no instance ref. `EuiCopyProps` never declared one, and grepping `packages/eui/src` the only consumers are `code_block_copy.tsx` and two stories files — none pass a ref. I did not add `forwardRef` since there is no DOM node that would obviously be the ref target; happy to add one if you'd prefer to keep that door open.

## Tests

Four new tests covering what the class guaranteed:

- reverts from `afterMessage` to `beforeMessage` on mouse out
- shows `afterMessage` again on a repeat copy
- calling the render-prop `copy` after unmount neither throws nor warns
- no tooltip is left behind after unmount

`copy.test.tsx`: **14 passed** (was 10), 1 snapshot passed unchanged.

**Negative controls**, run one at a time:

- keying the effect on `isCopied` instead of `copyCount` → exactly the repeat-copy test fails (`Unable to find an accessible element with the role "tooltip"`), 13 pass
- replacing `onMouseOut={resetTooltipText}` with a no-op → exactly the mouse-out test fails (expected `copy this`, received `successfully copied`), 13 pass

Both restored; final run is green.

## Verification caveats

- Verified on **Windows** with Node 20.18.1, so the repo's `validate-env` yarn plugin was bypassed locally. Please treat CI as authoritative for the platform.
- One deliberate behaviour difference: the class froze the tooltip text in state at copy/reset time, so a `beforeMessage`/`afterMessage` prop change arriving mid-flight was ignored until the next reset. The derived value now reflects the current prop immediately. I believe that's a fix, but no test covered either version, so I'm calling it out rather than hiding it.
- `document.execCommand` is mocked in the suite, so the clipboard-failure path is only exercised implicitly.
- The Cypress a11y spec (`copy.a11y.tsx`) and visual-regression screenshots are CI-side and were not run locally.

Changelog entry follows in a second commit, named after this PR number.
