### PR TITLE
[Chore] Check for v[0-9]* tag

### DIFF
--- a/.buildkite/scripts/deploy_docs/step_setup.sh
+++ b/.buildkite/scripts/deploy_docs/step_setup.sh
@@ -64,7 +64,7 @@ if is_pipeline_trigger_pull_request; then
   copy_to_root_directory=false
   echo "Detected a PR preview environment configuration. The built files will be copied to ${bucket_directory}"
 elif is_pipeline_trigger_tag; then
-  latest_release_tag_on_main=$(git describe --tags --abbrev=0 --match 'v[0-9]*' main)
+  latest_release_tag_on_main=$(git tag --list --merged main --sort=-version:refname | grep -E "^${release_tag_pattern}$" | head -1)
   bucket_directory="${BUILDKITE_TAG}/"
   copy_to_root_directory=false
   if [[ "${BUILDKITE_TAG}" == "${latest_release_tag_on_main}" ]]; then

--- a/.buildkite/scripts/deploy_docs/step_setup.sh
+++ b/.buildkite/scripts/deploy_docs/step_setup.sh
@@ -64,7 +64,7 @@ if is_pipeline_trigger_pull_request; then
   copy_to_root_directory=false
   echo "Detected a PR preview environment configuration. The built files will be copied to ${bucket_directory}"
 elif is_pipeline_trigger_tag; then
-  latest_release_tag_on_main=$(git describe --tags "$(git rev-list --branches=main --tags --max-count=1)")
+  latest_release_tag_on_main=$(git describe --tags --abbrev=0 --match 'v[0-9]*' main)
   bucket_directory="${BUILDKITE_TAG}/"
   copy_to_root_directory=false
   if [[ "${BUILDKITE_TAG}" == "${latest_release_tag_on_main}" ]]; then


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

https://eui.elastic.co/ is not updated to the latest released EUI version. The reason is `copy_root` is set to `false` because now commits can have several tags (= several GH releases) but `git describe --tags --max-count=1` will return e.g. `@elastic/eslint-plugin-eui@2.15.0`which doesn't match the `BUILDKITE_TAG`.

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

This is hard to test locally.

- Build `#4649` (v119.0.0): https://buildkite.com/elastic/eui-deploy-docs/builds/4649
- Build `#4453` (v118.0.0): https://buildkite.com/elastic/eui-deploy-docs/builds/4453

You can see that `copy_to_root_directory: false` and if you checkout the tags and run:

```bash
git describe --tags "$(git rev-list --branches=main --tags --max-count=1)"
```

it will return e.g. `@elastic/eslint-plugin-eui@2.15.0)`, not `v118.0.0`.

You can also check that:
```bash
git tag --list --merged main --sort=-version:refname | grep -E "^${release_tag_pattern}$" | head -1
```

returns the correct tag.