### PR TITLE
[eslint-plugin] update `button-group-no-invalid-children` rule to support segmented variant

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -377,10 +377,13 @@ When the render-prop child is not an `EuiToolTip`, `beforeMessage` simply config
 
 Enforce that `EuiButtonGroup` children (when using the Children API) are valid button components.
 
-Valid direct children are:
-- `variant="default"`: `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon`
+Valid direct children depend on the variant:
+- `variant="default"` (or no variant): `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon`
+- `variant="segmented"`: `EuiButton` and `EuiButtonIcon` only (`EuiButtonEmpty` is not allowed)
 
-Besides those button components, these three wrapper components are also allowed: `EuiPopover`, `EuiToolTip` and `EuiCopy`.
+In addition, these wrapper components are allowed for both variants: `EuiPopover`, `EuiToolTip`, and `EuiCopy`.
+
+For `variant="segmented"`, all children must also use the **same button type** — either all `EuiButton` or all `EuiButtonIcon`. Mixing both types is reported as an error, including when buttons appear inside `EuiToolTip`, as an `EuiPopover` trigger, or in an `EuiCopy` render prop.
 
 #### Examples
 
@@ -389,6 +392,18 @@ Besides those button components, these three wrapper components are also allowed
 <EuiButtonGroup legend="Actions">
   <div>Not a button</div>
   <EuiFlexGroup>...</EuiFlexGroup>
+</EuiButtonGroup>
+
+// ✗ Bad - variant="segmented" with EuiButtonEmpty (not allowed)
+<EuiButtonGroup legend="Actions" variant="segmented">
+  <EuiButton>Save</EuiButton>
+  <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
+</EuiButtonGroup>
+
+// ✗ Bad - variant="segmented" mixing EuiButton and EuiButtonIcon
+<EuiButtonGroup legend="Actions" variant="segmented">
+  <EuiButton>Save</EuiButton>
+  <EuiButtonIcon iconType="trash" aria-label="Delete" />
 </EuiButtonGroup>
 
 // ✓ Good - direct buttons
@@ -441,6 +456,18 @@ Besides those button components, these three wrapper components are also allowed
   >
     Panel content
   </EuiPopover>
+</EuiButtonGroup>
+
+// ✓ Good - variant="segmented" with all EuiButton
+<EuiButtonGroup legend="Actions" variant="segmented">
+  <EuiButton>Save</EuiButton>
+  <EuiButton color="danger">Delete</EuiButton>
+</EuiButtonGroup>
+
+// ✓ Good - variant="segmented" with all EuiButtonIcon
+<EuiButtonGroup legend="Actions" variant="segmented">
+  <EuiButtonIcon iconType="pencil" aria-label="Edit" />
+  <EuiButtonIcon iconType="trash" aria-label="Delete" />
 </EuiButtonGroup>
 ```
 

--- a/packages/eslint-plugin/changelogs/upcoming/9890.md
+++ b/packages/eslint-plugin/changelogs/upcoming/9890.md
@@ -1,1 +1,1 @@
-- updated `button-group-no-invalid-children` rule to support segmented variant checks ([#9849](https://github.com/elastic/eui/pull/9849))
+- updated `button-group-no-invalid-children` rule to support segmented variant checks

--- a/packages/eslint-plugin/changelogs/upcoming/9890.md
+++ b/packages/eslint-plugin/changelogs/upcoming/9890.md
@@ -1,1 +1,1 @@
-- updated `button-group-no-invalid-children` rule to support segmented variant checks
+- Updated `button-group-no-invalid-children` rule to support segmented variant checks

--- a/packages/eslint-plugin/changelogs/upcoming/9890.md
+++ b/packages/eslint-plugin/changelogs/upcoming/9890.md
@@ -1,0 +1,1 @@
+- updated `button-group-no-invalid-children` rule to support segmented variant checks ([#9849](https://github.com/elastic/eui/pull/9849))

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
@@ -1531,7 +1531,7 @@ ruleTester.run(
         languageOptions,
         errors: [
           {
-            messageId: 'invalidUnresolvableChild',
+            messageId: 'invalidChild',
             data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
           },
         ],
@@ -1580,7 +1580,7 @@ ruleTester.run(
         languageOptions,
         errors: [
           {
-            messageId: 'invalidUnresolvableChild',
+            messageId: 'invalidChild',
             data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
           },
         ],
@@ -1612,7 +1612,7 @@ ruleTester.run(
         languageOptions,
         errors: [
           {
-            messageId: 'invalidUnresolvableWrapperChild',
+            messageId: 'invalidWrapperChild',
             data: {
               name: 'EuiButtonEmpty',
               wrapper: 'EuiToolTip',
@@ -1654,7 +1654,7 @@ ruleTester.run(
         languageOptions,
         errors: [
           {
-            messageId: 'invalidUnresolvablePopoverButton',
+            messageId: 'invalidPopoverButton',
             data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
           },
         ],
@@ -1692,7 +1692,7 @@ ruleTester.run(
         languageOptions,
         errors: [
           {
-            messageId: 'invalidUnresolvablePopoverButton',
+            messageId: 'invalidPopoverButton',
             data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
           },
         ],
@@ -1709,7 +1709,7 @@ ruleTester.run(
         languageOptions,
         errors: [
           {
-            messageId: 'invalidUnresolvableWrapperChild',
+            messageId: 'invalidWrapperChild',
             data: {
               name: 'EuiButtonEmpty',
               wrapper: 'EuiCopy',
@@ -1750,6 +1750,49 @@ ruleTester.run(
             <EuiToolTip content="Delete">
               <EuiButtonIcon iconType="trash" aria-label="Delete" />
             </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+      },
+      {
+        name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiPopover trigger is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <EuiPopover button={<EuiButtonIcon iconType="menu" aria-label="More" />} isOpen={false} closePopover={() => {}}>
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+      },
+      {
+        name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiPopover with EuiToolTip-wrapped trigger is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <EuiPopover
+              button={<EuiToolTip content="More"><EuiButtonIcon iconType="menu" aria-label="More" /></EuiToolTip>}
+              isOpen={false}
+              closePopover={() => {}}
+            >
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+      },
+      {
+        name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiCopy render prop is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButtonIcon iconType="plus" aria-label="Add" />
+            <EuiCopy textToCopy="text">
+              {(copy) => <EuiButton onClick={copy}>Copy</EuiButton>}
+            </EuiCopy>
           </EuiButtonGroup>
         `,
         languageOptions,

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
@@ -8,7 +8,11 @@
 
 import dedent from 'dedent';
 import { RuleTester } from '@typescript-eslint/rule-tester';
