### PR TITLE
Replace /#/ hash-router links and add JSDoc doc links to public API

### DIFF
--- a/packages/eui/CHANGELOG.md
+++ b/packages/eui/CHANGELOG.md
@@ -1,5 +1,4 @@
 EUI's changelogs are too numerous to view in a single file, and have been split up by year. Ways to view them:
 
 - In the [changelogs](./changelogs) folder as raw markdown files
-- On our [docs website](https://eui.elastic.co/#/package/changelog) as rich text
 - [Searching for individual release](https://github.com/elastic/eui/releases) changelogs

--- a/packages/eui/src/components/accordion/accordion.tsx
+++ b/packages/eui/src/components/accordion/accordion.tsx
@@ -115,6 +115,9 @@ export type EuiAccordionProps = CommonProps &
     isDisabled?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/containers/accordion/|EuiAccordion documentation}
+ */
 export const EuiAccordion: FunctionComponent<EuiAccordionProps> = ({
   children,
   className,

--- a/packages/eui/src/components/aspect_ratio/aspect_ratio.tsx
+++ b/packages/eui/src/components/aspect_ratio/aspect_ratio.tsx
@@ -35,6 +35,9 @@ export type EuiAspectRatioProps = HTMLAttributes<HTMLDivElement> &
     children: ReactElement<any>;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/aspect-ratio/|EuiAspectRatio documentation}
+ */
 export const EuiAspectRatio: FunctionComponent<EuiAspectRatioProps> = ({
   children,
   className,

--- a/packages/eui/src/components/avatar/avatar.tsx
+++ b/packages/eui/src/components/avatar/avatar.tsx
@@ -114,6 +114,9 @@ export type EuiAvatarProps = Omit<HTMLAttributes<HTMLDivElement>, 'color'> &
     isDisabled?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/avatar/|EuiAvatar documentation}
+ */
 export const EuiAvatar: FunctionComponent<EuiAvatarProps> = ({
   className,
   color,

--- a/packages/eui/src/components/badge/badge.tsx
+++ b/packages/eui/src/components/badge/badge.tsx
@@ -125,6 +125,9 @@ export type EuiBadgeProps = {
     WithSpanProps
   >;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/badge/|EuiBadge documentation}
+ */
 export const EuiBadge: FunctionComponent<EuiBadgeProps> = ({
   children,
   color = 'default',

--- a/packages/eui/src/components/banner/banner.tsx
+++ b/packages/eui/src/components/banner/banner.tsx
@@ -88,6 +88,9 @@ export type EuiBannerProps = CommonProps & {
   announceOnMount?: boolean;
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/banner/|EuiBanner documentation}
+ */
 export const EuiBanner = forwardRef<HTMLDivElement, EuiBannerProps>(
   (
     {

--- a/packages/eui/src/components/basic_table/basic_table.tsx
+++ b/packages/eui/src/components/basic_table/basic_table.tsx
@@ -320,6 +320,9 @@ function hasPagination<T extends object>(
   return x.hasOwnProperty('pagination') && !!x.pagination;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/tables/basic/|EuiBasicTable documentation}
+ */
 export class EuiBasicTable<T extends object = any> extends Component<
   EuiBasicTableProps<T>,
   State<T>

--- a/packages/eui/src/components/basic_table/in_memory_table.tsx
+++ b/packages/eui/src/components/basic_table/in_memory_table.tsx
@@ -313,6 +313,9 @@ function getInitialSorting<T extends object>(
   };
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/tables/in-memory/|EuiInMemoryTable documentation}
+ */
 export class EuiInMemoryTable<T extends object = object> extends Component<
   EuiInMemoryTableProps<T>,
   State<T>

--- a/packages/eui/src/components/beacon/beacon.tsx
+++ b/packages/eui/src/components/beacon/beacon.tsx
@@ -41,6 +41,9 @@ export type EuiBeaconProps = Omit<
     color?: EuiBeaconColor;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/beacon/|EuiBeacon documentation}
+ */
 export const EuiBeacon: FunctionComponent<EuiBeaconProps> = ({
   className,
   size = 12,

--- a/packages/eui/src/components/bottom_bar/bottom_bar.tsx
+++ b/packages/eui/src/components/bottom_bar/bottom_bar.tsx
@@ -245,6 +245,9 @@ const _EuiBottomBar = forwardRef<
   }
 );
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/containers/bottom-bar/|EuiBottomBar documentation}
+ */
 export const EuiBottomBar = forwardRef<HTMLElement, EuiBottomBarProps>(
   (props, ref) => {
     const BottomBar = _EuiBottomBar;

--- a/packages/eui/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/eui/src/components/breadcrumbs/breadcrumbs.tsx
@@ -29,6 +29,9 @@ const responsiveDefault: EuiBreadcrumbResponsiveMaxCount = {
   m: 4,
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/breadcrumbs/|EuiBreadcrumbs documentation}
+ */
 export const EuiBreadcrumbs: FunctionComponent<EuiBreadcrumbsProps> = ({
   breadcrumbs,
   className,

--- a/packages/eui/src/components/breadcrumbs/types.ts
+++ b/packages/eui/src/components/breadcrumbs/types.ts
@@ -108,7 +108,7 @@ export type EuiBreadcrumbProps = Omit<
     popoverContent?: ReactNode | ((closePopover: () => void) => ReactNode);
     /**
      * Allows customizing the popover if necessary. Accepts any props that
-     * [EuiPopover](/#/layout/popover) accepts, except for props that control state.
+     * [EuiPopover](https://eui.elastic.co/docs/components/containers/popover/) accepts, except for props that control state.
      */
     popoverProps?: Omit<EuiPopoverProps, 'button' | 'closePopover' | 'isOpen'>;
   };

--- a/packages/eui/src/components/button/button.tsx
+++ b/packages/eui/src/components/button/button.tsx
@@ -87,6 +87,7 @@ export type Props = ExclusiveUnion<
 /**
  * EuiButton is largely responsible for providing relevant props
  * and the logic for element-specific attributes
+ * @see {@link https://eui.elastic.co/docs/components/navigation/buttons/button/|EuiButton documentation}
  */
 export const EuiButton: FunctionComponent<Props> = ({
   className,

--- a/packages/eui/src/components/button/button_group/button_group.tsx
+++ b/packages/eui/src/components/button/button_group/button_group.tsx
@@ -59,7 +59,7 @@ export interface EuiButtonGroupOptionProps
    */
   toolTipContent?: EuiToolTipProps['content'];
   /**
-   * Optional props to pass to the underlying **[EuiToolTip](/#/display/tooltip)**
+   * Optional props to pass to the underlying **[EuiToolTip](https://eui.elastic.co/docs/components/display/tooltip/)**
    */
   toolTipProps?: Partial<Omit<EuiToolTipProps, 'content' | 'children'>>;
 }

--- a/packages/eui/src/components/call_out/call_out.tsx
+++ b/packages/eui/src/components/call_out/call_out.tsx
@@ -115,6 +115,9 @@ export type EuiCallOutProps = CommonProps &
     };
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/callout/|EuiCallOut documentation}
+ */
 export const EuiCallOut = forwardRef<HTMLDivElement, EuiCallOutProps>(
   (
     {

--- a/packages/eui/src/components/card/card.tsx
+++ b/packages/eui/src/components/card/card.tsx
@@ -138,6 +138,9 @@ export type EuiCardProps = Omit<CommonProps, 'aria-label'> &
     hasBorder?: EuiPanelProps['hasBorder'];
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/containers/card/|EuiCard documentation}
+ */
 export const EuiCard: FunctionComponent<EuiCardProps> = ({
   className,
   description,

--- a/packages/eui/src/components/code/code.tsx
+++ b/packages/eui/src/components/code/code.tsx
@@ -20,6 +20,9 @@ import { euiCodeStyles } from './code.styles';
 
 export type EuiCodeProps = EuiCodeSharedProps;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/code/|EuiCode documentation}
+ */
 export const EuiCode: FunctionComponent<EuiCodeProps> = ({
   transparentBackground = false,
   language: _language = DEFAULT_LANGUAGE,

--- a/packages/eui/src/components/collapsible_nav/collapsible_nav.tsx
+++ b/packages/eui/src/components/collapsible_nav/collapsible_nav.tsx
@@ -54,6 +54,9 @@ export type EuiCollapsibleNavProps = Omit<
   showButtonIfDocked?: boolean;
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/collapsible-nav/|EuiCollapsibleNav documentation}
+ */
 export const EuiCollapsibleNav: FunctionComponent<EuiCollapsibleNavProps> = ({
   id,
   children,

--- a/packages/eui/src/components/color_picker/color_palette_picker/color_palette_picker.tsx
+++ b/packages/eui/src/components/color_picker/color_palette_picker/color_palette_picker.tsx
@@ -119,6 +119,9 @@ export type EuiColorPalettePickerProps<T extends string> = CommonProps &
     palettes: EuiColorPalettePickerPaletteProps[];
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/other/palette-picker/|EuiColorPalettePicker documentation}
+ */
 export const EuiColorPalettePicker: FunctionComponent<
   EuiColorPalettePickerProps<string>
 > = ({

--- a/packages/eui/src/components/color_picker/color_picker.tsx
+++ b/packages/eui/src/components/color_picker/color_picker.tsx
@@ -185,6 +185,9 @@ const getHsv = (hsv?: number[], fallback: number = 0) => {
   return [hue, hsv[1], hsv[2]] as ColorSpaces['hsv'];
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/other/color-picker/|EuiColorPicker documentation}
+ */
 export const EuiColorPicker: FunctionComponent<EuiColorPickerProps> = ({
   button,
   className,

--- a/packages/eui/src/components/combo_box/combo_box.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.tsx
@@ -162,7 +162,7 @@ export interface _EuiComboBoxProps<T>
    */
   autoFocus?: boolean;
   /**
-   * Required when rendering without a visible label from [EuiFormRow](https://eui.elastic.co/docs/components/forms/layouts/).
+   * Required when rendering without a visible label from [EuiFormRow](https://eui.elastic.co/docs/components/forms/layouts/row/).
    */
   'aria-label'?: string;
   /**

--- a/packages/eui/src/components/combo_box/combo_box.tsx
+++ b/packages/eui/src/components/combo_box/combo_box.tsx
@@ -162,18 +162,18 @@ export interface _EuiComboBoxProps<T>
    */
   autoFocus?: boolean;
   /**
-   * Required when rendering without a visible label from [EuiFormRow](/#/forms/form-layouts).
+   * Required when rendering without a visible label from [EuiFormRow](https://eui.elastic.co/docs/components/forms/layouts/).
    */
   'aria-label'?: string;
   /**
    * Reference ID of a text element containing the visible label for the combo box when not
-   * supplied by `aria-label` or from [EuiFormRow](/#/forms/form-layouts).
+   * supplied by `aria-label` or from [EuiFormRow](https://eui.elastic.co/docs/components/forms/layouts/).
    */
   'aria-labelledby'?: string;
   /**
    * By default, EuiComboBox will truncate option labels at the end of
    * the string. You can pass in a custom truncation configuration that
-   * accepts any [EuiTextTruncate](/#/utilities/text-truncation) prop,
+   * accepts any [EuiTextTruncate](https://eui.elastic.co/docs/utilities/text-truncation/) prop,
    * except for `text` and `children`.
    *
    * Note: when searching, custom truncation props are ignored. The highlighted search

--- a/packages/eui/src/components/combo_box/types.ts
+++ b/packages/eui/src/components/combo_box/types.ts
@@ -30,7 +30,7 @@ export interface EuiComboBoxOptionOption<
    */
   toolTipContent?: EuiToolTipProps['content'];
   /**
-   * Optional props to pass to the underlying **[EuiToolTip](/#/display/tooltip)**
+   * Optional props to pass to the underlying **[EuiToolTip](https://eui.elastic.co/docs/components/display/tooltip/)**
    */
   toolTipProps?: Partial<Omit<EuiToolTipProps, 'content' | 'children'>>;
 }

--- a/packages/eui/src/components/comment_list/comment_list.tsx
+++ b/packages/eui/src/components/comment_list/comment_list.tsx
@@ -25,6 +25,9 @@ export type EuiCommentListProps = Omit<
   gutterSize?: EuiTimelineProps['gutterSize'];
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/comment-list/|EuiCommentList documentation}
+ */
 export const EuiCommentList: FunctionComponent<EuiCommentListProps> = ({
   children,
   className,

--- a/packages/eui/src/components/context_menu/context_menu.tsx
+++ b/packages/eui/src/components/context_menu/context_menu.tsx
@@ -495,5 +495,8 @@ export class EuiContextMenuClass extends Component<
   }
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/context-menu/|EuiContextMenu documentation}
+ */
 export const EuiContextMenu =
   withEuiStylesMemoizer<EuiContextMenuProps>(EuiContextMenuClass);

--- a/packages/eui/src/components/context_menu/context_menu_item.tsx
+++ b/packages/eui/src/components/context_menu/context_menu_item.tsx
@@ -50,7 +50,7 @@ export interface EuiContextMenuItemProps
    */
   toolTipContent?: ReactNode;
   /**
-   * Optional configuration to pass to the underlying [EuiToolTip](/#/display/tooltip).
+   * Optional configuration to pass to the underlying [EuiToolTip](https://eui.elastic.co/docs/components/display/tooltip/).
    * Accepts any prop that EuiToolTip does, except for `content` and `children`.
    */
   toolTipProps?: Partial<Omit<EuiToolTipProps, 'content' | 'children'>>;

--- a/packages/eui/src/components/datagrid/data_grid.tsx
+++ b/packages/eui/src/components/datagrid/data_grid.tsx
@@ -114,6 +114,9 @@ const cellPaddingsToClassMap: {
 
 const emptyVirtualizationOptions = {};
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/data-grid/|EuiDataGrid documentation}
+ */
 export const EuiDataGrid = memo(
   forwardRef<EuiDataGridRefProps, EuiDataGridProps>((props, ref) => {
     const {

--- a/packages/eui/src/components/date_picker/auto_refresh/auto_refresh.tsx
+++ b/packages/eui/src/components/date_picker/auto_refresh/auto_refresh.tsx
@@ -34,6 +34,9 @@ export type EuiAutoRefreshProps = EuiAutoRefreshSharedProps & {
   readOnly?: EuiFieldTextProps['readOnly'];
 } & Omit<EuiFieldTextProps, 'icon' | 'prepend' | 'controlOnly' | 'readOnly'>;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/date-and-time/auto-refresh/|EuiAutoRefresh documentation}
+ */
 export const EuiAutoRefresh: FunctionComponent<EuiAutoRefreshProps> = ({
   className,
   onRefreshChange,

--- a/packages/eui/src/components/date_picker/date_picker.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.tsx
@@ -138,7 +138,7 @@ interface EuiExtendedDatePickerProps
   /**
    * Sets the placement of the popover.
    *
-   * **Use [EuiPopover](/#/layout/popover) values**: 'upCenter', 'upLeft', 'upRight', downCenter', 'downLeft', 'downRight', 'leftCenter', 'leftUp', 'leftDown', 'rightCenter', 'rightUp', 'rightDown'.
+   * **Use [EuiPopover](https://eui.elastic.co/docs/components/containers/popover/) values**: 'upCenter', 'upLeft', 'upRight', downCenter', 'downLeft', 'downRight', 'leftCenter', 'leftUp', 'leftDown', 'rightCenter', 'rightUp', 'rightDown'.
    */
   popoverPlacement?: PopoverAnchorPosition;
 

--- a/packages/eui/src/components/date_picker/date_picker.tsx
+++ b/packages/eui/src/components/date_picker/date_picker.tsx
@@ -138,7 +138,7 @@ interface EuiExtendedDatePickerProps
   /**
    * Sets the placement of the popover.
    *
-   * **Use [EuiPopover](https://eui.elastic.co/docs/components/containers/popover/) values**: 'upCenter', 'upLeft', 'upRight', downCenter', 'downLeft', 'downRight', 'leftCenter', 'leftUp', 'leftDown', 'rightCenter', 'rightUp', 'rightDown'.
+   * **Use [EuiPopover](https://eui.elastic.co/docs/components/containers/popover/) values**: 'upCenter', 'upLeft', 'upRight', 'downCenter', 'downLeft', 'downRight', 'leftCenter', 'leftUp', 'leftDown', 'rightCenter', 'rightUp', 'rightDown'.
    */
   popoverPlacement?: PopoverAnchorPosition;
 

--- a/packages/eui/src/components/date_picker/date_picker_range.tsx
+++ b/packages/eui/src/components/date_picker/date_picker_range.tsx
@@ -103,6 +103,9 @@ export type EuiDatePickerRangeProps = CommonProps &
     onFocus?: FocusEventHandler<HTMLInputElement>;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/date-and-time/date-picker-range/|EuiDatePickerRange documentation}
+ */
 export const EuiDatePickerRange: FunctionComponent<EuiDatePickerRangeProps> = ({
   children,
   className,

--- a/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.tsx
+++ b/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.tsx
@@ -896,6 +896,9 @@ export class EuiSuperDatePickerInternal extends Component<
 // we have to use a render prop here in order for us to pass i18n'd strings/objects/etc
 // to all underlying usages of our timeOptions constants. If someday we convert
 // EuiSuperDatePicker to an FC, we can likely get rid of this wrapper.
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/date-and-time/super-date-picker/|EuiSuperDatePicker documentation}
+ */
 export const EuiSuperDatePicker: FunctionComponent<EuiSuperDatePickerProps> = (
   props
 ) => {

--- a/packages/eui/src/components/description_list/description_list.tsx
+++ b/packages/eui/src/components/description_list/description_list.tsx
@@ -18,6 +18,9 @@ import { EuiDescriptionListTitle } from './description_list_title';
 import { EuiDescriptionListDescription } from './description_list_description';
 import { euiDescriptionListStyles } from './description_list.styles';
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/description-list/|EuiDescriptionList documentation}
+ */
 export const EuiDescriptionList: FunctionComponent<
   CommonProps & HTMLAttributes<HTMLDListElement> & EuiDescriptionListProps
 > = ({

--- a/packages/eui/src/components/drag_and_drop/drag_drop_context.tsx
+++ b/packages/eui/src/components/drag_and_drop/drag_drop_context.tsx
@@ -27,6 +27,9 @@ export const EuiDragDropContextContext = createContext<EuiDragDropContextProps>(
   }
 );
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/drag-and-drop/|EuiDragDropContext documentation}
+ */
 export const EuiDragDropContext: FunctionComponent<DragDropContextProps> = ({
   onBeforeDragStart,
   onDragStart,

--- a/packages/eui/src/components/empty_prompt/empty_prompt.tsx
+++ b/packages/eui/src/components/empty_prompt/empty_prompt.tsx
@@ -80,6 +80,9 @@ export type EuiEmptyPromptProps = CommonProps &
     paddingSize?: PaddingSize;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/empty-prompt/|EuiEmptyPrompt documentation}
+ */
 export const EuiEmptyPrompt: FunctionComponent<EuiEmptyPromptProps> = ({
   icon,
   iconType,

--- a/packages/eui/src/components/expression/expression.tsx
+++ b/packages/eui/src/components/expression/expression.tsx
@@ -93,6 +93,9 @@ type Buttonlike = EuiExpressionProps &
 type Spanlike = EuiExpressionProps &
   Omit<HTMLAttributes<HTMLSpanElement>, 'value'>;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/search-and-filter/expression/|EuiExpression documentation}
+ */
 export const EuiExpression: FunctionComponent<
   ExclusiveUnion<Buttonlike, Spanlike>
 > = ({

--- a/packages/eui/src/components/facet/facet_button.tsx
+++ b/packages/eui/src/components/facet/facet_button.tsx
@@ -59,6 +59,9 @@ export interface EuiFacetButtonProps
   quantity?: number;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/facet/|EuiFacetButton documentation}
+ */
 export const EuiFacetButton: FunctionComponent<EuiFacetButtonProps> = ({
   children,
   className,

--- a/packages/eui/src/components/filter_group/filter_group.tsx
+++ b/packages/eui/src/components/filter_group/filter_group.tsx
@@ -27,6 +27,9 @@ export type EuiFilterGroupProps = HTMLAttributes<HTMLDivElement> &
     compressed?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/buttons/filter-group/|EuiFilterGroup documentation}
+ */
 export const EuiFilterGroup: FunctionComponent<EuiFilterGroupProps> = ({
   children,
   className,

--- a/packages/eui/src/components/flex/flex_grid.tsx
+++ b/packages/eui/src/components/flex/flex_grid.tsx
@@ -68,6 +68,9 @@ export interface EuiFlexGridProps {
   component?: ElementType;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/layout/flex/grid/|EuiFlexGrid documentation}
+ */
 export const EuiFlexGrid: FunctionComponent<
   CommonProps & HTMLAttributes<HTMLDivElement> & EuiFlexGridProps
 > = ({

--- a/packages/eui/src/components/flex/flex_group.tsx
+++ b/packages/eui/src/components/flex/flex_group.tsx
@@ -113,11 +113,11 @@ const EuiFlexGroupInternal = <TComponent extends ElementType>(
   return <Component {...rest} ref={ref} className={classes} css={cssStyles} />;
 };
 
+// Cast forwardRef return type to work with the generic TComponent type
+// and not fallback to implicit any typing
 /**
  * @see {@link https://eui.elastic.co/docs/components/layout/flex/|EuiFlexGroup documentation}
  */
-// Cast forwardRef return type to work with the generic TComponent type
-// and not fallback to implicit any typing
 export const EuiFlexGroup = forwardRef(EuiFlexGroupInternal) as (<
   TComponent extends ElementType = 'div',
   TComponentRef = ReactElement<any, TComponent>

--- a/packages/eui/src/components/flex/flex_group.tsx
+++ b/packages/eui/src/components/flex/flex_group.tsx
@@ -113,6 +113,9 @@ const EuiFlexGroupInternal = <TComponent extends ElementType>(
   return <Component {...rest} ref={ref} className={classes} css={cssStyles} />;
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/layout/flex/|EuiFlexGroup documentation}
+ */
 // Cast forwardRef return type to work with the generic TComponent type
 // and not fallback to implicit any typing
 export const EuiFlexGroup = forwardRef(EuiFlexGroupInternal) as (<

--- a/packages/eui/src/components/flex/flex_item.tsx
+++ b/packages/eui/src/components/flex/flex_item.tsx
@@ -115,6 +115,9 @@ const EuiFlexItemInternal = <TComponent extends ElementType>(
 
 // Cast forwardRef return type to work with the generic TComponent type
 // and not fallback to implicit any typing
+/**
+ * @see {@link https://eui.elastic.co/docs/components/layout/flex/item/|EuiFlexItem documentation}
+ */
 export const EuiFlexItem = forwardRef(EuiFlexItemInternal) as (<
   TComponent extends ElementType,
   TComponentRef = ReactElement<any, TComponent>

--- a/packages/eui/src/components/form/checkbox/checkbox.tsx
+++ b/packages/eui/src/components/form/checkbox/checkbox.tsx
@@ -39,6 +39,9 @@ export interface EuiCheckboxProps
   labelProps?: CommonProps & LabelHTMLAttributes<HTMLLabelElement>;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/selection/checkbox-and-checkbox-group/|EuiCheckbox documentation}
+ */
 export const EuiCheckbox: FunctionComponent<EuiCheckboxProps> = ({
   className,
   id,

--- a/packages/eui/src/components/form/described_form_group/described_form_group.tsx
+++ b/packages/eui/src/components/form/described_form_group/described_form_group.tsx
@@ -71,6 +71,9 @@ export type EuiDescribedFormGroupProps = CommonProps &
     fieldFlexItemProps?: PropsOf<typeof EuiFlexItem>;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/layouts/described-groups/|EuiDescribedFormGroup documentation}
+ */
 export const EuiDescribedFormGroup: FunctionComponent<
   EuiDescribedFormGroupProps
 > = (props) => {

--- a/packages/eui/src/components/form/field_number/field_number.tsx
+++ b/packages/eui/src/components/form/field_number/field_number.tsx
@@ -83,6 +83,9 @@ export type EuiFieldNumberProps = Omit<
     compressed?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/numeric/basic/|EuiFieldNumber documentation}
+ */
 export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
   props
 ) => {

--- a/packages/eui/src/components/form/field_number/field_number.tsx
+++ b/packages/eui/src/components/form/field_number/field_number.tsx
@@ -84,7 +84,7 @@ export type EuiFieldNumberProps = Omit<
   };
 
 /**
- * @see {@link https://eui.elastic.co/docs/components/forms/numeric/basic/|EuiFieldNumber documentation}
+ * @see {@link https://eui.elastic.co/docs/components/forms/numeric/|EuiFieldNumber documentation}
  */
 export const EuiFieldNumber: FunctionComponent<EuiFieldNumberProps> = (
   props

--- a/packages/eui/src/components/form/field_password/field_password.tsx
+++ b/packages/eui/src/components/form/field_password/field_password.tsx
@@ -74,6 +74,9 @@ export type EuiFieldPasswordProps = Omit<
     dualToggleProps?: Partial<EuiButtonIconPropsForButton>;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/text/password/|EuiFieldPassword documentation}
+ */
 export const EuiFieldPassword: FunctionComponent<EuiFieldPasswordProps> = (
   props
 ) => {

--- a/packages/eui/src/components/form/field_search/field_search.tsx
+++ b/packages/eui/src/components/form/field_search/field_search.tsx
@@ -302,5 +302,8 @@ export class EuiFieldSearchClass extends Component<
   }
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/search-and-filter/search/|EuiFieldSearch documentation}
+ */
 export const EuiFieldSearch =
   withEuiStylesMemoizer<EuiFieldSearchProps>(EuiFieldSearchClass);

--- a/packages/eui/src/components/form/field_text/field_text.tsx
+++ b/packages/eui/src/components/form/field_text/field_text.tsx
@@ -64,7 +64,7 @@ export type EuiFieldTextProps = InputHTMLAttributes<HTMLInputElement> &
   };
 
 /**
- * @see {@link https://eui.elastic.co/docs/components/forms/text/basic/|EuiFieldText documentation}
+ * @see {@link https://eui.elastic.co/docs/components/forms/text/|EuiFieldText documentation}
  */
 export const EuiFieldText: FunctionComponent<EuiFieldTextProps> = (props) => {
   const { defaultFullWidth } = useFormContext();

--- a/packages/eui/src/components/form/field_text/field_text.tsx
+++ b/packages/eui/src/components/form/field_text/field_text.tsx
@@ -63,6 +63,9 @@ export type EuiFieldTextProps = InputHTMLAttributes<HTMLInputElement> &
     compressed?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/text/basic/|EuiFieldText documentation}
+ */
 export const EuiFieldText: FunctionComponent<EuiFieldTextProps> = (props) => {
   const { defaultFullWidth } = useFormContext();
   const {

--- a/packages/eui/src/components/form/file_picker/file_picker.tsx
+++ b/packages/eui/src/components/form/file_picker/file_picker.tsx
@@ -375,5 +375,8 @@ export class EuiFilePickerClass extends Component<
   }
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/other/file-picker/|EuiFilePicker documentation}
+ */
 export const EuiFilePicker =
   withEuiStylesMemoizer<EuiFilePickerProps>(EuiFilePickerClass);

--- a/packages/eui/src/components/form/form.tsx
+++ b/packages/eui/src/components/form/form.tsx
@@ -49,6 +49,9 @@ export type EuiFormProps = CommonProps &
     fullWidth?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/layouts/|EuiForm documentation}
+ */
 export const EuiForm = forwardRef<HTMLElement, EuiFormProps>(
   (
     {

--- a/packages/eui/src/components/form/form.tsx
+++ b/packages/eui/src/components/form/form.tsx
@@ -50,7 +50,7 @@ export type EuiFormProps = CommonProps &
   };
 
 /**
- * @see {@link https://eui.elastic.co/docs/components/forms/layouts/|EuiForm documentation}
+ * @see {@link https://eui.elastic.co/docs/components/forms/layouts/row/|EuiForm documentation}
  */
 export const EuiForm = forwardRef<HTMLElement, EuiFormProps>(
   (

--- a/packages/eui/src/components/form/form_control_layout/form_control_layout.tsx
+++ b/packages/eui/src/components/form/form_control_layout/form_control_layout.tsx
@@ -82,6 +82,9 @@ export type EuiFormControlLayoutProps = CommonProps &
     wrapperProps?: CommonProps & HTMLAttributes<HTMLDivElement>;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/layouts/controls/|EuiFormControlLayout documentation}
+ */
 export const EuiFormControlLayout: FunctionComponent<
   EuiFormControlLayoutProps & {
     // Internal prop used by EuiFormControlLayoutDelimited

--- a/packages/eui/src/components/form/form_label/form_label.tsx
+++ b/packages/eui/src/components/form/form_label/form_label.tsx
@@ -55,6 +55,9 @@ export type EuiFormLabelProps = ExclusiveUnion<
   _EuiFormLabelSpanProps
 >;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/layouts/label/|EuiFormLabel documentation}
+ */
 export const EuiFormLabel: FunctionComponent<EuiFormLabelProps> = ({
   type = 'label',
   isFocused,

--- a/packages/eui/src/components/form/form_row/form_row.tsx
+++ b/packages/eui/src/components/form/form_row/form_row.tsx
@@ -109,6 +109,9 @@ type LegendProps = {
 
 export type EuiFormRowProps = ExclusiveUnion<LabelProps, LegendProps>;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/layouts/row/|EuiFormRow documentation}
+ */
 export const EuiFormRow: FunctionComponent<EuiFormRowProps> = ({
   className,
   children,

--- a/packages/eui/src/components/form/radio/radio.tsx
+++ b/packages/eui/src/components/form/radio/radio.tsx
@@ -47,6 +47,9 @@ export type EuiRadioProps = CommonProps &
   Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'id'> &
   ExclusiveUnion<ExclusiveUnion<RadioProps, idWithLabel>, withId>;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/selection/radio-and-radio-group/|EuiRadio documentation}
+ */
 export const EuiRadio: FunctionComponent<EuiRadioProps> = ({
   className,
   id,

--- a/packages/eui/src/components/form/range/range.tsx
+++ b/packages/eui/src/components/form/range/range.tsx
@@ -335,4 +335,7 @@ export class EuiRangeClass extends Component<
   }
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/numeric/range-sliders/|EuiRange documentation}
+ */
 export const EuiRange = withEuiTheme<EuiRangeProps>(EuiRangeClass);

--- a/packages/eui/src/components/form/range/types.ts
+++ b/packages/eui/src/components/form/range/types.ts
@@ -122,7 +122,7 @@ export interface _SharedRangeInputProps {
   /**
    * Only impacts input popovers rendered when the `showInput` prop is set to `"inputWithPopover"`
    *
-   * Allows customizing the underlying [EuiInputPopover](https://eui.elastic.co/docs/components/containers/popover#popover-attached-to-input-element),
+   * Allows customizing the underlying [EuiInputPopover](https://eui.elastic.co/docs/components/containers/popover/),
    * except for props controlled by the range component
    */
   inputPopoverProps?: Omit<

--- a/packages/eui/src/components/form/range/types.ts
+++ b/packages/eui/src/components/form/range/types.ts
@@ -122,7 +122,7 @@ export interface _SharedRangeInputProps {
   /**
    * Only impacts input popovers rendered when the `showInput` prop is set to `"inputWithPopover"`
    *
-   * Allows customizing the underlying [EuiInputPopover](/#/layout/popover#popover-attached-to-input-element),
+   * Allows customizing the underlying [EuiInputPopover](https://eui.elastic.co/docs/components/containers/popover#popover-attached-to-input-element),
    * except for props controlled by the range component
    */
   inputPopoverProps?: Omit<

--- a/packages/eui/src/components/form/select/select.tsx
+++ b/packages/eui/src/components/form/select/select.tsx
@@ -76,6 +76,9 @@ export type EuiSelectProps = Omit<
     append?: EuiFormControlLayoutProps['append'];
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/selection/basic-select/|EuiSelect documentation}
+ */
 export const EuiSelect: FunctionComponent<EuiSelectProps> = (props) => {
   const { defaultFullWidth } = useFormContext();
   const {

--- a/packages/eui/src/components/form/super_select/super_select.tsx
+++ b/packages/eui/src/components/form/super_select/super_select.tsx
@@ -72,7 +72,7 @@ export type EuiSuperSelectProps<T = string> = CommonProps &
     isOpen?: boolean;
 
     /**
-     * Optional props to pass to the underlying [EuiInputPopover](https://eui.elastic.co/docs/components/containers/popover#popover-attached-to-input-element).
+     * Optional props to pass to the underlying [EuiInputPopover](https://eui.elastic.co/docs/components/containers/popover/).
      * Allows fine-grained control of the popover dropdown menu, including
      * `repositionOnScroll` for EuiSuperSelects used within scrollable containers,
      * and customizing popover panel styling.

--- a/packages/eui/src/components/form/super_select/super_select.tsx
+++ b/packages/eui/src/components/form/super_select/super_select.tsx
@@ -72,7 +72,7 @@ export type EuiSuperSelectProps<T = string> = CommonProps &
     isOpen?: boolean;
 
     /**
-     * Optional props to pass to the underlying [EuiInputPopover](/#/layout/popover#popover-attached-to-input-element).
+     * Optional props to pass to the underlying [EuiInputPopover](https://eui.elastic.co/docs/components/containers/popover#popover-attached-to-input-element).
      * Allows fine-grained control of the popover dropdown menu, including
      * `repositionOnScroll` for EuiSuperSelects used within scrollable containers,
      * and customizing popover panel styling.

--- a/packages/eui/src/components/form/switch/switch.tsx
+++ b/packages/eui/src/components/form/switch/switch.tsx
@@ -52,6 +52,9 @@ export type EuiSwitchProps = CommonProps &
     labelProps?: CommonProps & HTMLAttributes<HTMLSpanElement>;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/selection/switch/|EuiSwitch documentation}
+ */
 export const EuiSwitch: FunctionComponent<
   EuiSwitchProps & {
     /**

--- a/packages/eui/src/components/header/header.tsx
+++ b/packages/eui/src/components/header/header.tsx
@@ -74,6 +74,9 @@ export type EuiHeaderProps = CommonProps &
     theme?: 'default' | 'dark';
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/layout/header/|EuiHeader documentation}
+ */
 export const EuiHeader: FunctionComponent<EuiHeaderProps> = ({
   children,
   className,

--- a/packages/eui/src/components/health/health.tsx
+++ b/packages/eui/src/components/health/health.tsx
@@ -33,6 +33,9 @@ export type EuiHealthProps = CommonProps &
     textSize?: (typeof TEXT_SIZES)[number];
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/health/|EuiHealth documentation}
+ */
 export const EuiHealth: FunctionComponent<EuiHealthProps> = ({
   children,
   className,

--- a/packages/eui/src/components/horizontal_rule/horizontal_rule.tsx
+++ b/packages/eui/src/components/horizontal_rule/horizontal_rule.tsx
@@ -29,6 +29,9 @@ export interface EuiHorizontalRuleProps
   margin?: EuiHorizontalRuleMargin;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/layout/horizontal-rule/|EuiHorizontalRule documentation}
+ */
 export const EuiHorizontalRule: FunctionComponent<EuiHorizontalRuleProps> = ({
   className,
   size = 'full',

--- a/packages/eui/src/components/icon/icon.tsx
+++ b/packages/eui/src/components/icon/icon.tsx
@@ -344,5 +344,8 @@ export class EuiIconClass extends PureComponent<
   }
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/icons/|EuiIcon documentation}
+ */
 export const EuiIcon = withEuiStylesMemoizer<EuiIconProps>(EuiIconClass);
 EuiIcon.displayName = 'EuiIcon';

--- a/packages/eui/src/components/illustration/illustration.tsx
+++ b/packages/eui/src/components/illustration/illustration.tsx
@@ -58,6 +58,9 @@ export type EuiIllustrationProps = Omit<
     fullWidth?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/illustrations/|EuiIllustration documentation}
+ */
 export const EuiIllustration: FunctionComponent<EuiIllustrationProps> = ({
   type,
   alt,

--- a/packages/eui/src/components/image/image.tsx
+++ b/packages/eui/src/components/image/image.tsx
@@ -17,6 +17,9 @@ import { EuiImageFullScreenWrapper } from './image_fullscreen_wrapper';
 import type { EuiImageProps, EuiImageSize } from './image_types';
 import { SIZES } from './image_types';
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/image/|EuiImage documentation}
+ */
 export const EuiImage: FunctionComponent<EuiImageProps> = ({
   className,
   alt,

--- a/packages/eui/src/components/inline_edit/inline_edit_text.tsx
+++ b/packages/eui/src/components/inline_edit/inline_edit_text.tsx
@@ -29,6 +29,9 @@ export type EuiInlineEditTextProps = EuiInlineEditCommonProps & {
   size?: EuiInlineEditTextSizes;
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/text/inline-edit/|EuiInlineEditText documentation}
+ */
 export const EuiInlineEditText: FunctionComponent<EuiInlineEditTextProps> = ({
   className,
   size = 'm',

--- a/packages/eui/src/components/key_pad_menu/key_pad_menu.tsx
+++ b/packages/eui/src/components/key_pad_menu/key_pad_menu.tsx
@@ -48,6 +48,9 @@ export type EuiKeyPadMenuProps = CommonProps &
     checkable?: _EuiKeyPadMenuCheckableProps | true;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/buttons/key-pad-menu/|EuiKeyPadMenu documentation}
+ */
 export const EuiKeyPadMenu: FunctionComponent<EuiKeyPadMenuProps> = ({
   children,
   className,

--- a/packages/eui/src/components/link/link.tsx
+++ b/packages/eui/src/components/link/link.tsx
@@ -75,6 +75,9 @@ export type EuiLinkProps = ExclusiveUnion<
   EuiLinkAnchorProps
 >;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/link/|EuiLink documentation}
+ */
 const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
   (
     {

--- a/packages/eui/src/components/list_group/list_group.tsx
+++ b/packages/eui/src/components/list_group/list_group.tsx
@@ -59,6 +59,9 @@ export type EuiListGroupProps = CommonProps &
     ariaLabelledby?: string;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/list-group/|EuiListGroup documentation}
+ */
 export const EuiListGroup: FunctionComponent<EuiListGroupProps> = ({
   children,
   className,

--- a/packages/eui/src/components/list_group/list_group_item.tsx
+++ b/packages/eui/src/components/list_group/list_group_item.tsx
@@ -143,7 +143,7 @@ export type EuiListGroupItemProps = CommonProps &
 
     /**
      * Allows customizing the tooltip shown when `showToolTip` is true.
-     * Accepts any props that [EuiToolTip](/#/display/tooltip) accepts.
+     * Accepts any props that [EuiToolTip](https://eui.elastic.co/docs/components/display/tooltip/) accepts.
      */
     toolTipProps?: Partial<EuiToolTipProps>;
   };

--- a/packages/eui/src/components/loading/loading_spinner.tsx
+++ b/packages/eui/src/components/loading/loading_spinner.tsx
@@ -37,6 +37,9 @@ export type EuiLoadingSpinnerProps = CommonProps &
     color?: EuiLoadingSpinnerColor;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/loading/|EuiLoadingSpinner documentation}
+ */
 export const EuiLoadingSpinner: FunctionComponent<EuiLoadingSpinnerProps> = ({
   size = 'm',
   className,

--- a/packages/eui/src/components/markdown_editor/markdown_editor.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_editor.tsx
@@ -198,6 +198,9 @@ function padWithNewlinesIfNeeded(textarea: HTMLTextAreaElement, text: string) {
   return text;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/editors-and-syntax/markdown/editor/|EuiMarkdownEditor documentation}
+ */
 export const EuiMarkdownEditor = forwardRef<
   EuiMarkdownEditorRef,
   EuiMarkdownEditorProps

--- a/packages/eui/src/components/markdown_editor/markdown_format.tsx
+++ b/packages/eui/src/components/markdown_editor/markdown_format.tsx
@@ -33,6 +33,9 @@ export type EuiMarkdownFormatProps = CommonProps &
     textSize?: EuiTextProps['size'];
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/editors-and-syntax/markdown/format/|EuiMarkdownFormat documentation}
+ */
 export const EuiMarkdownFormat: FunctionComponent<EuiMarkdownFormatProps> = ({
   children,
   className,

--- a/packages/eui/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
+++ b/packages/eui/src/components/markdown_editor/plugins/markdown_default_plugins/processing_plugins.tsx
@@ -56,7 +56,7 @@ export type DefaultEuiMarkdownProcessingPlugins = [
 export type DefaultProcessingPluginsConfig = {
   /**
    * Allows customizing all formatted links.
-   * Accepts any prop that [EuiLink](/#/navigation/link) or any anchor link tag accepts.
+   * Accepts any prop that [EuiLink](https://eui.elastic.co/docs/components/navigation/link/) or any anchor link tag accepts.
    * Useful for, e.g. setting `target="_blank"` on all links
    */
   linkProps?: Partial<EuiLinkProps>;

--- a/packages/eui/src/components/modal/modal.tsx
+++ b/packages/eui/src/components/modal/modal.tsx
@@ -70,6 +70,9 @@ export interface EuiModalProps extends HTMLAttributes<HTMLDivElement> {
   outsideClickCloses?: boolean;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/containers/modal/|EuiModal documentation}
+ */
 export const EuiModal: FunctionComponent<EuiModalProps> = ({
   className,
   children,

--- a/packages/eui/src/components/modal/modal.tsx
+++ b/packages/eui/src/components/modal/modal.tsx
@@ -71,7 +71,7 @@ export interface EuiModalProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 /**
- * @see {@link https://eui.elastic.co/docs/components/containers/modal/|EuiModal documentation}
+ * @see {@link https://eui.elastic.co/docs/containers/modal/|EuiModal documentation}
  */
 export const EuiModal: FunctionComponent<EuiModalProps> = ({
   className,

--- a/packages/eui/src/components/page/page.tsx
+++ b/packages/eui/src/components/page/page.tsx
@@ -48,7 +48,7 @@ export interface EuiPageProps
 }
 
 /**
- * @see {@link https://eui.elastic.co/docs/components/layout/page_components/|EuiPage documentation}
+ * @see {@link https://eui.elastic.co/docs/layout/page-components/|EuiPage documentation}
  */
 export const EuiPage: FunctionComponent<EuiPageProps> = ({
   children,

--- a/packages/eui/src/components/page/page.tsx
+++ b/packages/eui/src/components/page/page.tsx
@@ -47,6 +47,9 @@ export interface EuiPageProps
   color?: 'plain' | 'transparent';
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/layout/page_components/|EuiPage documentation}
+ */
 export const EuiPage: FunctionComponent<EuiPageProps> = ({
   children,
   restrictWidth = false,

--- a/packages/eui/src/components/page/page_header/page_header.tsx
+++ b/packages/eui/src/components/page/page_header/page_header.tsx
@@ -45,6 +45,9 @@ export interface EuiPageHeaderProps
   color?: 'plain' | 'transparent';
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/layout/page-header/|EuiPageHeader documentation}
+ */
 export const EuiPageHeader: FunctionComponent<EuiPageHeaderProps> = ({
   className,
   restrictWidth = false,

--- a/packages/eui/src/components/page_template/page_template.tsx
+++ b/packages/eui/src/components/page_template/page_template.tsx
@@ -251,6 +251,9 @@ const _EuiPageBottomBar: FunctionComponent<_EuiPageBottomBarProps> = (
 };
 _EuiPageBottomBar.displayName = 'EuiPageTemplate.BottomBar';
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/templates/page-template/|EuiPageTemplate documentation}
+ */
 export const EuiPageTemplate = Object.assign(_EuiPageTemplate, {
   Sidebar: _EuiPageSidebar,
   Header: _EuiPageHeader,

--- a/packages/eui/src/components/pagination/pagination.tsx
+++ b/packages/eui/src/components/pagination/pagination.tsx
@@ -65,6 +65,9 @@ export interface EuiPaginationProps {
 
 type Props = CommonProps & HTMLAttributes<HTMLDivElement> & EuiPaginationProps;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/pagination/|EuiPagination documentation}
+ */
 export const EuiPagination: FunctionComponent<Props> = ({
   className,
   pageCount = 1,

--- a/packages/eui/src/components/panel/panel.tsx
+++ b/packages/eui/src/components/panel/panel.tsx
@@ -95,6 +95,9 @@ export type EuiPanelProps = ExclusiveUnion<
   _EuiPanelDivlike
 >;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/containers/panel/|EuiPanel documentation}
+ */
 export const EuiPanel: FunctionComponent<EuiPanelProps> = ({
   children,
   className,

--- a/packages/eui/src/components/popover/popover.tsx
+++ b/packages/eui/src/components/popover/popover.tsx
@@ -293,6 +293,9 @@ type PropsWithDefaults = Props & {
   panelPaddingSize: EuiPaddingSize;
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/containers/popover/|EuiPopover documentation}
+ */
 export class EuiPopover extends Component<Props, State> {
   static contextType = EuiComponentDefaultsContext;
   declare context: ContextType<typeof EuiComponentDefaultsContext>;

--- a/packages/eui/src/components/progress/progress.tsx
+++ b/packages/eui/src/components/progress/progress.tsx
@@ -89,6 +89,9 @@ type Determinate = EuiProgressProps &
     labelProps?: CommonProps & HTMLAttributes<HTMLSpanElement>;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/progress/|EuiProgress documentation}
+ */
 export const EuiProgress: FunctionComponent<
   ExclusiveUnion<Determinate, Indeterminate>
 > = ({

--- a/packages/eui/src/components/resizable_container/resizable_container.tsx
+++ b/packages/eui/src/components/resizable_container/resizable_container.tsx
@@ -88,6 +88,9 @@ const initialState: EuiResizableContainerState = {
   resizers: {},
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/containers/resizable-container/|EuiResizableContainer documentation}
+ */
 export const EuiResizableContainer: FunctionComponent<
   EuiResizableContainerProps
 > = ({

--- a/packages/eui/src/components/search_bar/search_bar.tsx
+++ b/packages/eui/src/components/search_bar/search_bar.tsx
@@ -213,6 +213,9 @@ function notifyControllingParent(
   }
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/search-and-filter/search-bar/|EuiSearchBar documentation}
+ */
 export const EuiSearchBar = (props: EuiSearchBarProps) => {
   const {
     box: { schema, 'aria-describedby': boxAriaDescribedBy, ...box } = {

--- a/packages/eui/src/components/selectable/selectable.tsx
+++ b/packages/eui/src/components/selectable/selectable.tsx
@@ -221,6 +221,9 @@ export interface EuiSelectableState<T> {
   isFocused: boolean;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/forms/selection/selectable/|EuiSelectable documentation}
+ */
 export class EuiSelectable<T = {}> extends Component<
   EuiSelectableProps<T>,
   EuiSelectableState<T>

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list.tsx
@@ -112,7 +112,7 @@ export type EuiSelectableOptionsListProps = CommonProps &
     textWrap?: EuiSelectableListItemProps['textWrap'];
     /**
      * If textWrap is set to `truncate`, you can pass a custom truncation configuration
-     * that accepts any [EuiTextTruncate](/#/utilities/text-truncation) prop except for
+     * that accepts any [EuiTextTruncate](https://eui.elastic.co/docs/utilities/text-truncation/) prop except for
      * `text` and `children`.
      *
      * Note: when searching, custom truncation props are ignored. The highlighted search

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list_item.tsx
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list_item.tsx
@@ -71,7 +71,7 @@ export type EuiSelectableListItemProps = LiHTMLAttributes<HTMLLIElement> &
      */
     toolTipContent?: EuiSelectableOption['toolTipContent'];
     /**
-     * Optional props to pass to the underlying **[EuiToolTip](/#/display/tooltip)**
+     * Optional props to pass to the underlying **[EuiToolTip](https://eui.elastic.co/docs/components/display/tooltip/)**
      */
     toolTipProps?: EuiSelectableOption['toolTipProps'];
   };

--- a/packages/eui/src/components/selectable/selectable_option.tsx
+++ b/packages/eui/src/components/selectable/selectable_option.tsx
@@ -70,7 +70,7 @@ export type EuiSelectableOptionBase = CommonProps & {
   textWrap?: 'truncate' | 'wrap';
   /**
    * If textWrap is set to `truncate`, you can pass a custom truncation configuration
-   * that accepts any [EuiTextTruncate](/#/utilities/text-truncation) prop except for
+   * that accepts any [EuiTextTruncate](https://eui.elastic.co/docs/utilities/text-truncation/) prop except for
    * `text` and `children`.
    *
    * Note: when searching, custom truncation props are ignored. The highlighted search
@@ -82,7 +82,7 @@ export type EuiSelectableOptionBase = CommonProps & {
    */
   toolTipContent?: EuiToolTipProps['content'];
   /**
-   * Optional props to pass to the underlying **[EuiToolTip](/#/display/tooltip)**
+   * Optional props to pass to the underlying **[EuiToolTip](https://eui.elastic.co/docs/components/display/tooltip/)**
    */
   toolTipProps?: Partial<Omit<EuiToolTipProps, 'content' | 'children'>>;
 };

--- a/packages/eui/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
+++ b/packages/eui/src/components/selectable/selectable_templates/selectable_template_sitewide.tsx
@@ -94,6 +94,9 @@ export type EuiSelectableTemplateSitewideProps = Partial<
   };
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/templates/sitewide-search/|EuiSelectableTemplateSitewide documentation}
+ */
 export const EuiSelectableTemplateSitewide: FunctionComponent<
   EuiSelectableTemplateSitewideProps
 > = ({

--- a/packages/eui/src/components/side_nav/side_nav.a11y.tsx
+++ b/packages/eui/src/components/side_nav/side_nav.a11y.tsx
@@ -34,7 +34,7 @@ describe('EuiSideNav', () => {
             {
               name: 'Item with href',
               id: htmlIdGenerator('basicExample')(),
-              href: '/#/navigation/side-nav',
+              href: 'https://eui.elastic.co/docs/components/navigation/side-nav/',
             },
             {
               name: 'Selected item',
@@ -94,7 +94,7 @@ describe('EuiSideNav', () => {
             {
               name: 'Item with href',
               id: htmlIdGenerator('basicExample')(),
-              href: '/#/navigation/side-nav',
+              href: 'https://eui.elastic.co/docs/components/navigation/side-nav/',
             },
             {
               name: 'Selected item',

--- a/packages/eui/src/components/side_nav/side_nav.tsx
+++ b/packages/eui/src/components/side_nav/side_nav.tsx
@@ -73,6 +73,9 @@ export type EuiSideNavProps<T = {}> = T &
     truncate?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/side-nav/|EuiSideNav documentation}
+ */
 export const EuiSideNav = <T = {},>({
   className,
   items = [],

--- a/packages/eui/src/components/skeleton/skeleton_loading.tsx
+++ b/packages/eui/src/components/skeleton/skeleton_loading.tsx
@@ -60,6 +60,9 @@ export type EuiSkeletonLoadingProps = CommonProps &
     loadedContent: any;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/skeleton/|EuiSkeletonLoading documentation}
+ */
 export const EuiSkeletonLoading: FunctionComponent<EuiSkeletonLoadingProps> = ({
   isLoading = true,
   contentAriaLabel,

--- a/packages/eui/src/components/spacer/spacer.tsx
+++ b/packages/eui/src/components/spacer/spacer.tsx
@@ -22,6 +22,9 @@ export type EuiSpacerProps = HTMLAttributes<HTMLDivElement> &
     size?: SpacerSize;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/layout/spacer/|EuiSpacer documentation}
+ */
 export const EuiSpacer: FunctionComponent<EuiSpacerProps> = ({
   className,
   size = 'm',

--- a/packages/eui/src/components/stat/stat.tsx
+++ b/packages/eui/src/components/stat/stat.tsx
@@ -72,6 +72,9 @@ export interface EuiStatProps {
   descriptionElement?: string;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/stat/|EuiStat documentation}
+ */
 export const EuiStat: FunctionComponent<
   CommonProps & Omit<HTMLAttributes<HTMLDivElement>, 'title'> & EuiStatProps
 > = ({

--- a/packages/eui/src/components/steps/steps.tsx
+++ b/packages/eui/src/components/steps/steps.tsx
@@ -63,6 +63,9 @@ function renderSteps(
   });
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/steps/|EuiSteps documentation}
+ */
 export const EuiSteps: FunctionComponent<EuiStepsProps> = ({
   className,
   firstStepNumber = 1,

--- a/packages/eui/src/components/tabs/tabs.tsx
+++ b/packages/eui/src/components/tabs/tabs.tsx
@@ -46,6 +46,9 @@ export type EuiTabsProps = HTMLAttributes<HTMLDivElement> &
 
 export type EuiTabRef = HTMLDivElement;
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/containers/tabs/|EuiTabs documentation}
+ */
 export const EuiTabs = forwardRef<EuiTabRef, EuiTabsProps>(
   (
     {

--- a/packages/eui/src/components/text/text.tsx
+++ b/packages/eui/src/components/text/text.tsx
@@ -29,6 +29,9 @@ export type EuiTextProps = SharedTextProps &
     grow?: boolean;
   };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/text/|EuiText documentation}
+ */
 export const EuiText: FunctionComponent<EuiTextProps> = ({
   component = 'div',
   size = 'm',

--- a/packages/eui/src/components/timeline/timeline.tsx
+++ b/packages/eui/src/components/timeline/timeline.tsx
@@ -30,6 +30,9 @@ export interface EuiTimelineProps
   gutterSize?: EuiTimelineGutterSize;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/timeline/|EuiTimeline documentation}
+ */
 export const EuiTimeline: FunctionComponent<EuiTimelineProps> = ({
   className,
   items = [],

--- a/packages/eui/src/components/title/title.tsx
+++ b/packages/eui/src/components/title/title.tsx
@@ -30,6 +30,9 @@ export type EuiTitleProps = CommonProps & {
   id?: string;
 };
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/title/|EuiTitle documentation}
+ */
 export const EuiTitle: FunctionComponent<EuiTitleProps> = ({
   size = 'm',
   children,

--- a/packages/eui/src/components/toast/global_toast_list.tsx
+++ b/packages/eui/src/components/toast/global_toast_list.tsx
@@ -84,6 +84,9 @@ export interface EuiGlobalToastListProps extends CommonProps {
   showNotificationBadge?: boolean;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/toast/|EuiGlobalToastList documentation}
+ */
 export const EuiGlobalToastList: FunctionComponent<EuiGlobalToastListProps> = ({
   className,
   toasts = [],

--- a/packages/eui/src/components/tool_tip/tool_tip.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.tsx
@@ -150,6 +150,9 @@ export interface EuiToolTipRef {
   id: string;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/tooltip/|EuiToolTip documentation}
+ */
 export const EuiToolTip = forwardRef<EuiToolTipRef, EuiToolTipProps>(
   (
     {

--- a/packages/eui/src/components/tour/tour.tsx
+++ b/packages/eui/src/components/tour/tour.tsx
@@ -21,6 +21,9 @@ export interface EuiTourProps {
   initialState: EuiTourState;
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/display/tour/|EuiTour documentation}
+ */
 export const EuiTour: FunctionComponent<EuiTourProps> = ({
   children,
   steps,

--- a/packages/eui/src/components/tree_view/tree_view.tsx
+++ b/packages/eui/src/components/tree_view/tree_view.tsx
@@ -371,6 +371,9 @@ export class EuiTreeViewClass extends Component<
   }
 }
 
+/**
+ * @see {@link https://eui.elastic.co/docs/components/navigation/tree-view/|EuiTreeView documentation}
+ */
 export const EuiTreeView = Object.assign(
   withEuiTheme<EuiTreeViewProps>(EuiTreeViewClass),
   { Item: EuiTreeViewItem }

--- a/packages/website/docs/content/accessibility.mdx
+++ b/packages/website/docs/content/accessibility.mdx
@@ -7,7 +7,7 @@ sidebar_position: 6
 This page shares common tips and tricks for writing accessible UI copy. It is not exhaustive and does not replace the official
 [WCAG 2.0 guidelines](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#guidelines).
 
-Writing accessible UI copy is only one part of improving web accessibility. Check the [EUI documentation](https://eui.elastic.co/#/guidelines/accessibility) for more accessibility guidelines.
+Writing accessible UI copy is only one part of improving web accessibility. Check the [EUI documentation](https://eui.elastic.co/docs/utilities/accessibility/) for more accessibility guidelines.
 
 ## What is accessible content and why does it matter
 

--- a/packages/website/docs/dataviz/dashboard-good-practices.mdx
+++ b/packages/website/docs/dataviz/dashboard-good-practices.mdx
@@ -146,7 +146,7 @@ This is just an example useful to explain the concept and can be applied to seve
 
 #### Consistency
 
-The most important thing to keep in mind is that the best option is always to stick with the guidelines provided by our EUI. Colors provided there for visualization have been tested for accessibility contrast and using them you would be sure to properly serving the biggest audience. You can find this documentation [here](https://eui.elastic.co/docs/dataviz/ "EUI Charts page")
+The most important thing to keep in mind is that the best option is always to stick with the guidelines provided by our EUI. Colors provided there for visualization have been tested for accessibility contrast and using them you would be sure to properly serve the biggest audience. You can find this documentation [here](https://eui.elastic.co/docs/dataviz/ "EUI Charts page")
 
 In addition to that, following these guidelines you'll be sure to get a consistent interface that will work perfectly with all other solutions.
 

--- a/packages/website/docs/dataviz/dashboard-good-practices.mdx
+++ b/packages/website/docs/dataviz/dashboard-good-practices.mdx
@@ -146,7 +146,7 @@ This is just an example useful to explain the concept and can be applied to seve
 
 #### Consistency
 
-The most important thing to keep in mind is that the best option is always to stick with the guidelines provided by our EUI. Colors provided there for visualization have been tested for accessibility contrast and using them you would be sure to properly serving the biggest audience. You can find this documentation [here](https://elastic.github.io/eui/#/elastic-charts/creating-charts "EUI Charts page")
+The most important thing to keep in mind is that the best option is always to stick with the guidelines provided by our EUI. Colors provided there for visualization have been tested for accessibility contrast and using them you would be sure to properly serving the biggest audience. You can find this documentation [here](https://eui.elastic.co/docs/dataviz/ "EUI Charts page")
 
 In addition to that, following these guidelines you'll be sure to get a consistent interface that will work perfectly with all other solutions.
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui-private/issues/749

- Replace all old hash-router `/#/` documentation links (from the previous docs site) with current `https://eui.elastic.co/docs/` URLs
- Add `@see` JSDoc documentation links to every public component that was missing one

## Changes

### Commit 1 — Replace `/#/` hash-router links

The previous EUI documentation website used a hash router, leaving `/#/category/component` links scattered across JSDoc comments and markdown files. These are now broken or point to the wrong place.

- 17 files updated across component source files, website markdown docs, and `CHANGELOG.md`
- Example mapping: `/#/layout/popover` → `https://eui.elastic.co/docs/components/containers/popover/` (also reflects the category reorganization from `layout` to `containers`)
- Fixed two full `eui.elastic.co/#/` URLs and one very old `elastic.github.io/eui/#/` URL
- Removed a dead "On our docs website" bullet from `CHANGELOG.md` (no equivalent page exists on the new site)

### Commit 2 — Add `@see` doc links to public component JSDoc

85 public API component files were missing a link to their documentation page. Added `@see {@link URL|ComponentName documentation}` to the JSDoc of each.

## Test plan

- [x] Verify a sample of the new URLs resolve correctly on https://eui.elastic.co
- [x] Check that no `/#/` documentation links remain in JSDoc or markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)