### PR TITLE
[EuiContextMenuItem] Add `hasAriaDisabled` prop type

### DIFF
--- a/packages/eui/changelogs/upcoming/9870.md
+++ b/packages/eui/changelogs/upcoming/9870.md
@@ -2,4 +2,4 @@
 
 **Bug fixes**
 
-- Fixed missing type declarations for the `focusEuiToolTipTrigger` and `simulateFocusVisible` test helpers
+- Fixed the missing type declaration for the `focusEuiToolTipTrigger` test helper

--- a/packages/eui/changelogs/upcoming/9870.md
+++ b/packages/eui/changelogs/upcoming/9870.md
@@ -1,0 +1,5 @@
+- Added `hasAriaDisabled` prop to `EuiContextMenuItem`
+
+**Bug fixes**
+
+- Fixed missing type declarations for the `focusEuiToolTipTrigger` and `simulateFocusVisible` test helpers

--- a/packages/eui/src/components/context_menu/context_menu_item.stories.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_item.stories.tsx
@@ -25,12 +25,20 @@ const meta: Meta<EuiContextMenuItemProps> = {
       control: 'radio',
       options: [undefined, true, false],
     },
+    hasAriaDisabled: {
+      description: `NOTE: Beta feature, may be changed or removed in the future.<br/>
+      Changes the native \`disabled\` attribute to \`aria-disabled\` to preserve focusability.
+      This results in a semantically disabled item without the default browser handling of the disabled state.<br/>
+      Use e.g. when a disabled item should have a tooltip.
+      `,
+    },
   },
   args: {
     // Component defaults
     layoutAlign: 'center',
     hasPanel: false,
     disabled: false,
+    hasAriaDisabled: false,
     external: undefined,
   },
 };

--- a/packages/eui/src/components/context_menu/context_menu_item.test.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_item.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { fireEvent } from '@testing-library/react';
-import { render } from '../../test/rtl';
+import { render, focusEuiToolTipTrigger } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { requiredProps } from '../../test/required_props';
 
