### PR TITLE
[Chore] Kibana nightly auto cherry pick

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,8 +122,8 @@ jobs:
           fetch-depth: 0
       - name: Configure git
         run: |
-          git config --global user.name 'EUI Machine'
-          git config --global user.email 'tkajtoch@users.noreply.github.com'
+          git config --global user.name 'elasticmachine'
+          git config --global user.email 'elasticmachine@users.noreply.github.com'
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -239,8 +239,8 @@ jobs:
           fi
       - name: Configure git
         run: |
-          git config --global user.name 'EUI Machine'
-          git config --global user.email 'tkajtoch@users.noreply.github.com'
+          git config --global user.name 'elasticmachine'
+          git config --global user.email 'elasticmachine@users.noreply.github.com'
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -113,7 +113,6 @@ jobs:
           echo "BRANCH_NAME=$branch_name" >> "$GITHUB_OUTPUT"
           echo "::debug::Created branch '$branch_name'"
       - name: Cherry-pick Kibana prep commits
-        if: ${{ inputs.nightly }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # language=bash

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -113,6 +113,7 @@ jobs:
           echo "BRANCH_NAME=$branch_name" >> "$GITHUB_OUTPUT"
           echo "::debug::Created branch '$branch_name'"
       - name: Cherry-pick Kibana prep commits
+        id: cherry_pick
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # language=bash
@@ -127,6 +128,8 @@ jobs:
             exit 0
           fi
 
+          notes=""
+
           while IFS= read -r url; do
             pr_number=$(grep -oP '(?<=/pull/)\d+' <<< "$url")
             sha=$(grep -oP '[0-9a-f]{40}$' <<< "$url")
@@ -139,7 +142,18 @@ jobs:
             echo "Cherry-picking $sha from PR #$pr_number"
             git fetch origin "pull/$pr_number/head"
             git cherry-pick "$sha"
+
+            short_sha="${sha:0:8}"
+            notes+="- [\`$short_sha\`](https://github.com/elastic/kibana/pull/$pr_number/commits/$sha) from elastic/kibana#$pr_number"$'\n'
           done <<< "$prep_commits"
+
+          if [[ -n "$notes" ]]; then
+            {
+              echo 'cherry_pick_notes<<CHERRY_PICK_DELIMITER'
+              printf '%s' "$notes"
+              echo 'CHERRY_PICK_DELIMITER'
+            } >> "$GITHUB_OUTPUT"
+          fi
       - name: Update dependency versions
         env:
           DEPENDENCIES: ${{ inputs.dependencies }}
@@ -184,6 +198,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TITLE: ${{ inputs.pr_title }}
           PR_BODY: ${{ inputs.pr_body }}
+          CHERRY_PICK_NOTES: ${{ steps.cherry_pick.outputs.cherry_pick_notes }}
           BRANCH_NAME: ${{ steps.git_branch.outputs.BRANCH_NAME }}
           SOURCE_PR_NUMBER: ${{ inputs.source_pr_number }}
           NIGHTLY: ${{ inputs.nightly }}
@@ -193,6 +208,11 @@ jobs:
         # language=bash
         run: |
           set -euo pipefail
+
+          if [[ -n "${CHERRY_PICK_NOTES:-}" ]]; then
+            PR_BODY="${PR_BODY}"$'\n\n'"### Cherry-picked commits"$'\n\n'"${CHERRY_PICK_NOTES}"
+          fi
+
           # --repo is required because we're in the context of elastic/kibana right now
           args=(
             --repo elastic/eui

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -112,6 +112,35 @@ jobs:
           git checkout -b "$branch_name"
           echo "BRANCH_NAME=$branch_name" >> "$GITHUB_OUTPUT"
           echo "::debug::Created branch '$branch_name'"
+      - name: Cherry-pick Kibana prep commits
+        if: ${{ inputs.nightly }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # language=bash
+        run: |
+          set -euo pipefail
+
+          prep_commits=$(gh api repos/elastic/eui/contents/packages/release-cli/kibana-prep-commits \
+            --jq '.content' | base64 -d | grep -v '^\s*#' | grep -v '^\s*$' || true)
+
+          if [[ -z "$prep_commits" ]]; then
+            echo "No Kibana prep commits to cherry-pick"
+            exit 0
+          fi
+
+          while IFS= read -r url; do
+            pr_number=$(grep -oP '(?<=/pull/)\d+' <<< "$url")
+            sha=$(grep -oP '[0-9a-f]{40}$' <<< "$url")
+
+            if [[ -z "$pr_number" || -z "$sha" ]]; then
+              echo "::warning::Could not parse URL: $url"
+              continue
+            fi
+
+            echo "Cherry-picking $sha from PR #$pr_number"
+            git fetch origin "pull/$pr_number/head"
+            git cherry-pick "$sha"
+          done <<< "$prep_commits"
       - name: Update dependency versions
         env:
           DEPENDENCIES: ${{ inputs.dependencies }}

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -121,7 +121,7 @@ jobs:
           set -euo pipefail
 
           prep_commits=$(gh api repos/elastic/eui/contents/packages/release-cli/kibana-prep-commits \
-            --jq '.content' | base64 -d | grep -v '^\s*#' | grep -v '^\s*$' || true)
+            --jq '.content' | base64 -d | grep -v '^\s*#' | grep -v '^\s*$' | sort -u || true)
 
           if [[ -z "$prep_commits" ]]; then
             echo "No Kibana prep commits to cherry-pick"

--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -1,6 +1,6 @@
 # List Kibana prep commits to cherry-pick during the nightly Kibana integration run.
 # Add one URL per line in the format:
-# https://github.com/elastic/kibana/pull/NNNN/changes/COMMIT_SHA
+# https://github.com/elastic/kibana/pull/NNNN/commits/COMMIT_SHA
 #
 # Entries are cleared as part of the EUI release process.
 https://github.com/elastic/kibana/pull/235177/commits/bd0c5acbf5768534786919271150e2a2ea92d5b7

--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -1,0 +1,5 @@
+# List Kibana prep commits to cherry-pick during the nightly Kibana integration run.
+# Add one URL per line in the format:
+# https://github.com/elastic/kibana/pull/NNNN/changes/COMMIT_SHA
+#
+# Entries are cleared as part of the EUI release process.

--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -3,3 +3,4 @@
 # https://github.com/elastic/kibana/pull/NNNN/changes/COMMIT_SHA
 #
 # Entries are cleared as part of the EUI release process.
+https://github.com/elastic/kibana/pull/235177/commits/bd0c5acbf5768534786919271150e2a2ea92d5b7

--- a/packages/release-cli/src/steps/update_versions.ts
+++ b/packages/release-cli/src/steps/update_versions.ts
@@ -7,6 +7,7 @@
  */
 
 import path from 'node:path';
+import fs from 'node:fs/promises';
 import { type ReleaseOptions } from '../release';
 import { type YarnWorkspace, updateWorkspaceVersion } from '../yarn_utils';
 import {
@@ -31,6 +32,23 @@ import {
   isFileAddedToGit,
   stageFiles,
 } from '../git_utils';
+
+const KIBANA_PREP_COMMITS_FILE = 'packages/release-cli/kibana-prep-commits';
+
+const clearKibanaPrepCommits = async (
+  rootWorkspaceDir: string
+): Promise<string | null> => {
+  const filePath = path.join(rootWorkspaceDir, KIBANA_PREP_COMMITS_FILE);
+  const content = await fs.readFile(filePath, 'utf-8').catch(() => null);
+
+  if (content === null) return null;
+
+  const cleared = content.replace(/^(?!\s*#).*\S.*\n?/gm, '');
+  if (cleared === content) return null;
+
+  await fs.writeFile(filePath, cleared, 'utf-8');
+  return filePath;
+};
 
 /**
  * Update version numbers and yearly changelogs based on workspace
@@ -64,7 +82,9 @@ export const stepUpdateVersions = async (
       const newVersion = getUpcomingSnapshotVersion(currentVersion, snapshotId);
       await updateWorkspaceVersion(workspace.name, newVersion);
 
-      logger.info(`[${workspace.name}] Updating version ${currentVersion} -> ${newVersion}`);
+      logger.info(
+        `[${workspace.name}] Updating version ${currentVersion} -> ${newVersion}`
+      );
     } else {
       const { changelogMap, changelog, hasChanges, processedChangelogFiles } =
         await collateChangelogFiles(workspaceDir);
@@ -126,6 +146,13 @@ export const stepUpdateVersions = async (
     const yarnLockPath = path.join(rootWorkspaceDir, 'yarn.lock');
     filesToCommit.push(yarnLockPath);
     await stageFiles([yarnLockPath]);
+
+    // Clear Kibana prep commits and include in the release commit
+    const kibanaPrepCommitsPath =
+      await clearKibanaPrepCommits(rootWorkspaceDir);
+    if (kibanaPrepCommitsPath) {
+      filesToCommit.push(kibanaPrepCommitsPath);
+    }
 
     // Stage updated package.json files
     const uniqueFilesToCommit = [...new Set(filesToCommit)];


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Closes https://github.com/elastic/eui-private/issues/748

Adds `kibana-prep-commits` file and:
- uses it in [update_kibana_dependencies__prepare_changes.yml](https://github.com/elastic/eui/pull/9871/changes/75484e214559b9330c925ab5c5a46ca570f9574d#diff-01f3dac42468a68036aab9563c8a2fee4c27741e5374b6dc7c930ccd00e4cb28) to cherry-pick commits to the [Nightly draft PR](https://github.com/elastic/kibana/pull/279387),
- clears it on each release prep (it will be an additional change on release PRs).

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

- [x] add a URL to `packages/release-cli/kibana-prep-commits`, then run `yarn release run official` locally in dry-run mode,
- [x] confirm the file has the URL stripped and only comments remain after the run,
- [x] confirm nothing happens when the file is already empty.

CI integration can only be tested once merged (unless manually dispatched).