-import { ButtonGroupNoInvalidChildren } from './button_group_no_invalid_children';
+import {
+  ButtonGroupNoInvalidChildren,
+  VALID_BUTTONS,
+  SEGMENTED_VALID_BUTTONS,
+} from './button_group_no_invalid_children';
 
 const languageOptions = {
   parserOptions: {
@@ -18,8 +22,8 @@ const languageOptions = {
   },
 };
 
-const DEFAULT_ALLOWED = 'EuiButton, EuiButtonEmpty, EuiButtonIcon';
-const SEGMENTED_ALLOWED = 'EuiButton, EuiButtonIcon';
+const DEFAULT_ALLOWED = Array.from(VALID_BUTTONS).join(', ');
+const SEGMENTED_ALLOWED = Array.from(SEGMENTED_VALID_BUTTONS).join(', ');
 
 const ruleTester = new RuleTester();
 

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
@@ -18,6 +18,9 @@ const languageOptions = {
   },
 };
 
+const DEFAULT_ALLOWED = 'EuiButton, EuiButtonEmpty, EuiButtonIcon';
+const SEGMENTED_ALLOWED = 'EuiButton, EuiButtonIcon';
+
 const ruleTester = new RuleTester();
 
 ruleTester.run(
@@ -476,10 +479,115 @@ ruleTester.run(
         languageOptions,
       },
       {
-        name: 'variant="segmented" is not yet validated — invalid children pass through',
+        name: 'variant="segmented" with EuiButton children is accepted',
         code: dedent`
           <EuiButtonGroup legend="Actions" variant="segmented">
-            <div>Not a button</div>
+            <EuiButton>Save</EuiButton>
+            <EuiButton>Cancel</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with EuiButtonIcon children is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButtonIcon iconType="trash" aria-label="Delete" />
+            <EuiButtonIcon iconType="pencil" aria-label="Edit" />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with EuiToolTip wrapping EuiButton is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <EuiToolTip content="Delete">
+              <EuiButton color="danger">Delete</EuiButton>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with EuiToolTip wrapping EuiButtonIcon is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiToolTip content="Delete">
+              <EuiButtonIcon iconType="trash" aria-label="Delete" />
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with EuiPopover wrapping EuiButton trigger is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <EuiPopover button={<EuiButton>More</EuiButton>} isOpen={false} closePopover={() => {}}>
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with EuiPopover wrapping EuiButtonIcon trigger is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiPopover button={<EuiButtonIcon iconType="menu" aria-label="More" />} isOpen={false} closePopover={() => {}}>
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with EuiPopover and EuiToolTip-wrapped trigger is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiPopover
+              button={<EuiToolTip content="More"><EuiButton>More</EuiButton></EuiToolTip>}
+              isOpen={false}
+              closePopover={() => {}}
+            >
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with EuiCopy wrapping EuiButton is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <EuiCopy textToCopy="text">
+              {(copy) => <EuiButton onClick={copy}>Copy</EuiButton>}
+            </EuiCopy>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with EuiButton children inside a fragment is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <>
+              <EuiButton>Save</EuiButton>
+              <EuiButton>Cancel</EuiButton>
+            </>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented" with spread props on child — cannot statically be determined',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton {...buttonProps} />
           </EuiButtonGroup>
         `,
         languageOptions,
@@ -623,7 +731,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidChild', data: { name: 'div' } }],
+        errors: [
+          {
+            messageId: 'invalidChild',
+            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'EuiFlexGroup child',
@@ -635,7 +748,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiFlexGroup' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiFlexGroup', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'multiple invalid children reported individually',
@@ -648,8 +766,14 @@ ruleTester.run(
         `,
         languageOptions,
         errors: [
-          { messageId: 'invalidChild', data: { name: 'span' } },
-          { messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } },
+          {
+            messageId: 'invalidChild',
+            data: { name: 'span', allowed: DEFAULT_ALLOWED },
+          },
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
         ],
       },
 
@@ -667,7 +791,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiCopy' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiCopy',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -684,7 +812,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiCopy' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiCopy',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -704,7 +836,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiCopy' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiCopy',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -721,7 +857,10 @@ ruleTester.run(
         `,
         languageOptions,
         errors: [
-          { messageId: 'invalidUnresolvablePopoverButton', data: { name: 'EuiText' } },
+          {
+            messageId: 'invalidUnresolvablePopoverButton',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
         ],
       },
       {
@@ -734,7 +873,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidPopoverButton', data: { name: 'div' } }],
+        errors: [
+          {
+            messageId: 'invalidPopoverButton',
+            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'EuiToolTip in EuiPopover button prop with invalid child',
@@ -751,7 +895,10 @@ ruleTester.run(
         `,
         languageOptions,
         errors: [
-          { messageId: 'invalidUnresolvablePopoverButton', data: { name: 'EuiText' } },
+          {
+            messageId: 'invalidUnresolvablePopoverButton',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
         ],
       },
       {
@@ -766,7 +913,10 @@ ruleTester.run(
         `,
         languageOptions,
         errors: [
-          { messageId: 'invalidUnresolvablePopoverButton', data: { name: 'EuiText' } },
+          {
+            messageId: 'invalidUnresolvablePopoverButton',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
         ],
       },
       {
@@ -784,7 +934,10 @@ ruleTester.run(
         `,
         languageOptions,
         errors: [
-          { messageId: 'invalidUnresolvablePopoverButton', data: { name: 'EuiText' } },
+          {
+            messageId: 'invalidUnresolvablePopoverButton',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
         ],
       },
 
@@ -804,7 +957,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiFlexGroup', wrapper: 'EuiToolTip' },
+            data: {
+              name: 'EuiFlexGroup',
+              wrapper: 'EuiToolTip',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -825,7 +982,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiToolTip' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiToolTip',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -843,7 +1004,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiToolTip' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiToolTip',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -860,7 +1025,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: '<Fragment> wrapping invalid element',
@@ -872,7 +1042,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidChild', data: { name: 'div' } }],
+        errors: [
+          {
+            messageId: 'invalidChild',
+            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: '<React.Fragment> wrapping invalid element',
@@ -884,7 +1059,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'fragment inside EuiToolTip wrapping invalid element',
@@ -901,7 +1081,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiToolTip' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiToolTip',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -916,7 +1100,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'ternary with one invalid branch',
@@ -926,7 +1115,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'ternary with both invalid branches reported separately',
@@ -937,8 +1131,14 @@ ruleTester.run(
         `,
         languageOptions,
         errors: [
-          { messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } },
-          { messageId: 'invalidUnresolvableChild', data: { name: 'EuiBadge' } },
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiBadge', allowed: DEFAULT_ALLOWED },
+          },
         ],
       },
 
@@ -950,7 +1150,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: '{unresolvable ?? <EuiText />} invalid right side is flagged',
@@ -960,7 +1165,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: '{resolvedInvalidButton || <EuiButton />} resolved invalid left side is flagged',
@@ -971,7 +1181,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
 
       // Unresolvable custom component
@@ -988,7 +1203,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'SaveButton', wrapper: 'EuiToolTip' },
+            data: {
+              name: 'SaveButton',
+              wrapper: 'EuiToolTip',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -1005,7 +1224,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'SaveButton', wrapper: 'EuiCopy' },
+            data: {
+              name: 'SaveButton',
+              wrapper: 'EuiCopy',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -1020,7 +1243,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'const variable holding an array with an invalid element is resolved and reported',
@@ -1034,7 +1262,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
 
       // Local arrow-function
@@ -1047,7 +1280,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'local block-body arrow-fn component with invalid return is resolved and reported at the invalid element',
@@ -1058,7 +1296,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'local block-body arrow-fn component with invalid branch is resolved and reported',
@@ -1072,7 +1315,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'imported custom component cannot be resolved — uses invalidUnresolvableChild message',
@@ -1085,7 +1333,7 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'SaveButton' },
+            data: { name: 'SaveButton', allowed: DEFAULT_ALLOWED },
           },
         ],
       },
@@ -1102,7 +1350,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'array containing a wrapper (EuiToolTip) with an invalid inner element',
@@ -1119,7 +1372,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiToolTip' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiToolTip',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -1133,7 +1390,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidChild', data: { name: 'div' } }],
+        errors: [
+          {
+            messageId: 'invalidChild',
+            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'map() with block-body returning invalid element is reported',
@@ -1145,7 +1407,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidChild', data: { name: 'div' } }],
+        errors: [
+          {
+            messageId: 'invalidChild',
+            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'map() with block-body invalid branch is reported',
@@ -1158,7 +1425,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
       {
         name: 'variable holding map() result with invalid element is reported',
@@ -1169,7 +1441,12 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidChild', data: { name: 'div' } }],
+        errors: [
+          {
+            messageId: 'invalidChild',
+            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+          },
+        ],
       },
 
       // Spread on wrapper
@@ -1186,7 +1463,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiToolTip' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiToolTip',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -1203,7 +1484,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableWrapperChild',
-            data: { name: 'EuiText', wrapper: 'EuiCopy' },
+            data: {
+              name: 'EuiText',
+              wrapper: 'EuiCopy',
+              allowed: DEFAULT_ALLOWED,
+            },
           },
         ],
       },
@@ -1223,7 +1508,248 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidUnresolvableChild', data: { name: 'EuiText' } }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+          },
+        ],
+      },
+
+      // variant="segmented"
+      {
+        name: 'variant="segmented" with unsupported button component is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with plain HTML child is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <div>Not a button</div>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidChild',
+            data: { name: 'div', allowed: SEGMENTED_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with unsupported component is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <EuiText>Not allowed</EuiText>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: SEGMENTED_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with unsupported component inside a fragment is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <>
+              <EuiButton>Save</EuiButton>
+              <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
+            </>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with unresolvable custom component is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <SaveButton />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'SaveButton', allowed: SEGMENTED_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with unsupported component inside EuiToolTip is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiToolTip content="Cancel">
+              <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableWrapperChild',
+            data: {
+              name: 'EuiButtonEmpty',
+              wrapper: 'EuiToolTip',
+              allowed: SEGMENTED_ALLOWED,
+            },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with unresolvable custom component inside EuiToolTip is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiToolTip content="tip">
+              <SaveButton />
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableWrapperChild',
+            data: {
+              name: 'SaveButton',
+              wrapper: 'EuiToolTip',
+              allowed: SEGMENTED_ALLOWED,
+            },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with EuiPopover using an unsupported component as trigger is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiPopover button={<EuiButtonEmpty color="text">More</EuiButtonEmpty>} isOpen={false} closePopover={() => {}}>
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvablePopoverButton',
+            data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with EuiPopover using invalid HTML element as trigger is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiPopover button={<div>Not a button</div>} isOpen={false} closePopover={() => {}}>
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidPopoverButton',
+            data: { name: 'div', allowed: SEGMENTED_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with EuiPopover and EuiToolTip wrapping an unsupported component as trigger is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiPopover
+              button={<EuiToolTip content="More"><EuiButtonEmpty>More</EuiButtonEmpty></EuiToolTip>}
+              isOpen={false}
+              closePopover={() => {}}
+            >
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvablePopoverButton',
+            data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with EuiCopy wrapping an unsupported component is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiCopy textToCopy="text">
+              {(copy) => <EuiButtonEmpty onClick={copy}>Copy</EuiButtonEmpty>}
+            </EuiCopy>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableWrapperChild',
+            data: {
+              name: 'EuiButtonEmpty',
+              wrapper: 'EuiCopy',
+              allowed: SEGMENTED_ALLOWED,
+            },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" mixing EuiButton and EuiButtonIcon children is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <EuiButtonIcon iconType="trash" aria-label="Delete" />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+      },
+      {
+        name: 'variant="segmented" mixing EuiButton and EuiButtonIcon inside a fragment is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <>
+              <EuiButton>Save</EuiButton>
+              <EuiButtonIcon iconType="trash" aria-label="Delete" />
+            </>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+      },
+      {
+        name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiToolTip is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <EuiToolTip content="Delete">
+              <EuiButtonIcon iconType="trash" aria-label="Delete" />
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
       },
     ],
   }

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
@@ -19,9 +19,9 @@ import { findAttrValue } from '../utils/get_attr_value';
 
 const BUTTON_GROUP = 'EuiButtonGroup';
 const VALID_BUTTONS = new Set(['EuiButton', 'EuiButtonEmpty', 'EuiButtonIcon']);
+const SEGMENTED_VALID_BUTTONS = new Set(['EuiButton', 'EuiButtonIcon']);
 const VALID_WRAPPERS = new Set(['EuiToolTip', 'EuiPopover', 'EuiCopy']);
 
-const VALID_BUTTONS_LIST = Array.from(VALID_BUTTONS).join(', ');
 const VALID_WRAPPERS_LIST = Array.from(VALID_WRAPPERS).join(', ');
 
 function isCustomComponent(name: string): boolean {
@@ -47,21 +47,27 @@ function collectJsxChildren(
 
 function reportInvalidWrapperChildren<
   TContext extends TSESLint.RuleContext<string, unknown[]>,
->(wrapper: TSESTree.JSXElement, wrapperName: string, context: TContext): void {
+>(
+  wrapper: TSESTree.JSXElement,
+  wrapperName: string,
+  context: TContext,
+  validButtons: Set<string>,
+  allowed: string
+): void {
   const children = flatMap(wrapper.children, (c) =>
     collectJsxChildren(c, context.sourceCode)
   );
   for (const wrapperChild of children) {
     if (hasSpread(wrapperChild.openingElement.attributes)) continue;
     const wrapperChildName = getElementName(wrapperChild.openingElement);
-    if (wrapperChildName === null || VALID_BUTTONS.has(wrapperChildName))
+    if (wrapperChildName === null || validButtons.has(wrapperChildName))
       continue;
     context.report({
       node: wrapperChild.openingElement,
       messageId: isCustomComponent(wrapperChildName)
         ? 'invalidUnresolvableWrapperChild'
         : 'invalidWrapperChild',
-      data: { name: wrapperChildName, wrapper: wrapperName },
+      data: { name: wrapperChildName, wrapper: wrapperName, allowed },
     });
   }
 }
@@ -80,15 +86,25 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
             return;
           }
 
-          // Only validate when the variant is "default" (or absent — the default).
-          // Rules for "segmented" and "selection" are added in later chunks.
+          // Validate "default" and "segmented" variants.
           // Dynamic variant values (variables) are conservatively skipped.
           const variant = findAttrValue(
             context,
             openingElement.attributes,
             'variant'
           );
-          if (variant !== undefined && variant !== 'default') return;
+          if (
+            variant !== undefined &&
+            variant !== 'default' &&
+            variant !== 'segmented'
+          )
+            return;
+
+          const isSegmented = variant === 'segmented';
+          const validButtons = isSegmented
+            ? SEGMENTED_VALID_BUTTONS
+            : VALID_BUTTONS;
+          const allowed = Array.from(validButtons).join(', ');
 
           const children = flatMap(node.children, (c) =>
             collectJsxChildren(c, context.sourceCode)
@@ -99,12 +115,18 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
             const name = getElementName(child.openingElement);
             if (name === null) continue;
 
-            if (VALID_BUTTONS.has(name)) continue;
+            if (validButtons.has(name)) continue;
 
             if (VALID_WRAPPERS.has(name)) {
               if (name === 'EuiToolTip') {
                 // Validate JSX children (expanding fragments/conditionals).
-                reportInvalidWrapperChildren(child, name, context);
+                reportInvalidWrapperChildren(
+                  child,
+                  name,
+                  context,
+                  validButtons,
+                  allowed
+                );
               } else if (name === 'EuiPopover') {
                 // The trigger is the `button` prop, not JSX children (panel
                 // content). The prop value may be a JSXExpressionContainer or
@@ -133,7 +155,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
 
                     if (
                       triggerElementName === null ||
-                      VALID_BUTTONS.has(triggerElementName)
+                      validButtons.has(triggerElementName)
                     )
                       continue;
 
@@ -154,7 +176,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
 
                         if (
                           tooltipChildName === null ||
-                          VALID_BUTTONS.has(tooltipChildName)
+                          validButtons.has(tooltipChildName)
                         )
                           continue;
 
@@ -163,7 +185,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                           messageId: isCustomComponent(tooltipChildName)
                             ? 'invalidUnresolvablePopoverButton'
                             : 'invalidPopoverButton',
-                          data: { name: tooltipChildName },
+                          data: { name: tooltipChildName, allowed },
                         });
                       }
                       continue;
@@ -173,7 +195,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                       messageId: isCustomComponent(triggerElementName)
                         ? 'invalidUnresolvablePopoverButton'
                         : 'invalidPopoverButton',
-                      data: { name: triggerElementName },
+                      data: { name: triggerElementName, allowed },
                     });
                   }
                 }
@@ -181,7 +203,13 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                 // Children is a render prop: {(copy) => <EuiButton />}
                 // ArrowFunctionExpression with expression body is expanded by
                 // collectJsxChildren, so validation works the same as EuiToolTip.
-                reportInvalidWrapperChildren(child, name, context);
+                reportInvalidWrapperChildren(
+                  child,
+                  name,
+                  context,
+                  validButtons,
+                  allowed
+                );
               }
               continue;
             }