@@ -201,6 +201,63 @@ describe('EuiContextMenuItem', () => {
       const { getByRole } = renderWithToolTip();
 
       expect(getByRole('button')).toHaveAttribute('type', 'button');
+    });
+  });
+
+  describe('hasAriaDisabled', () => {
+    it('renders `aria-disabled` when `disabled=true`', () => {
+      const { getByTestSubject } = render(
+        <EuiContextMenuItem
+          hasAriaDisabled
+          disabled
+          onClick={() => {}}
+          data-test-subj="item"
+        />
+      );
+
+      const item = getByTestSubject('item');
+
+      expect(item).toBeEuiDisabled();
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+      expect(item).not.toHaveAttribute('disabled');
+    });
+
+    it('keeps the `toolTipContent` reachable on focus', () => {
+      const { getByRole } = render(
+        <EuiContextMenuItem hasAriaDisabled disabled toolTipContent="Nope">
+          Hello
+        </EuiContextMenuItem>
+      );
+
+      const item = getByRole('button');
+      item.focus();
+
+      // a natively disabled button is not focusable, which is the whole point
+      // of swapping `disabled` for `aria-disabled`
+      expect(item).toHaveFocus();
+
+      const cleanup = focusEuiToolTipTrigger(item);
+
+      expect(getByRole('tooltip')).toHaveTextContent('Nope');
+
+      cleanup();
+    });
+
+    it('does not call `onClick` while aria-disabled', () => {
+      const onClickHandler = jest.fn();
+
+      const { getByTestSubject } = render(
+        <EuiContextMenuItem
+          hasAriaDisabled
+          disabled
+          onClick={onClickHandler}
+          data-test-subj="item"
+        />
+      );
+
+      fireEvent.click(getByTestSubject('item'));
+
+      expect(onClickHandler).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/eui/src/components/context_menu/context_menu_item.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_item.tsx
@@ -24,6 +24,7 @@ import {
   cloneElementWithCss,
 } from '../../services';
 import { validateHref } from '../../services/security/href_validator';
+import { type EuiDisabledProps } from '../../services/hooks/useEuiDisabledElement';
 import { type _EuiExtendedButtonColor } from '../../global_styling';
 import { CommonProps, keysOf } from '../common';
 import { EuiIcon, type IconType } from '../icon';
@@ -38,7 +39,8 @@ export type EuiContextMenuItemLayoutAlignment = 'center' | 'top' | 'bottom';
 
 export interface EuiContextMenuItemProps
   extends PropsWithChildren,
-    CommonProps {
+    CommonProps,
+    Pick<EuiDisabledProps, 'hasAriaDisabled'> {
   icon?: EuiContextMenuItemIcon;
   hasPanel?: boolean;
   disabled?: boolean;
@@ -109,6 +111,7 @@ export const EuiContextMenuItem: FunctionComponent<Props> = ({
   rel,
   color = 'text',
   external,
+  hasAriaDisabled,
   ...rest
 }) => {
   const isHrefValid = !href || validateHref(href);
@@ -212,6 +215,7 @@ export const EuiContextMenuItem: FunctionComponent<Props> = ({
       append={arrow}
       textWrap="wrap"
       isDisabled={disabled}
+      hasAriaDisabled={hasAriaDisabled}
       textProps={{
         className: 'euiContextMenuItem__text',
         css: textStyles,

--- a/packages/eui/src/test/rtl/component_helpers.d.ts
+++ b/packages/eui/src/test/rtl/component_helpers.d.ts
@@ -6,21 +6,6 @@
 export declare const waitForEuiPopoverOpen: () => Promise<void>;
 export declare const waitForEuiPopoverClose: () => Promise<void>;
 
-/**
- * jsdom does not track keyboard vs. mouse input modality, so `:focus-visible`
- * always returns false. Call this before `fireEvent.focus()` on an element that
- * should be treated as keyboard-focused.
- *
- * Returns a cleanup function, call it after test assertions to restore the spy.
- */
-export declare const simulateFocusVisible: (element: Element) => () => void;
-
-/**
- * Prefer this over `fireEvent.focus()` in tooltip tests. Plain `fireEvent.focus`
- * does not set `:focus-visible` in jsdom and will not trigger the tooltip.
- *
- * Returns a cleanup function to restore the mock after assertions.
- */
 export declare const focusEuiToolTipTrigger: (element: Element) => () => void;
 
 export declare const showEuiComboBoxOptions: () => Promise<void>;

--- a/packages/eui/src/test/rtl/component_helpers.d.ts
+++ b/packages/eui/src/test/rtl/component_helpers.d.ts
@@ -6,6 +6,23 @@
 export declare const waitForEuiPopoverOpen: () => Promise<void>;
 export declare const waitForEuiPopoverClose: () => Promise<void>;
 
+/**
+ * jsdom does not track keyboard vs. mouse input modality, so `:focus-visible`
+ * always returns false. Call this before `fireEvent.focus()` on an element that
+ * should be treated as keyboard-focused.
+ *
+ * Returns a cleanup function, call it after test assertions to restore the spy.
+ */
+export declare const simulateFocusVisible: (element: Element) => () => void;
+
+/**
+ * Prefer this over `fireEvent.focus()` in tooltip tests. Plain `fireEvent.focus`
+ * does not set `:focus-visible` in jsdom and will not trigger the tooltip.
+ *
+ * Returns a cleanup function to restore the mock after assertions.
+ */
+export declare const focusEuiToolTipTrigger: (element: Element) => () => void;
+
 export declare const showEuiComboBoxOptions: () => Promise<void>;
 
 export declare const waitForEuiContextMenuPanelTransition: () => Promise<void>;


### PR DESCRIPTION
## Summary

- **What:** Declares the `hasAriaDisabled` prop on `EuiContextMenuItemProps` and forwards it explicitly to `EuiListItemLayout`. Also adds the missing `focusEuiToolTipTrigger` declaration to the published test-util types.
- **Why:** `hasAriaDisabled` ([#9214](https://github.com/elastic/eui/issues/9214)) already worked on `EuiContextMenuItem` **at runtime** — it fell through `...rest` into `EuiListItemLayout`, which declares the prop, performs the `disabled` → `aria-disabled` swap via `useEuiDisabledElement`, ships a dedicated disabled style, and keeps the item focusable so a `toolTipContent` explaining *why* it's disabled stays reachable. Only the **prop type** was missing, so TS consumers have to widen the props themselves.

  This came out of [elastic/kibana#281982](https://github.com/elastic/kibana/pull/281982) (*[Agent Builder] Return conversation permissions for rename and delete*), which disables the **Rename** / **Delete** context menu items when the user lacks permission and attaches a `toolTipContent` explaining why. A natively `disabled` item is removed from the tab order and dispatches no mouse events, so that explanation is unreachable by both mouse and keyboard — exactly what `hasAriaDisabled` exists to solve. Because the prop is undeclared, that PR carries two workarounds it can delete once this ships:

  - `const AriaDisabledContextMenuItem: React.FC<EuiContextMenuItemProps & EuiDisabledProps> = EuiContextMenuItem;` — duplicated in `conversation_title.tsx` and `conversation_list_item_row.tsx`.
  - A hand-copied `focusEuiToolTipTrigger` in the two sibling test files, because the published declarations don't export EUI's own.
- **How:**
  - `EuiContextMenuItemProps` now extends `Pick<EuiDisabledProps, 'hasAriaDisabled'>` rather than the full `EuiDisabledProps`: the full type also carries `isDisabled`, and this component's disabled prop is named `disabled` — extending fully would add a second, dead disabled prop.
  - The prop is destructured and passed to `EuiListItemLayout` explicitly instead of relying on `...rest`, which was accidental and would silently break if `rest` were ever allow-listed.
  - `src/test/rtl/component_helpers.d.ts` is hand-written and is the source the build uses for the published `lib/test/rtl` types (see `scripts/compile-eui.js`), so `focusEuiToolTipTrigger` (added in [#9201](https://github.com/elastic/eui/pull/9201)) existed at runtime but not in the published declarations — external consumers got TS2305 importing `focusEuiToolTipTrigger` from `@elastic/eui/lib/test/rtl`. Kibana currently inlines a copy of the helper in two test files because of this.

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| EuiContextMenuItem | hasAriaDisabled | Added | Beta. Swaps the native `disabled` attribute for `aria-disabled` so a disabled item stays focusable and its `toolTipContent` stays reachable. Runtime behavior was already supported; this only adds the type. |
| `@elastic/eui/lib/test/rtl` | focusEuiToolTipTrigger | Added | Missing type declaration for an already-exported test helper |

## Screenshots

No visual change. The disabled-with-tooltip rendering is unchanged from what `EuiListItemLayout` already produced for consumers passing the prop through untyped.

## Impact Assessment

- [ ] 🔴 **Breaking changes**
- [ ] 💅 **Visual changes**
- [ ] 🧪 **Test impact**
- [ ] 🔧 **Hard to integrate**

**Impact level:** 🟢 None — purely additive types plus an explicit prop forward; no rendered output changes for existing usages.

## Release Readiness

- [x] **Documentation:** props table is generated from the type, so the beta JSDoc on `EuiDisabledProps['hasAriaDisabled']` carries over. The general guidance already lives on the [Tooltip / Disabled elements](https://eui.elastic.co/docs/components/display/tooltip/) page.
- ~~**Figma**~~
- ~~**Migration guide**~~
- [x] **Adoption plan:** [elastic/kibana#281982](https://github.com/elastic/kibana/pull/281982) (`agent_builder`) is the driving consumer — it deletes the two `AriaDisabledContextMenuItem` local aliases and the two inlined `focusEuiToolTipTrigger` copies once this ships.

### QA instructions for reviewer

- Open Storybook → `Navigation/EuiContextMenu/EuiContextMenuItem` → Playground.
- [ ] Set `disabled: true`, `hasAriaDisabled: true` and fill in `toolTipContent`.
- [ ] Confirm the item renders `aria-disabled="true"` and no `disabled` attribute.
- [ ] Confirm the tooltip shows on hover **and** on keyboard focus (Tab to the item).
- [ ] Confirm the item does not activate on click or Enter.
- [ ] With `hasAriaDisabled: false`, confirm the item is natively `disabled` as before.

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [x] **QA:** keyboard-only verified via unit tests (focus reaches the item, tooltip opens); no visual change to test across themes
- [ ] **QA:** Tested in CodeSandbox and Kibana
- ~~**QA:** Tested docs changes~~
- [x] **Tests:** Added Jest coverage (`describe('hasAriaDisabled')` in `context_menu_item.test.tsx`) — verified they fail without the prop forward
- [x] **Changelog:** Added
- ~~**Breaking changes**~~
