### PR TITLE
[test-helpers] Add EuiDataGridObject, EuiSuperSelectObject and EuiGlobalToastListObject

### DIFF
--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -47,6 +47,9 @@ their own version at runtime.
 | Component | Documentation |
 |---|---|
 | `EuiComboBoxObject` | [src/components/combo_box/README.md](src/components/combo_box/README.md) |
+| `EuiDataGridObject` | [src/components/datagrid/README.md](src/components/datagrid/README.md) |
+| `EuiSuperSelectObject` | [src/components/form/super_select/README.md](src/components/form/super_select/README.md) |
+| `EuiGlobalToastListObject` | [src/components/toast/README.md](src/components/toast/README.md) |
 
 ## Contributing
 

--- a/packages/test-helpers/changelogs/upcoming/9874.md
+++ b/packages/test-helpers/changelogs/upcoming/9874.md
@@ -1,0 +1,3 @@
+- Added `EuiDataGridObject` with `rows`, `cell()`, `cells()`, `doActionOnColumn()` and `openFullScreenMode()`/`closeFullScreenMode()`
+- Added `EuiSuperSelectObject` with `selectOptionByValue()`, `selectOptionByLabel()` and `getSelectedValue()`
+- Added `EuiGlobalToastListObject` with a `toasts` locator and `closeAll()`

--- a/packages/test-helpers/src/components/datagrid/README.md
+++ b/packages/test-helpers/src/components/datagrid/README.md
@@ -1,6 +1,6 @@
 # EuiDataGridObject
 
