### PR TITLE
[EuiFlyout] Keep body content reachable on short viewports

### DIFF
--- a/packages/eui/changelogs/upcoming/9888.md
+++ b/packages/eui/changelogs/upcoming/9888.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFlyoutBody` collapsing to zero height on short viewports, which put flyout body content out of reach at 400% browser zoom

--- a/packages/eui/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -43,6 +43,9 @@ exports[`EuiCollapsibleNav close button can be hidden 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
     </nav>
   </div>
   <div
@@ -100,6 +103,9 @@ exports[`EuiCollapsibleNav is rendered 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
     </nav>
   </div>
   <div
@@ -150,6 +156,9 @@ exports[`EuiCollapsibleNav props accepts EuiFlyout props 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
     </nav>
   </div>
   <div
@@ -208,6 +217,9 @@ exports[`EuiCollapsibleNav props button 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
     </nav>
   </div>
   <div
@@ -261,6 +273,9 @@ exports[`EuiCollapsibleNav props dockedBreakpoint 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
     </nav>
   </div>
   <div
@@ -285,7 +300,11 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
       id="id"
       style="inline-size: 320px; z-index: 1000;"
-    />
+    >
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
+    </nav>
   </div>
   <div
     data-focus-guard="true"
@@ -338,6 +357,9 @@ exports[`EuiCollapsibleNav props onClose 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
     </nav>
   </div>
   <div
@@ -367,7 +389,11 @@ exports[`EuiCollapsibleNav props showButtonIfDocked 1`] = `
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
       id="id"
       style="inline-size: 320px; z-index: 1000;"
-    />
+    >
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
+    </nav>
   </div>
   <div
     data-focus-guard="true"
@@ -420,6 +446,9 @@ exports[`EuiCollapsibleNav props size 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__scroll emotion-euiFlyout__scroll"
+      />
     </nav>
   </div>
   <div

--- a/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -47,6 +47,9 @@ exports[`EuiFlyout is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -104,6 +107,9 @@ exports[`EuiFlyout props accepts div props 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -160,6 +166,9 @@ exports[`EuiFlyout props closeButtonPosition can be outside 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -216,6 +225,9 @@ exports[`EuiFlyout props closeButtonProps 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -259,6 +271,9 @@ exports[`EuiFlyout props hideCloseButton 1`] = `
           You are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close.
            
         </p>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -316,6 +331,9 @@ exports[`EuiFlyout props is rendered as nav 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </nav>
     </div>
     <div
@@ -373,6 +391,9 @@ exports[`EuiFlyout props maxWidth can be set to a custom number 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -430,6 +451,9 @@ exports[`EuiFlyout props maxWidth can be set to a custom value and measurement 1
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -487,6 +511,9 @@ exports[`EuiFlyout props maxWidth can be set to a default 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -544,6 +571,9 @@ exports[`EuiFlyout props outsideClickCloses 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -601,6 +631,9 @@ exports[`EuiFlyout props ownFocus can alter mask props with maskProps without th
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -655,6 +688,9 @@ exports[`EuiFlyout props ownFocus can be false 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -712,6 +748,9 @@ exports[`EuiFlyout props paddingSize l is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -769,6 +808,9 @@ exports[`EuiFlyout props paddingSize m is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -826,6 +868,9 @@ exports[`EuiFlyout props paddingSize none is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -883,6 +928,9 @@ exports[`EuiFlyout props paddingSize s is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -913,6 +961,9 @@ exports[`EuiFlyout props push flyouts renders 1`] = `
       data-euiicon-type="cross"
     />
   </button>
+  <div
+    class="euiFlyout__scroll emotion-euiFlyout__scroll"
+  />
 </div>
 `;
 
@@ -961,6 +1012,9 @@ exports[`EuiFlyout props sides left is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -1017,6 +1071,9 @@ exports[`EuiFlyout props sides right is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -1074,6 +1131,9 @@ exports[`EuiFlyout props size accepts custom number 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -1131,6 +1191,9 @@ exports[`EuiFlyout props size fill is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -1188,6 +1251,9 @@ exports[`EuiFlyout props size l is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -1245,6 +1311,9 @@ exports[`EuiFlyout props size m is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -1302,6 +1371,9 @@ exports[`EuiFlyout props size s is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div
@@ -1366,6 +1438,9 @@ exports[`EuiFlyout renders extra screen reader instructions when fixed EuiHeader
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__scroll emotion-euiFlyout__scroll"
+        />
       </div>
     </div>
     <div

--- a/packages/eui/src/components/flyout/flyout.component.tsx
+++ b/packages/eui/src/components/flyout/flyout.component.tsx
@@ -1156,7 +1156,9 @@ export const EuiFlyoutComponent = forwardRef(
                 onKeyDown={onKeyDownResizableButton}
               />
             )}
-            <EuiFlyoutParentProvider>{children}</EuiFlyoutParentProvider>
+            <div className="euiFlyout__scroll" css={styles.euiFlyout__scroll}>
+              <EuiFlyoutParentProvider>{children}</EuiFlyoutParentProvider>
+            </div>
           </Element>
         </EuiFocusTrap>
       </EuiFlyoutOverlay>

--- a/packages/eui/src/components/flyout/flyout.spec.tsx
+++ b/packages/eui/src/components/flyout/flyout.spec.tsx
@@ -18,6 +18,7 @@ import { EuiCollapsibleNav, EuiCollapsibleNavGroup } from '../collapsible_nav';
 import { EuiFlexGroup } from '../flex';
 import { EuiFlyout } from './flyout';
 import { EuiFlyoutBody } from './flyout_body';
+import { EuiFlyoutFooter } from './flyout_footer';
 import { EuiFlyoutHeader } from './flyout_header';
 import { EuiGlobalToastList } from '../toast';
 import {
@@ -28,6 +29,7 @@ import {
 import { EuiIcon } from '../icon';
 import { EuiPanel } from '../panel';
 import { EuiPopover } from '../popover';
+import { EuiTab, EuiTabs } from '../tabs';
 import { EuiText } from '../text';
 import { EuiTitle } from '../title';
 import { useEuiTheme } from '../../services';
@@ -581,6 +583,83 @@ describe('EuiFlyout', () => {
       // 3. Tab from the popover trigger into the popover content.
       cy.realPress('Tab');
       cy.get('[data-test-subj="popover-confirm-action"]').should('be.focused');
+    });
+  });
+
+  describe('Short viewports', () => {
+    // The flyout is as tall as the viewport, so a header carrying a title and
+    // tabs plus a footer carrying actions and helper text can leave the body
+    // with no room at all. The body is the only part of the flyout that can
+    // shrink (it is a scroll container, so its automatic minimum size is zero),
+    // which used to collapse it to 0px and put its content out of reach.
+    // https://github.com/elastic/eui/issues/9881
+    const ShortViewportFlyout = () => (
+      <Flyout>
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m">
+            <h2>Rule details</h2>
+          </EuiTitle>
+          <EuiTabs>
+            <EuiTab isSelected>Definition</EuiTab>
+            <EuiTab>Actions</EuiTab>
+            <EuiTab>History</EuiTab>
+          </EuiTabs>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <EuiText>
+            <p>Index pattern</p>
+            <p>Query</p>
+            <p>Schedule</p>
+            <p>Severity</p>
+            <p>
+              <a href="#related" data-test-subj="lastBodyLink">
+                Related integrations
+              </a>
+            </p>
+          </EuiText>
+        </EuiFlyoutBody>
+        <EuiFlyoutFooter>
+          <EuiButton data-test-subj="footerAction">Save rule</EuiButton>
+          <EuiText size="s">
+            <p>Changes are applied on the next rule execution.</p>
+          </EuiText>
+        </EuiFlyoutFooter>
+      </Flyout>
+    );
+
+    it('keeps the body scrollable when the header and footer fill the viewport', () => {
+      cy.viewport(1280, 200);
+      cy.mount(<ShortViewportFlyout />);
+
+      cy.get('[data-test-subj="euiFlyoutBodyOverflow"]').then(([overflow]) => {
+        // This collapsed to exactly 0px before, so there was no scrollable
+        // region left and the content inside it could not be reached at all.
+        expect(overflow.clientHeight).to.be.greaterThan(0);
+        expect(overflow.scrollHeight).to.be.greaterThan(overflow.clientHeight);
+      });
+
+      cy.get('[data-test-subj="lastBodyLink"]').scrollIntoView();
+      cy.get('[data-test-subj="lastBodyLink"]').should('be.visible');
+    });
+
+    it('keeps the footer reachable when the header and footer fill the viewport', () => {
+      cy.viewport(1280, 200);
+      cy.mount(<ShortViewportFlyout />);
+
+      cy.get('[data-test-subj="footerAction"]').scrollIntoView();
+      cy.get('[data-test-subj="footerAction"]').should('be.visible');
+    });
+
+    it('leaves taller viewports laying out exactly as before', () => {
+      cy.viewport(1280, 800);
+      cy.mount(<ShortViewportFlyout />);
+
+      // Nothing overflows, so the flyout-level scroll never engages and the
+      // body still takes all the room the header and footer leave it.
+      cy.get('.euiFlyout__scroll').then(([wrapper]) => {
+        expect(wrapper.scrollHeight).to.eq(wrapper.clientHeight);
+      });
+      cy.get('[data-test-subj="footerAction"]').should('be.visible');
     });
   });
 });

--- a/packages/eui/src/components/flyout/flyout.styles.ts
+++ b/packages/eui/src/components/flyout/flyout.styles.ts
@@ -19,6 +19,7 @@ import {
   euiMaxBreakpoint,
   euiMinBreakpoint,
   logicalCSS,
+  logicalCSSWithFallback,
   logicalStyles,
   mathWithUnits,
 } from '../../global_styling';
@@ -100,6 +101,26 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       }
 
       ${maxedFlyoutWidth(euiThemeContext)}
+    `,
+
+    /**
+     * Scrolls the header, body and footer together once a short viewport
+     * (400% browser zoom, for example) leaves less room than they need.
+     *
+     * This sits on a wrapper around the flyout's children rather than on
+     * `.euiFlyout` itself. The flyout also owns the `closeButtonPosition="outside"`
+     * button, which is positioned beyond the flyout's own bounds, and turning the
+     * flyout into a scroll container clips that button away at every viewport
+     * height. The `clip-path` above exists to keep the same area paintable.
+     */
+    euiFlyout__scroll: css`
+      display: flex;
+      flex-direction: column;
+      flex-grow: 1;
+      /* Allow the wrapper itself to shrink below its content */
+      ${logicalCSS('min-height', 0)}
+      ${logicalCSSWithFallback('overflow-y', 'auto')}
+      ${logicalCSSWithFallback('overflow-x', 'hidden')}
     `,
 
     // Flyout sizes (media queries + % sizing)

--- a/packages/eui/src/components/flyout/flyout_body.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_body.styles.ts
@@ -20,7 +20,15 @@ export const euiFlyoutBodyStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     euiFlyoutBody: css`
       ${logicalCSSWithFallback('overflow-y', 'hidden')}
-      ${logicalCSS('height', '100%')}
+      flex-grow: 1;
+      /* Keep a floor under the body. Its automatic minimum size is zero (it is
+         a scroll container in the block axis), so without this a tall header
+         and footer shrink it to nothing on short viewports and its content
+         becomes unreachable. Below this height the flyout scrolls instead. */
+      ${logicalCSS('min-height', euiTheme.size.xxxxl)}
+      /* The below fixes scroll on Chrome and Safari */
+      display: flex;
+      flex-direction: column;
     `,
     overflow: {
       euiFlyoutBody__overflow: css``,


### PR DESCRIPTION
## Summary

Closes #9881.

`EuiFlyoutBody` can collapse to zero height when a flyout has a non-trivial header and footer. At 400% browser zoom the body's content is then invisible and unreachable, which fails [WCAG 2.2 SC 1.4.10 Reflow](https://www.w3.org/WAI/WCAG22/Understanding/reflow.html).

### Why the body is the part that disappears

`.euiFlyout` is a column flex container pinned to the viewport height. `.euiFlyoutBody` sets `overflow-y: hidden`, so its automatic minimum size resolves to `0` and it is free to shrink away to nothing. The header and footer set only `flex-grow: 0`, and their automatic minimum size is their content height, so they never yield. Every pixel of shrinkage therefore lands on the body, and `.euiFlyoutBody__overflow` (which is `block-size: 100%`) is left with nothing to scroll.

### Measurements

A header with a title and tabs (117px) plus a footer with actions and helper text (85px), varying the flyout height. "Usable body" is the body pixels actually visible to the user, not the box height.

| flyout height | before | after |
| --- | --- | --- |
| 900px | 698px | 698px |
| 320px | 118px | 118px |
| 266px | 64px | 64px |
| 222px | 20px | 64px |
| 180px | 0px, footer unreachable | 64px |

At 266px and above nothing changes. The new behavior engages only in the range that is broken today.

### Two approaches that look right and are not

I measured both before settling on this one, and those numbers are the reason they are not in the diff.

**Making the header and footer `position: sticky` changes nothing.** Giving the body a `min-block-size` floor does make the body box taller, but a pinned header and a pinned footer paint over the extra, so the gap the user can actually see stays `flyoutHeight - header - footer`. Measured usable body came out identical to today at every height: still 20px at 222px, still 0px at 180px.

**Putting `overflow-y: auto` on `.euiFlyout` breaks `closeButtonPosition="outside"`.** That button is a child of `.euiFlyout` positioned at `inset-inline-start: 0` with `transform: translateX(calc(-100% - 24px))`, so it sits entirely outside the flyout box. That is what the existing `clip-path: polygon(-50% 0, 100% 0, 100% 100%, -50% 100%)` is protecting. Any overflow value other than `visible` turns the flyout into a scroll container and clips the button away, at every viewport height rather than only short ones. `overflow-x: clip` is not an escape hatch either, since it computes to `hidden` once the other axis is `auto`.

That is why the scroll goes on an inner wrapper instead: the close button and the resize button stay outside it and keep working.

### The change

- `EuiFlyoutBody` swaps `block-size: 100%` for `flex-grow: 1` plus a `min-block-size` floor of `euiTheme.size.xxxxl`, and picks up the `display: flex; flex-direction: column` that `EuiModalBody` already uses for the same Chrome and Safari scroll reason.
- `EuiFlyout` renders its children inside a `.euiFlyout__scroll` wrapper that scrolls in the block axis. The close button and resize button are deliberately left outside that wrapper.

### Testing

Three cases added to `flyout.spec.tsx`. With the source change reverted, the first fails with `expected 0 to be above 0`, which is the reported bug reproduced in the component test harness.

- `flyout.spec.tsx`: 22 passing
- flyout jest suite: 452 passing, with 25 snapshots updated for the new wrapper element (plus 9 in `collapsible_nav`)
- `tsc --noEmit` and `lint-css-in-js` clean

### Open question

The floor is `euiTheme.size.xxxxl` (64px). That is a judgement call: a larger floor guarantees more body content but starts the flyout scrolling sooner. Happy to move it if you have a preference.