@@ -195,8 +223,47 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
               messageId: isCustomComponent(name)
                 ? 'invalidUnresolvableChild'
                 : 'invalidChild',
-              data: { name },
+              data: { name, allowed },
             });
+          }
+
+          // For segmented, all children must be the same button type — either
+          // all EuiButton or all EuiButtonIcon. EuiToolTip children are
+          // inspected to determine the wrapped type. EuiPopover triggers and
+          // EuiCopy render props are not inspected (too indirect to resolve
+          // reliably), so mixing through those wrappers is not detected.
+          if (isSegmented) {
+            const seenButtonTypes = new Set<string>();
+
+            for (const child of children) {
+              const name = getElementName(child.openingElement);
+              if (name === 'EuiButton' || name === 'EuiButtonIcon') {
+                seenButtonTypes.add(name);
+              } else if (name === 'EuiToolTip') {
+                const tooltipInner = flatMap(child.children, (c) =>
+                  collectJsxChildren(c, context.sourceCode)
+                );
+                for (const inner of tooltipInner) {
+                  const innerName = getElementName(inner.openingElement);
+                  if (
+                    innerName === 'EuiButton' ||
+                    innerName === 'EuiButtonIcon'
+                  ) {
+                    seenButtonTypes.add(innerName);
+                  }
+                }
+              }
+            }
+
+            if (
+              seenButtonTypes.has('EuiButton') &&
+              seenButtonTypes.has('EuiButtonIcon')
+            ) {
+              context.report({
+                node: openingElement,
+                messageId: 'invalidSegmentedMixedTypes',
+              });
+            }
           }
         },
       };