-Playwright Component Object for [EuiDataGrid](https://eui.elastic.co/docs/components/tables/data-grid/).
+Playwright Component Object for [EuiDataGrid](https://eui.elastic.co/docs/components/data-grid).
 
 ## Usage
 

--- a/packages/test-helpers/src/components/datagrid/README.md
+++ b/packages/test-helpers/src/components/datagrid/README.md
@@ -1,0 +1,25 @@
+# EuiDataGridObject
+
+Playwright Component Object for [EuiDataGrid](https://eui.elastic.co/docs/components/tables/data-grid/).
+
+## Usage
+
+```ts
+import { EuiDataGridObject } from '@elastic/eui-test-helpers';
+
+const dataGrid = new EuiDataGridObject(page, 'myDataGrid');
+await expect(dataGrid.rows).toHaveCount(10);
+await expect(dataGrid.cells('name').filter({ hasText: 'my-rule' })).toBeVisible();
+```
+
+Set `data-test-subj` on the `<EuiDataGrid>` itself — EUI spreads it onto the `.euiDataGrid` element, and the Component Object verifies that (the component-type guard throws otherwise). EUI also toggles state classes such as fullscreen on that element, so a wrapper subj would not work. When the subj is not unique on the page (e.g. portal-rendered duplicates), narrow with the `scope` constructor parameter instead of pointing the subj at a wrapper.
+
+## API
+
+| Member | Description |
+|---|---|
+| `rows` | `Locator` for the rendered rows, keeping Playwright auto-retry for count/content assertions. For a paginated grid this is the current page. Rows are virtualized: on a grid too tall for its container this is only the visible window, never the full data set. |
+| `cell(rowIndex, columnId)` | `Locator` for a single data cell. The column id is stable against column reordering and horizontal virtualization. |
+| `cells(columnId)` | `Locator` for every rendered data cell of a column (excludes the header cell). |
+| `doActionOnColumn(columnId, actionLabel)` | Opens the column's header actions and clicks the action with the given visible label (e.g. `'Hide column'`). Handles the hover/focus dance the actions button requires and the portal-rendered menu (scoped per column id, safe with multiple grids). |
+| `openFullScreenMode()` / `closeFullScreenMode()` | Toggles fullscreen via the toolbar button and settles on the synchronously-set state class. Blurs the button afterwards so its tooltip does not cover the grid. |

--- a/packages/test-helpers/src/components/datagrid/selectors.ts
+++ b/packages/test-helpers/src/components/datagrid/selectors.ts
@@ -35,9 +35,6 @@ export const EuiDataGridSelectors = {
   /** The header cell's actions button, interactable on focus/hover. */
   HEADER_ACTIONS_BUTTON_SELECTOR: '.euiDataGridHeaderCell__button',
 
-  /** Label of an item inside the header actions menu (matched by `title`). */
-  ACTION_LABEL_SELECTOR: '.euiListGroupItem__label',
-
   FULL_SCREEN_BUTTON_TEST_SUBJ: 'dataGridFullScreenButton',
 
   /**

--- a/packages/test-helpers/src/components/datagrid/selectors.ts
+++ b/packages/test-helpers/src/components/datagrid/selectors.ts
@@ -8,7 +8,7 @@
 
 /**
  * Stable selectors for
- * {@link https://eui.elastic.co/docs/components/tables/data-grid/|EuiDataGrid}.
+ * {@link https://eui.elastic.co/docs/components/data-grid|EuiDataGrid}.
  * `*_SELECTOR` values are CSS; `*_TEST_SUBJ` values are `data-test-subj` names.
  */
 export const EuiDataGridSelectors = {

--- a/packages/test-helpers/src/components/datagrid/selectors.ts
+++ b/packages/test-helpers/src/components/datagrid/selectors.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/tables/data-grid/|EuiDataGrid}.
+ * `*_SELECTOR` values are CSS; `*_TEST_SUBJ` values are `data-test-subj` names.
+ */
+export const EuiDataGridSelectors = {
+  /** Root element (the `.euiDataGrid` div carrying the consumer's `data-test-subj`). */
+  ROOT_SELECTOR: '.euiDataGrid',
+
+  /** Root element only while fullscreen mode is active (state class set synchronously). */
+  FULL_SCREEN_ROOT_SELECTOR: '.euiDataGrid--fullScreen',
+
+  /** A rendered data row. Rows are virtualized — only a window is mounted. */
+  ROW_SELECTOR: '.euiDataGridRow',
+
+  /**
+   * A rendered data cell. Cells carry `data-gridcell-column-id` (stable column
+   * id, unaffected by column order) and `data-gridcell-row-index`. Header cells
+   * carry `data-gridcell-column-id` too, so cell queries must include this
+   * class to exclude them.
+   */
+  ROW_CELL_SELECTOR: '.euiDataGridRowCell',
+
+  /** A column header cell (also carries `data-gridcell-column-id`). */
+  HEADER_CELL_SELECTOR: '.euiDataGridHeaderCell',
+
+  /** The header cell's actions button, interactable on focus/hover. */
+  HEADER_ACTIONS_BUTTON_SELECTOR: '.euiDataGridHeaderCell__button',
+
+  /** Label of an item inside the header actions menu (matched by `title`). */
+  ACTION_LABEL_SELECTOR: '.euiListGroupItem__label',
+
+  FULL_SCREEN_BUTTON_TEST_SUBJ: 'dataGridFullScreenButton',
+
+  /**
+   * A column's header actions menu. It renders in a portal, but EUI names it
+   * per column id, which keeps lookups safe when several grids coexist.
+   */
+  headerActionsMenuFor: (columnId: string): string =>
+    `[data-test-subj="dataGridHeaderCellActionGroup-${columnId}"]`,
+
+  /** A rendered data cell addressed by column id and row index. */
+  cellFor: (columnId: string, rowIndex: number): string =>
+    `.euiDataGridRowCell[data-gridcell-column-id="${columnId}"][data-gridcell-row-index="${rowIndex}"]`,
+
+  /** All rendered data cells of a column. */
+  columnCellsFor: (columnId: string): string =>
+    `.euiDataGridRowCell[data-gridcell-column-id="${columnId}"]`,
+
+  /** A column's header cell. */
+  headerCellFor: (columnId: string): string =>
+    `.euiDataGridHeaderCell[data-gridcell-column-id="${columnId}"]`,
+};

--- a/packages/test-helpers/src/components/form/super_select/README.md
+++ b/packages/test-helpers/src/components/form/super_select/README.md
@@ -1,0 +1,25 @@
+# EuiSuperSelectObject
+
+Playwright Component Object for [EuiSuperSelect](https://eui.elastic.co/docs/components/forms/selection/super-select/).
+
+## Usage
+
+```ts
+import { EuiSuperSelectObject } from '@elastic/eui-test-helpers';
+
+const superSelect = new EuiSuperSelectObject(page, 'mySuperSelect');
+await superSelect.selectOptionByValue('warning');
+expect(await superSelect.getSelectedValue()).toBe('warning');
+```
+
+Set `data-test-subj` on the `<EuiSuperSelect>` — EUI spreads it onto the control `<button>` (`.euiSuperSelectControl`), which the component-type guard verifies.
+
+## API
+
+| Method | Description |
+|---|---|
+| `selectOptionByValue(value)` | Selects the option whose `value` matches. Works on any EuiSuperSelect without extra test hooks (EUI renders each option with `id={String(value)}`) and is the preferred method when the value is a stable code constant — it is immune to i18n and display changes. |
+| `selectOptionByLabel(label)` | Selects the option by its visible label. Use for dynamic, data-driven option content where the test cannot know the value. Note the dropdown shows `dropdownDisplay` when the consumer provides it, which can differ from the committed `inputDisplay` text. |
+| `getSelectedValue()` | The committed selection's `value`, read from the hidden form input EUI renders next to the control (the visible button text shows the label, not the value). |
+
+Both select methods open the dropdown if needed and wait for it to close after the click.

--- a/packages/test-helpers/src/components/form/super_select/selectors.ts
+++ b/packages/test-helpers/src/components/form/super_select/selectors.ts
@@ -30,8 +30,12 @@ export const EuiSuperSelectSelectors = {
    */
   LISTBOX_SELECTOR: '.euiSuperSelect__listbox[role="listbox"]',
 
-  /** The hidden form input holding the committed `value`. */
-  HIDDEN_INPUT_SELECTOR: 'input[type="hidden"]',
+  /**
+   * The hidden form input holding the committed `value` — a direct child of
+   * the popover wrapper, scoped as such so hidden inputs a consumer might
+   * render inside prepend/append content are never matched.
+   */
+  HIDDEN_INPUT_SELECTOR: ':scope > input[type="hidden"]',
 
   /**
    * An option addressed by its `value` — EUI renders every option with

--- a/packages/test-helpers/src/components/form/super_select/selectors.ts
+++ b/packages/test-helpers/src/components/form/super_select/selectors.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/forms/selection/super-select/|EuiSuperSelect}.
+ * `*_SELECTOR` values are CSS.
+ */
+export const EuiSuperSelectSelectors = {
+  /**
+   * Root element (the control `<button>` carrying the consumer's
+   * `data-test-subj` — EUI spreads rest props onto it).
+   */
+  ROOT_SELECTOR: '.euiSuperSelectControl',
+
+  /**
+   * The popover wrapper around the control. The hidden form input holding the
+   * committed value is a sibling of the button inside it.
+   */
+  WRAPPER_SELECTOR: '.euiSuperSelect',
+
+  /**
+   * The options listbox. It renders in a popover portal, but EUI keeps at most
+   * one super-select dropdown open at a time, so a page-level lookup is safe.
+   */
+  LISTBOX_SELECTOR: '.euiSuperSelect__listbox[role="listbox"]',
+
+  /** The hidden form input holding the committed `value`. */
+  HIDDEN_INPUT_SELECTOR: 'input[type="hidden"]',
+
+  /**
+   * An option addressed by its `value` — EUI renders every option with
+   * `id={String(value)}`.
+   */
+  optionByValue: (value: string): string => `[role="option"][id="${value}"]`,
+};

--- a/packages/test-helpers/src/components/toast/README.md
+++ b/packages/test-helpers/src/components/toast/README.md
@@ -1,0 +1,22 @@
+# EuiGlobalToastListObject
+
+Playwright Component Object for [EuiGlobalToastList](https://eui.elastic.co/docs/components/display/toast/).
+
+## Usage
+
+```ts
+import { EuiGlobalToastListObject } from '@elastic/eui-test-helpers';
+
+const toastList = new EuiGlobalToastListObject(page, 'globalToastList');
+await expect(toastList.toasts).toHaveCount(1);
+await toastList.closeAll();
+```
+
+Set `data-test-subj` on the `<EuiGlobalToastList>` (EUI spreads it onto the `.euiGlobalToastList` element, which the component-type guard verifies). Toasts rendered outside the list (inline `EuiToast`) are not covered.
+
+## API
+
+| Member | Description |
+|---|---|
+| `toasts` | `Locator` for the toasts currently in the list, keeping Playwright auto-retry for count and content assertions (e.g. `expect(toasts).toHaveCount(1)`, `expect(toasts).toContainText('Saved')`). |
+| `closeAll()` | Clicks every toast's close button and waits until none remain. No-op when the list is already empty, so it doubles as a "dismiss if present" teardown helper. Tolerates toasts auto-dismissing mid-iteration. |

--- a/packages/test-helpers/src/components/toast/selectors.ts
+++ b/packages/test-helpers/src/components/toast/selectors.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/display/toast/|EuiGlobalToastList}.
+ * `*_SELECTOR` values are CSS; `*_TEST_SUBJ` values are `data-test-subj` names.
+ */
+export const EuiGlobalToastListSelectors = {
+  /** Root element (the list carrying the consumer's `data-test-subj`). */
+  ROOT_SELECTOR: '.euiGlobalToastList',
+
+  /** A toast inside the list. */
+  TOAST_SELECTOR: '.euiToast',
+
+  CLOSE_BUTTON_TEST_SUBJ: 'toastCloseButton',
+};

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -8,3 +8,6 @@
 
 export { BaseObject, type ObjectScope } from './playwright/base_object';
 export { EuiComboBoxObject } from './playwright/components/combo_box/object';
+export { EuiDataGridObject } from './playwright/components/datagrid/object';
+export { EuiSuperSelectObject } from './playwright/components/form/super_select/object';
+export { EuiGlobalToastListObject } from './playwright/components/toast/object';

--- a/packages/test-helpers/src/playwright/components/datagrid/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/datagrid/object.spec.ts
@@ -9,6 +9,7 @@
 import { test, expect } from '@playwright/test';
 
 import { EuiDataGridObject } from './object';
+import { EuiDataGridSelectors } from '../../../components/datagrid/selectors';
 import { storyUrl } from '../../../storybook';
 
 /**
@@ -54,7 +55,7 @@ test.describe('EuiDataGridObject', () => {
 
     test('excludes the column header cell', async () => {
       const headerText = await dataGrid.locator
-        .locator('.euiDataGridHeaderCell[data-gridcell-column-id="name"]')
+        .locator(EuiDataGridSelectors.headerCellFor('name'))
         .innerText();
       const cellTexts = await dataGrid.cells('name').allInnerTexts();
       expect(cellTexts).not.toContain(headerText);
@@ -74,12 +75,16 @@ test.describe('EuiDataGridObject', () => {
   test.describe('fullscreen', () => {
     test('enters and exits fullscreen mode', async ({ page }) => {
       await dataGrid.openFullScreenMode();
-      await expect(page.locator('.euiDataGrid--fullScreen')).toBeVisible();
+      await expect(
+        page.locator(EuiDataGridSelectors.FULL_SCREEN_ROOT_SELECTOR)
+      ).toBeVisible();
       // The grid keeps its rows across the mode change.
       await expect(dataGrid.rows).toHaveCount(10);
 
       await dataGrid.closeFullScreenMode();
-      await expect(page.locator('.euiDataGrid--fullScreen')).toHaveCount(0);
+      await expect(
+        page.locator(EuiDataGridSelectors.FULL_SCREEN_ROOT_SELECTOR)
+      ).toHaveCount(0);
       await expect(dataGrid.rows).toHaveCount(10);
     });
   });

--- a/packages/test-helpers/src/playwright/components/datagrid/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/datagrid/object.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiDataGridObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+/**
+ * Validates `EuiDataGridObject` against the live component in EUI Storybook.
+ * The Playground story renders 3 columns (`name`, `email`, `account`) and
+ * 10 rows; `data-test-subj` is injected via Storybook's `args` URL parameter
+ * onto the `.euiDataGrid` element itself, matching the component-type guard.
+ */
+
+const TEST_SUBJ = 'testDataGrid';
+
+const PLAYGROUND_URL = storyUrl(
+  'tabular-content-euidatagrid--playground',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiDataGridObject', () => {
+  let dataGrid: EuiDataGridObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    dataGrid = new EuiDataGridObject(page, TEST_SUBJ);
+  });
+
+  test.describe('rows', () => {
+    test('counts the rendered rows', async () => {
+      await expect(dataGrid.rows).toHaveCount(10);
+    });
+  });
+
+  test.describe('cell', () => {
+    test('locates a cell by row index and column id', async () => {
+      await expect(dataGrid.cell(0, 'name')).toBeVisible();
+      await expect(dataGrid.cell(0, 'name')).not.toHaveText('');
+    });
+  });
+
+  test.describe('cells', () => {
+    test('locates every rendered cell of a column', async () => {
+      await expect(dataGrid.cells('name')).toHaveCount(10);
+    });
+
+    test('excludes the column header cell', async () => {
+      const headerText = await dataGrid.locator
+        .locator('.euiDataGridHeaderCell[data-gridcell-column-id="name"]')
+        .innerText();
+      const cellTexts = await dataGrid.cells('name').allInnerTexts();
+      expect(cellTexts).not.toContain(headerText);
+    });
+  });
+
+  test.describe('doActionOnColumn', () => {
+    test('hides a column via its header actions', async () => {
+      await expect(dataGrid.cells('email')).toHaveCount(10);
+
+      await dataGrid.doActionOnColumn('email', 'Hide column');
+
+      await expect(dataGrid.cells('email')).toHaveCount(0);
+    });
+  });
+
+  test.describe('fullscreen', () => {
+    test('enters and exits fullscreen mode', async ({ page }) => {
+      await dataGrid.openFullScreenMode();
+      await expect(page.locator('.euiDataGrid--fullScreen')).toBeVisible();
+      // The grid keeps its rows across the mode change.
+      await expect(dataGrid.rows).toHaveCount(10);
+
+      await dataGrid.closeFullScreenMode();
+      await expect(page.locator('.euiDataGrid--fullScreen')).toHaveCount(0);
+      await expect(dataGrid.rows).toHaveCount(10);
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/datagrid/object.ts
+++ b/packages/test-helpers/src/playwright/components/datagrid/object.ts
@@ -13,7 +13,7 @@ import { EuiDataGridSelectors } from '../../../components/datagrid/selectors';
 
 /**
  * Playwright Component Object for {@link
- * https://eui.elastic.co/docs/components/tables/data-grid/ EuiDataGrid}.
+ * https://eui.elastic.co/docs/components/data-grid EuiDataGrid}.
  *
  * `testSubj` must match the `data-test-subj` set by the consumer on the
  * `EuiDataGrid` itself (the component-type guard enforces it) — EUI toggles

--- a/packages/test-helpers/src/playwright/components/datagrid/object.ts
+++ b/packages/test-helpers/src/playwright/components/datagrid/object.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiDataGridSelectors } from '../../../components/datagrid/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/tables/data-grid/ EuiDataGrid}.
+ *
+ * `testSubj` must match the `data-test-subj` set by the consumer on the
+ * `EuiDataGrid` itself (the component-type guard enforces it) — EUI toggles
+ * state classes (fullscreen) on that element. When the subj is not unique on
+ * the page (e.g. portal-rendered duplicates), narrow with the `scope`
+ * parameter instead of pointing the subj at a wrapper.
+ */
+export class EuiDataGridObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiDataGridSelectors.ROOT_SELECTOR);
+  }
+
+  /**
+   * The rows currently mounted in the DOM, as a `Locator` so callers keep
+   * Playwright auto-retry for count and content assertions
+   * (e.g. `expect(rows).toHaveCount(pageSize)`, `expect(rows).not.toHaveCount(0)`).
+   * For a paginated grid this is the current page's rows. Rows are virtualized,
+   * so on a grid too tall for its container this is only the visible window —
+   * never treat it as the full data set.
+   */
+  public get rows(): Locator {
+    return this.root.locator(EuiDataGridSelectors.ROW_SELECTOR);
+  }
+
+  /**
+   * A single data cell, addressed by row index and column id. Column order and
+   * virtualized horizontal scrolling do not affect the column id.
+   */
+  cell(rowIndex: number, columnId: string): Locator {
+    return this.root.locator(EuiDataGridSelectors.cellFor(columnId, rowIndex));
+  }
+
+  /**
+   * All currently rendered data cells of a column. Rows are virtualized, so
+   * this is the rendered window, not necessarily every row.
+   */
+  cells(columnId: string): Locator {
+    return this.root.locator(EuiDataGridSelectors.columnCellsFor(columnId));
+  }
+
+  /**
+   * Opens the header actions of a column and clicks the given action.
+   * `columnId` is the grid column id (matched verbatim), `actionLabel` is the
+   * visible action label (e.g. 'Hide column', 'Sort A-Z').
+   */
+  async doActionOnColumn(columnId: string, actionLabel: string): Promise<void> {
+    const headerCell = this.root.locator(
+      EuiDataGridSelectors.headerCellFor(columnId)
+    );
+    // The actions button only becomes interactable when the header cell is
+    // focused/hovered and inside the viewport.
+    await headerCell.scrollIntoViewIfNeeded();
+    await headerCell.focus();
+    await headerCell.hover();
+    await headerCell
+      .locator(EuiDataGridSelectors.HEADER_ACTIONS_BUTTON_SELECTOR)
+      .click();
+
+    const actionsMenu = this.root
+      .page()
+      .locator(EuiDataGridSelectors.headerActionsMenuFor(columnId));
+    await actionsMenu.waitFor({ state: 'visible' });
+    await actionsMenu
+      .locator(`${EuiDataGridSelectors.ACTION_LABEL_SELECTOR}[title="${actionLabel}"]`)
+      .click();
+    await actionsMenu.waitFor({ state: 'hidden' });
+  }
+
+  /** Enters fullscreen mode via the toolbar button. */
+  async openFullScreenMode(): Promise<void> {
+    await this.clickFullScreenButton();
+    await this.fullScreenGrid.waitFor({ state: 'visible' });
+  }
+
+  /** Exits fullscreen mode via the toolbar button. */
+  async closeFullScreenMode(): Promise<void> {
+    await this.clickFullScreenButton();
+    await this.fullScreenGrid.waitFor({ state: 'detached' });
+  }
+
+  /** The grid element only while it carries the fullscreen state class. */
+  private get fullScreenGrid(): Locator {
+    return this.root.and(
+      this.root.page().locator(EuiDataGridSelectors.FULL_SCREEN_ROOT_SELECTOR)
+    );
+  }
+
+  /**
+   * The fullscreen button sits in a tooltip wrapper and keeps focus after the
+   * click, which keeps the tooltip open over the grid — blur it right away.
+   */
+  private async clickFullScreenButton(): Promise<void> {
+    const button = this.root.getByTestId(
+      EuiDataGridSelectors.FULL_SCREEN_BUTTON_TEST_SUBJ
+    );
+    await button.click();
+    await button.blur();
+  }
+}

--- a/packages/test-helpers/src/playwright/components/datagrid/object.ts
+++ b/packages/test-helpers/src/playwright/components/datagrid/object.ts
@@ -76,7 +76,11 @@ export class EuiDataGridObject extends BaseObject {
       .page()
       .locator(EuiDataGridSelectors.headerActionsMenuFor(columnId));
     await actionsMenu.waitFor({ state: 'visible' });
-    await actionsMenu.getByTitle(actionLabel, { exact: true }).click();
+    // Role+name query auto-escapes the label and matches the accessible name
+    // (Kibana's lint also forbids getByTitle in favor of role queries).
+    await actionsMenu
+      .getByRole('button', { name: actionLabel, exact: true })
+      .click();
     await actionsMenu.waitFor({ state: 'hidden' });
   }
 

--- a/packages/test-helpers/src/playwright/components/datagrid/object.ts
+++ b/packages/test-helpers/src/playwright/components/datagrid/object.ts
@@ -76,9 +76,7 @@ export class EuiDataGridObject extends BaseObject {
       .page()
       .locator(EuiDataGridSelectors.headerActionsMenuFor(columnId));
     await actionsMenu.waitFor({ state: 'visible' });
-    await actionsMenu
-      .locator(`${EuiDataGridSelectors.ACTION_LABEL_SELECTOR}[title="${actionLabel}"]`)
-      .click();
+    await actionsMenu.getByTitle(actionLabel, { exact: true }).click();
     await actionsMenu.waitFor({ state: 'hidden' });
   }
 

--- a/packages/test-helpers/src/playwright/components/form/super_select/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/form/super_select/object.spec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiSuperSelectObject } from './object';
+import { storyUrl } from '../../../../storybook';
+
+/**
+ * Validates `EuiSuperSelectObject` against the live component in EUI
+ * Storybook. The Playground story is stateful with options `option-1..3`
+ * whose `dropdownDisplay` ("Option One") differs from `inputDisplay`
+ * ("Option 1") — exercising the label-vs-value distinction the object
+ * documents. `data-test-subj` is injected via Storybook's `args` URL
+ * parameter and lands on the control `<button>`.
+ */
+
+const TEST_SUBJ = 'testSuperSelect';
+
+const PLAYGROUND_URL = storyUrl(
+  'forms-euisuperselect--playground',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiSuperSelectObject', () => {
+  let superSelect: EuiSuperSelectObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    superSelect = new EuiSuperSelectObject(page, TEST_SUBJ);
+  });
+
+  test.describe('getSelectedValue', () => {
+    test('reads the initial committed value', async () => {
+      expect(await superSelect.getSelectedValue()).toBe('option-1');
+    });
+  });
+
+  test.describe('selectOptionByValue', () => {
+    test('selects an option and commits its value', async () => {
+      await superSelect.selectOptionByValue('option-2');
+
+      expect(await superSelect.getSelectedValue()).toBe('option-2');
+    });
+
+    test('is a no-op-safe re-selection of the current value', async () => {
+      await superSelect.selectOptionByValue('option-1');
+
+      expect(await superSelect.getSelectedValue()).toBe('option-1');
+    });
+  });
+
+  test.describe('selectOptionByLabel', () => {
+    test('selects an option by its visible dropdown label', async () => {
+      // The dropdown shows `dropdownDisplay` ("Option Two"), not the
+      // committed `inputDisplay` ("Option 2").
+      await superSelect.selectOptionByLabel('Option Two');
+
+      expect(await superSelect.getSelectedValue()).toBe('option-2');
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/form/super_select/object.ts
+++ b/packages/test-helpers/src/playwright/components/form/super_select/object.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../../base_object';
+import { EuiSuperSelectSelectors } from '../../../../components/form/super_select/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/forms/selection/super-select/ EuiSuperSelect}.
+ *
+ * `testSubj` must match the `data-test-subj` set by the consumer on the
+ * `<EuiSuperSelect>` — EUI spreads it onto the control `<button>`
+ * (`.euiSuperSelectControl`).
+ */
+export class EuiSuperSelectObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiSuperSelectSelectors.ROOT_SELECTOR);
+  }
+
+  /**
+   * Selects an option by its `value`. EUI renders every option with
+   * `id={String(value)}`, so this works for any EuiSuperSelect without extra
+   * test hooks and is the preferred method when the value is a stable code
+   * constant.
+   */
+  async selectOptionByValue(value: string): Promise<void> {
+    await this.open();
+    await this.listbox
+      .locator(EuiSuperSelectSelectors.optionByValue(value))
+      .click();
+    await this.listbox.waitFor({ state: 'detached' });
+  }
+
+  /**
+   * Selects an option by its visible label. Use for dynamic, data-driven
+   * option content where the value is not known to the test. Note the dropdown
+   * shows `dropdownDisplay` when the consumer provides it, which can differ
+   * from the committed `inputDisplay` text.
+   */
+  async selectOptionByLabel(label: string): Promise<void> {
+    await this.open();
+    await this.listbox.getByRole('option', { name: label }).click();
+    await this.listbox.waitFor({ state: 'detached' });
+  }
+
+  /**
+   * The committed selection's `value`, read from the hidden form input EUI
+   * renders next to the control (the visible button text shows the label, not
+   * the value).
+   */
+  async getSelectedValue(): Promise<string> {
+    return this.hiddenInput.inputValue();
+  }
+
+  /** Opens the dropdown if it is not already open. */
+  private async open(): Promise<void> {
+    if (await this.listbox.isVisible()) {
+      return;
+    }
+    await this.root.click();
+    await this.listbox.waitFor({ state: 'visible' });
+  }
+
+  private get listbox(): Locator {
+    return this.root.page().locator(EuiSuperSelectSelectors.LISTBOX_SELECTOR);
+  }
+
+  /**
+   * The hidden input is a sibling of the control button; reach it through the
+   * `.euiSuperSelect` popover wrapper that contains this instance's button.
+   */
+  private get hiddenInput(): Locator {
+    return this.scope
+      .locator(EuiSuperSelectSelectors.WRAPPER_SELECTOR)
+      .filter({ has: this.root })
+      .locator(EuiSuperSelectSelectors.HIDDEN_INPUT_SELECTOR);
+  }
+}

--- a/packages/test-helpers/src/playwright/components/toast/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/toast/object.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiGlobalToastListObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+/**
+ * Validates `EuiGlobalToastListObject` against the live component in EUI
+ * Storybook. The Playground story is stateful: it starts with one toast,
+ * wires `dismissToast`, and renders an "Add toast" button. `data-test-subj`
+ * is injected via Storybook's `args` URL parameter onto the list element.
+ */
+
+const TEST_SUBJ = 'testToastList';
+
+const PLAYGROUND_URL = storyUrl(
+  'display-euitoast-euiglobaltoastlist-euiglobaltoastlist--playground',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiGlobalToastListObject', () => {
+  let toastList: EuiGlobalToastListObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    toastList = new EuiGlobalToastListObject(page, TEST_SUBJ);
+  });
+
+  test.describe('toasts', () => {
+    test('locates the toasts in the list', async () => {
+      await expect(toastList.toasts).toHaveCount(1);
+      await expect(toastList.toasts).toContainText('Hello from Toast!');
+    });
+
+    test('tracks toasts as they are added', async ({ page }) => {
+      await page.getByRole('button', { name: 'Add toast' }).click();
+
+      await expect(toastList.toasts).toHaveCount(2);
+    });
+  });
+
+  test.describe('closeAll', () => {
+    test('closes every toast', async ({ page }) => {
+      await page.getByRole('button', { name: 'Add toast' }).click();
+      await expect(toastList.toasts).toHaveCount(2);
+
+      await toastList.closeAll();
+
+      await expect(toastList.toasts).toHaveCount(0);
+    });
+
+    test('is a no-op when the list is empty', async () => {
+      await toastList.closeAll();
+      await expect(toastList.toasts).toHaveCount(0);
+
+      await toastList.closeAll();
+
+      await expect(toastList.toasts).toHaveCount(0);
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/toast/object.ts
+++ b/packages/test-helpers/src/playwright/components/toast/object.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { expect, type Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiGlobalToastListSelectors } from '../../../components/toast/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/display/toast/ EuiGlobalToastList}.
+ *
+ * `testSubj` must match the `data-test-subj` set by the consumer on the
+ * `<EuiGlobalToastList>` (the `.euiGlobalToastList` element). Toasts rendered
+ * outside the list (inline `EuiToast`) are not covered.
+ */
+export class EuiGlobalToastListObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiGlobalToastListSelectors.ROOT_SELECTOR);
+  }
+
+  /**
+   * The toasts currently in the list. Exposed as a `Locator` so callers keep
+   * Playwright auto-retry for count and content assertions
+   * (e.g. `expect(toasts).toHaveCount(1)`).
+   */
+  public get toasts(): Locator {
+    return this.root.locator(EuiGlobalToastListSelectors.TOAST_SELECTOR);
+  }
+
+  /**
+   * Closes every toast in the list and waits until none remain. No-op when the
+   * list is empty (dismissing "if present" is a common teardown need).
+   */
+  async closeAll(): Promise<void> {
+    const closeButtons = await this.root
+      .getByTestId(EuiGlobalToastListSelectors.CLOSE_BUTTON_TEST_SUBJ)
+      .all();
+    for (const closeButton of closeButtons) {
+      // A toast may auto-dismiss while iterating; ignore clicks that miss.
+      await closeButton.click({ timeout: 5_000 }).catch(() => {});
+    }
+    await expect(this.toasts).toHaveCount(0);
+  }
+}

--- a/packages/test-helpers/src/selectors.ts
+++ b/packages/test-helpers/src/selectors.ts
@@ -7,3 +7,6 @@
  */
 
 export { EuiComboBoxSelectors } from './components/combo_box/selectors';
+export { EuiDataGridSelectors } from './components/datagrid/selectors';
+export { EuiSuperSelectSelectors } from './components/form/super_select/selectors';
+export { EuiGlobalToastListSelectors } from './components/toast/selectors';


### PR DESCRIPTION
## Summary

Adds three Playwright Component Objects to `@elastic/eui-test-helpers`, ported from Kibana's `kbn-scout` where they were prototyped against real consumer specs and validated end to end (locally plus two full Kibana CI builds): https://github.com/elastic/kibana/pull/282596. Kibana-side epic: https://github.com/elastic/apps-dx/issues/43 (port issue: https://github.com/elastic/apps-dx/issues/54).

| Object | Public surface |
|---|---|
| `EuiDataGridObject` | `rows` Locator, `cell()`, `cells()`, `doActionOnColumn()`, `openFullScreenMode()`/`closeFullScreenMode()` |
| `EuiSuperSelectObject` | `selectOptionByValue()`, `selectOptionByLabel()`, `getSelectedValue()` |
| `EuiGlobalToastListObject` | `toasts` Locator, `closeAll()` |

Each follows the package conventions: selectors in `src/components/<name>/selectors.ts` (re-exported from `src/selectors.ts`), object + validation specs under `src/playwright/components/<name>/`, a component README, and index exports. All 14 new validation specs pass against Storybook locally.

## Notes for review

- **Directory layout for `EuiSuperSelect`**: the helper lives at `form/super_select/` to mirror the EUI source layout. The flake-detection script only enumerates first-level helper directories, so the correlation fires through `form/` — coarse (any `form/*` change reruns these specs) but functional with zero script changes. A flat `super_select/` directory would never correlate with component changes. Happy to switch if you prefer a script change instead.
- **API shape**: the surface is deliberately minimal and demand-driven — every member is backed by a real Kibana consumer from a repo-wide call-site audit (details in the Kibana PR). Locator-returning members (`rows`, `toasts`, `cell`, `cells`) keep Playwright auto-retry with the consumer owning the assertion, per CONTRIBUTING.
- **`EuiDataGridObject` requires the subj on the grid itself** (component-type guard): EUI toggles state classes (fullscreen) on `.euiDataGrid`, so a wrapper subj cannot work; consumers narrow with the `scope` parameter when the subj is not page-unique.
- Storybook coverage for `EuiSuperSelect` and `EuiGlobalToastList` is thin (Playground only); the specs work within that. Props-variant specs can follow if/when stories are added.
- Changelog entry added under `changelogs/upcoming/`.

## Validation

- `tsc --noEmit` clean
- 14/14 new Playwright validation specs pass against local Storybook (plus the existing 34 combo_box specs still green)
- The same objects (identical code, kbn-scout import paths) passed the full Kibana Scout suite across all lanes in https://github.com/elastic/kibana/pull/282596, first-attempt failures audited
