### PR TITLE
[Chore] Deploy docs small fixes

### DIFF
--- a/.buildkite/pipelines/deploy_docs.yml
+++ b/.buildkite/pipelines/deploy_docs.yml
@@ -33,7 +33,10 @@ steps:
   
   - label: ":loudspeaker: Notify"
     key: "notify"
-    depends_on: "vrt"
+    depends_on:
+      - "build-website"
+      - "build-storybook"
+      - "vrt"
     allow_dependency_failure: true
     command: .buildkite/scripts/deploy_docs/step_notify.sh
 

--- a/.buildkite/scripts/deploy_docs/step_notify.sh
+++ b/.buildkite/scripts/deploy_docs/step_notify.sh
@@ -10,17 +10,17 @@ source .buildkite/scripts/common/utils.sh
 #                      Configuration                       #
 ############################################################
 
-bucket_directory="$(buildkite-agent meta-data get bucket_directory)"
-copy_to_root_directory="$(buildkite-agent meta-data get copy_to_root_directory)"
+bucket_directory="$(buildkite-agent meta-data get bucket_directory --default "")"
+copy_to_root_directory="$(buildkite-agent meta-data get copy_to_root_directory --default "")"
 # Default to "true" for non-PR builds where VRT never runs
 vrt_passed="$(buildkite-agent meta-data get vrt_passed --default true)"
 
-published_website_url="https://eui.elastic.co/${bucket_directory}"
-published_storybook_url="https://eui.elastic.co/${bucket_directory}storybook/"
+website_links="[Documentation website](https://eui.elastic.co/${bucket_directory})"
+storybook_links="[Storybook](https://eui.elastic.co/${bucket_directory}storybook/)"
 
 if [[ "${copy_to_root_directory}" == "true" ]]; then
-  published_website_url="https://eui.elastic.co/ (root) and https://eui.elastic.co/${bucket_directory}"
-  published_storybook_url="https://eui.elastic.co/storybook/ (root) and https://eui.elastic.co/${bucket_directory}storybook/"
+  website_links="[Documentation website (root)](https://eui.elastic.co/) and [${bucket_directory}](https://eui.elastic.co/${bucket_directory})"
+  storybook_links="[Storybook (root)](https://eui.elastic.co/storybook/) and [${bucket_directory}storybook](https://eui.elastic.co/${bucket_directory}storybook/)"
 fi
 
 ############################################################
@@ -58,11 +58,11 @@ fi
 
 # Buildkite annotation (visible in the build page)
 buildkite-agent annotate --style "${annotation_style}" --context "deployed" << ANNOTATION
-- :docusaurus: [Documentation website](${published_website_url})
-- :book: [Storybook](${published_storybook_url})
+- :docusaurus: ${website_links}
+- :book: ${storybook_links}
 ${vrt_annotation}
 ANNOTATION
 
 # GitHub PR comment (via the pr_comment meta-data convention)
-echo -e "* [Documentation website](${published_website_url})\n* [Storybook](${published_storybook_url})${vrt_pr_comment}" \
+echo -e "* ${website_links}\n* ${storybook_links}${vrt_pr_comment}" \
   | buildkite-agent meta-data set pr_comment:docs_deployment_link:head


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Two small fixes that I noticed when deploying v119.0.0 documentation website:
- "Notify" can run faster than `bucket_directory` is populated and fails with: _"buildkite-agent: fatal: failed to get meta-data: POST https://elastic.agent.buildkite.com/v3/jobs/019ff12e-2e0a-4878-85c7-525aa4f4fd95/data/get: 404 Not Found: No key "bucket_directory" found"_ ([build](https://buildkite.com/elastic/eui-deploy-docs/builds/4693#019ff12e-2e0a-4878-85c7-525aa4f4fd95)) because its only dependency is "Test visual regression" that is skipped when the build wasn't triggered by a pull request (but implicitly it also relies on the "Build and deploy website" and "Build and deploy Storybook",
- on latest tagged releases documentation website build is copied both under / and the version folder, e.g. /v119.0.0 but the Buildkite annotation renders incorrect Markdown:

<img width="1688" height="88" alt="Screenshot 2026-08-11 at 17 00 33" src="https://github.com/user-attachments/assets/1828a53d-44e5-4e50-a106-ac3b866df5a4" />

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

What this PR's run verifies:
- YAML doesn't have a syntax error,
- non-root Buildkite annotation still renders correctly,
- "Notify" step still passes.

What it cannot verify without merging to main/dispatching a non-PR build:
- "Notify" step doesn't fail with the ☝🏻 error,
- root Buildkite annotation now renders correctly.