@@ -204,18 +271,18 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
     meta: {
       type: 'problem',
       docs: {
-        description: `Enforce that EuiButtonGroup children are ${VALID_BUTTONS_LIST}, or a supported wrapper (${VALID_WRAPPERS_LIST})`,
+        description: `Enforce that EuiButtonGroup children are valid button components, or a supported wrapper (${VALID_WRAPPERS_LIST})`,
       },
       schema: [],
       messages: {
         invalidChild: [
           `{{ name }} is not a valid child of EuiButtonGroup.`,
-          `Allowed children: ${VALID_BUTTONS_LIST}.`,
+          `Allowed children: {{ allowed }}.`,
           `Allowed wrappers: ${VALID_WRAPPERS_LIST}.`,
         ].join(' '),
         invalidUnresolvableChild: [
           `{{ name }} cannot be verified as a valid child of EuiButtonGroup.`,
-          `Allowed children: ${VALID_BUTTONS_LIST}.`,
+          `Allowed children: {{ allowed }}.`,
           `Allowed wrappers: ${VALID_WRAPPERS_LIST}.`,
           `If {{ name }} is a shared button wrapper component only containing`,
           `valid button children, suppress this rule inline with a comment`,
@@ -224,11 +291,11 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
         ].join(' '),
         invalidPopoverButton: [
           `{{ name }} is not a valid trigger button for EuiPopover in EuiButtonGroup.`,
-          `The \`button\` prop must be ${VALID_BUTTONS_LIST}.`,
+          `The \`button\` prop must be {{ allowed }}.`,
         ].join(' '),
         invalidUnresolvablePopoverButton: [
           `{{ name }} cannot be verified as a valid trigger button for EuiPopover in EuiButtonGroup.`,
-          `The \`button\` prop must be ${VALID_BUTTONS_LIST}.`,
+          `The \`button\` prop must be {{ allowed }}.`,
           `If {{ name }} is a shared button wrapper component only containing`,
           `valid button children, suppress this rule inline with a comment`,
           `explaining why it's valid.`,
@@ -236,14 +303,18 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
         ].join(' '),
         invalidWrapperChild: [
           `{{ name }} inside {{ wrapper }} is not a valid button for EuiButtonGroup.`,
-          `The wrapper must contain ${VALID_BUTTONS_LIST}.`,
+          `The wrapper must contain {{ allowed }}.`,
         ].join(' '),
         invalidUnresolvableWrapperChild: [
           `{{ name }} inside {{ wrapper }} cannot be verified as a valid button for EuiButtonGroup.`,
-          `The wrapper must contain ${VALID_BUTTONS_LIST}.`,
+          `The wrapper must contain {{ allowed }}.`,
           `If {{ name }} is a shared button wrapper component, suppress this rule inline`,
           `with a comment explaining why it renders valid button children:`,
           `// eslint-disable-next-line @elastic/eui/button-group-no-invalid-children -- SaveButton wraps EuiButton`,
+        ].join(' '),
+        invalidSegmentedMixedTypes: [
+          `EuiButtonGroup with variant="segmented" must use a single button type throughout.`,
+          `Use either all EuiButton or all EuiButtonIcon children — not both.`,
         ].join(' '),
       },
     },

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
@@ -18,8 +18,12 @@ import { walkJsxChildren } from '../utils/walk_jsx_children';
 import { findAttrValue } from '../utils/get_attr_value';
 
 const BUTTON_GROUP = 'EuiButtonGroup';
-const VALID_BUTTONS = new Set(['EuiButton', 'EuiButtonEmpty', 'EuiButtonIcon']);
-const SEGMENTED_VALID_BUTTONS = new Set(['EuiButton', 'EuiButtonIcon']);
+export const VALID_BUTTONS = new Set([
+  'EuiButton',
+  'EuiButtonEmpty',
+  'EuiButtonIcon',
+]);
+export const SEGMENTED_VALID_BUTTONS = new Set(['EuiButton', 'EuiButtonIcon']);
 const VALID_WRAPPERS = new Set(['EuiToolTip', 'EuiPopover', 'EuiCopy']);
 
 const VALID_WRAPPERS_LIST = Array.from(VALID_WRAPPERS).join(', ');

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
@@ -56,19 +56,26 @@ function reportInvalidWrapperChildren<
   wrapperName: string,
   context: TContext,
   validButtons: Set<string>,
-  allowed: string
+  allowed: string,
+  seenButtonTypes?: Set<string>
 ): void {
   const children = flatMap(wrapper.children, (c) =>
     collectJsxChildren(c, context.sourceCode)
   );
   for (const wrapperChild of children) {
     if (hasSpread(wrapperChild.openingElement.attributes)) continue;
+
     const wrapperChildName = getElementName(wrapperChild.openingElement);
-    if (wrapperChildName === null || validButtons.has(wrapperChildName))
+
+    if (wrapperChildName === null) continue;
+
+    if (validButtons.has(wrapperChildName)) {
+      seenButtonTypes?.add(wrapperChildName);
       continue;
+    }
     context.report({
       node: wrapperChild.openingElement,
-      messageId: isCustomComponent(wrapperChildName)
+      messageId: isCustomComponent(wrapperChildName) && !VALID_BUTTONS.has(wrapperChildName)
         ? 'invalidUnresolvableWrapperChild'
         : 'invalidWrapperChild',
       data: { name: wrapperChildName, wrapper: wrapperName, allowed },
@@ -115,21 +122,30 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
           );
           if (children.length === 0) return;
 
+          // Collect seen button types for the segmented mixed-type check.
+          // Populated during the main loop to avoid a second traversal.
+          const seenButtonTypes = isSegmented ? new Set<string>() : null;
+
           for (const child of children) {
             const name = getElementName(child.openingElement);
             if (name === null) continue;
 
-            if (validButtons.has(name)) continue;
+            if (validButtons.has(name)) {
+              seenButtonTypes?.add(name);
+              continue;
+            }
 
             if (VALID_WRAPPERS.has(name)) {
               if (name === 'EuiToolTip') {
                 // Validate JSX children (expanding fragments/conditionals).
+                // Also collects button types for the segmented mixed-type check.
                 reportInvalidWrapperChildren(
                   child,
                   name,
                   context,
                   validButtons,
-                  allowed
+                  allowed,
+                  seenButtonTypes ?? undefined
                 );
               } else if (name === 'EuiPopover') {
                 // The trigger is the `button` prop, not JSX children (panel
@@ -157,11 +173,12 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                       triggerElement.openingElement
                     );
 
-                    if (
-                      triggerElementName === null ||
-                      validButtons.has(triggerElementName)
-                    )
+                    if (triggerElementName === null) continue;
+
+                    if (validButtons.has(triggerElementName)) {
+                      seenButtonTypes?.add(triggerElementName);
                       continue;
+                    }
 
                     if (triggerElementName === 'EuiToolTip') {
                       // EuiToolTip wrapping the trigger — validate its children.
@@ -178,15 +195,16 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                           tooltipChild.openingElement
                         );
 
-                        if (
-                          tooltipChildName === null ||
-                          validButtons.has(tooltipChildName)
-                        )
+                        if (tooltipChildName === null) continue;
+
+                        if (validButtons.has(tooltipChildName)) {
+                          seenButtonTypes?.add(tooltipChildName);
                           continue;
+                        }
 
                         context.report({
                           node: tooltipChild.openingElement,
-                          messageId: isCustomComponent(tooltipChildName)
+                          messageId: isCustomComponent(tooltipChildName) && !VALID_BUTTONS.has(tooltipChildName)
                             ? 'invalidUnresolvablePopoverButton'
                             : 'invalidPopoverButton',
                           data: { name: tooltipChildName, allowed },
@@ -196,7 +214,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                     }
                     context.report({
                       node: triggerElement.openingElement,
-                      messageId: isCustomComponent(triggerElementName)
+                      messageId: isCustomComponent(triggerElementName) && !VALID_BUTTONS.has(triggerElementName)
                         ? 'invalidUnresolvablePopoverButton'
                         : 'invalidPopoverButton',
                       data: { name: triggerElementName, allowed },
@@ -207,12 +225,14 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                 // Children is a render prop: {(copy) => <EuiButton />}
                 // ArrowFunctionExpression with expression body is expanded by
                 // collectJsxChildren, so validation works the same as EuiToolTip.
+                // Also collects button types for the segmented mixed-type check.
                 reportInvalidWrapperChildren(
                   child,
                   name,
                   context,
                   validButtons,
-                  allowed
+                  allowed,
+                  seenButtonTypes ?? undefined
                 );
               }
               continue;
@@ -224,7 +244,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
 
             context.report({
               node: child.openingElement,
-              messageId: isCustomComponent(name)
+              messageId: isCustomComponent(name) && !VALID_BUTTONS.has(name)
                 ? 'invalidUnresolvableChild'
                 : 'invalidChild',
               data: { name, allowed },
@@ -232,42 +252,16 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
           }
 
           // For segmented, all children must be the same button type — either
-          // all EuiButton or all EuiButtonIcon. EuiToolTip children are
-          // inspected to determine the wrapped type. EuiPopover triggers and
-          // EuiCopy render props are not inspected (too indirect to resolve
-          // reliably), so mixing through those wrappers is not detected.
-          if (isSegmented) {
-            const seenButtonTypes = new Set<string>();
-
-            for (const child of children) {
-              const name = getElementName(child.openingElement);
-              if (name === 'EuiButton' || name === 'EuiButtonIcon') {
-                seenButtonTypes.add(name);
-              } else if (name === 'EuiToolTip') {
-                const tooltipInner = flatMap(child.children, (c) =>
-                  collectJsxChildren(c, context.sourceCode)
-                );
-                for (const inner of tooltipInner) {
-                  const innerName = getElementName(inner.openingElement);
-                  if (
-                    innerName === 'EuiButton' ||
-                    innerName === 'EuiButtonIcon'
-                  ) {
-                    seenButtonTypes.add(innerName);
-                  }
-                }
-              }
-            }
-
-            if (
-              seenButtonTypes.has('EuiButton') &&
-              seenButtonTypes.has('EuiButtonIcon')
-            ) {
-              context.report({
-                node: openingElement,
-                messageId: 'invalidSegmentedMixedTypes',
-              });
-            }
+          // all EuiButton or all EuiButtonIcon. Types are collected during the
+          // main loop above, including from EuiToolTip, EuiPopover, and EuiCopy.
+          if (
+            seenButtonTypes?.has('EuiButton') &&
+            seenButtonTypes.has('EuiButtonIcon')
+          ) {
+            context.report({
+              node: openingElement,
+              messageId: 'invalidSegmentedMixedTypes',
+            });
           }
         },
       };


### PR DESCRIPTION
## Summary

>[!note]
This PR is related to https://github.com/elastic/eui/pull/9862 which adds `variant="segmented"` to `EuiButtonGroup`.
This PR should be rebased after merging the implementation PR.

- **What:** Extends the existing `button-group-no-invalid-children` ESLint rule with validation for `variant="segmented"`.
- **Why:** Part of https://github.com/elastic/eui-private/issues/726. The segmented variant has stricter child requirements than the default variant and needs lint-time enforcement to match.
- **How:** Adds a `SEGMENTED_VALID_BUTTONS` set (`EuiButton`, `EuiButtonIcon` — `EuiButtonEmpty` is excluded) and a mixed-type check that reports an error when both `EuiButton` and `EuiButtonIcon` appear in the same segmented group.

**Examples**

✅ valid
```jsx
// EuiButton children only
<EuiButtonGroup legend="Actions" variant="segmented">
  <EuiButton>Save</EuiButton>
  <EuiButton>Cancel</EuiButton>
</EuiButtonGroup>

// EuiButtonIcon children only
<EuiButtonGroup legend="Actions" variant="segmented">
  <EuiButtonIcon iconType="pencil" />
  <EuiButtonIcon iconType="trash" />
</EuiButtonGroup>

// EuiToolTip wrapping a valid button
<EuiButtonGroup legend="Actions" variant="segmented">
  <EuiButton>Save</EuiButton>
  <EuiToolTip content="Delete permanently">
    <EuiButton color="danger">Delete</EuiButton>
  </EuiToolTip>
</EuiButtonGroup>

// EuiPopover with a valid trigger
<EuiButtonGroup legend="Actions" variant="segmented">
  <EuiButton>Save</EuiButton>
  <EuiPopover button={<EuiButton>More</EuiButton>} isOpen={false} closePopover={() => {}}>
    Panel content
  </EuiPopover>
</EuiButtonGroup>
```

❌ invalid
```jsx
// EuiButtonEmpty is not valid for segmented
<EuiButtonGroup legend="Actions" variant="segmented">
  <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
</EuiButtonGroup>

// mixing EuiButton and EuiButtonIcon is not allowed
<EuiButtonGroup legend="Actions" variant="segmented">
  <EuiButton>Save</EuiButton>
  <EuiButtonIcon iconType="trash" />
</EuiButtonGroup>

// invalid component inside EuiToolTip
<EuiButtonGroup legend="Actions" variant="segmented">
  <EuiToolTip content="Cancel">
    <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
  </EuiToolTip>
</EuiButtonGroup>

// invalid EuiPopover trigger for segmented
<EuiButtonGroup legend="Actions" variant="segmented">
  <EuiPopover button={<EuiButtonEmpty>More</EuiButtonEmpty>} isOpen={false} closePopover={() => {}}>
    Panel content
  </EuiPopover>
</EuiButtonGroup>
```

Additional information

What the rule validates for variant="segmented"

- Valid direct children: EuiButton, EuiButtonIcon (not EuiButtonEmpty - it has no background and is incompatible with the segmented visual design)
- Valid wrappers: same as variant="default" (EuiToolTip, EuiPopover, EuiCopy) but with the restricted button set applied inside each
- Mixed types: reports invalidSegmentedMixedTypes when both EuiButton and EuiButtonIcon are present in the same group. Children inside EuiToolTip are inspected for this check; EuiPopover triggers and EuiCopy render props are not (too indirect to resolve statically)

Error message changes

The allowed list in all error messages is now dynamic (interpolated via {{ allowed }}) so segmented errors list only EuiButton, EuiButtonIcon while default-variant errors continue to list EuiButton, EuiButtonEmpty, EuiButtonIcon.


API Changes

⚪ No API changes

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


<img width="897" height="183" alt="Screenshot 2026-08-11 at 15 27 48" src="https://github.com/user-attachments/assets/1788eec9-dee5-4b9a-8999-f15078f979b1" />

<img width="899" height="384" alt="Screenshot 2026-08-11 at 15 28 08" src="https://github.com/user-attachments/assets/c1af69d6-e4b5-4aa2-9f13-584be0af2523" />


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [ ] CI passes
- [ ] verify locally the rule applies and flags invalid usages
  - checkout the PR
  - run `yarn workspace @elastic/eslint-plugin-eui build` on root
  - run `yarn workspace @elastic/eui build:workspaces` on root
  - add testing code example (e.g. see above) and/or update `button_group_children.stories.tsx` and run eslint check with `yarn workspace @elastic/eui lint` on root

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
