### PR TITLE
[EuiLink] Quieter default: paragraph text, dotted underline, primary on hover

### DIFF
--- a/packages/eui/changelogs/upcoming/9904.md
+++ b/packages/eui/changelogs/upcoming/9904.md
@@ -1,0 +1,1 @@
+- Quieter default `EuiLink`: paragraph color with a dotted underline at rest, primary color on hover/focus; `color="primary"` and `color="text"` now share that interactive treatment

--- a/packages/eui/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
+++ b/packages/eui/src/components/breadcrumbs/__snapshots__/breadcrumbs.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`EuiBreadcrumbs is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-primary-euiBreadcrumb__content-page-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-euiBreadcrumb__content-page-isTruncated-isInteractive"
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
@@ -123,7 +123,7 @@ exports[`EuiBreadcrumbs is rendered with final item as link 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-primary-euiBreadcrumb__content-page-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-euiBreadcrumb__content-page-isTruncated-isInteractive"
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
@@ -232,7 +232,7 @@ exports[`EuiBreadcrumbs props max doesn't break when max exceeds the number of b
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-primary-euiBreadcrumb__content-page-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-euiBreadcrumb__content-page-isTruncated-isInteractive"
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
@@ -397,7 +397,7 @@ exports[`EuiBreadcrumbs props max renders all items with null 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-primary-euiBreadcrumb__content-page-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-euiBreadcrumb__content-page-isTruncated-isInteractive"
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
@@ -504,7 +504,7 @@ exports[`EuiBreadcrumbs props responsive is rendered 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-primary-euiBreadcrumb__content-page-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-euiBreadcrumb__content-page-isTruncated-isInteractive"
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"
@@ -612,7 +612,7 @@ exports[`EuiBreadcrumbs props responsive is rendered as false 1`] = `
       data-test-subj="euiBreadcrumb"
     >
       <a
-        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-primary-euiBreadcrumb__content-page-isTruncated-isInteractive"
+        class="euiLink euiBreadcrumb__content customClass emotion-euiLink-euiBreadcrumb__content-page-isTruncated-isInteractive"
         data-test-subj="breadcrumbsAnimals"
         href="#"
         rel="noreferrer"

--- a/packages/eui/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
+++ b/packages/eui/src/components/date_picker/super_date_picker/quick_select_popover/__snapshots__/quick_select_popover.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`EuiQuickSelectPanels customQuickSelectPanels should render custom panel
           class="euiFlexItem emotion-euiFlexItem-grow-1"
         >
           <button
-            class="euiLink emotion-euiLink-primary"
+            class="euiLink emotion-euiLink"
             data-test-subj="superDatePickerCommonlyUsed_Today"
             type="button"
           >
@@ -271,7 +271,7 @@ exports[`EuiQuickSelectPanels customQuickSelectPanels should render custom panel
           class="euiFlexItem emotion-euiFlexItem-grow-1"
         >
           <button
-            class="euiLink emotion-euiLink-primary"
+            class="euiLink emotion-euiLink"
             type="button"
           >
             Today
@@ -401,7 +401,7 @@ exports[`EuiQuickSelectPanels customQuickSelectPanels should render custom panel
       class="emotion-euiQuickSelectPanel__section"
     >
       <button
-        class="euiLink emotion-euiLink-primary"
+        class="euiLink emotion-euiLink"
         data-test-subj="customComponentSelectPanel"
         type="button"
       >

--- a/packages/eui/src/components/link/__snapshots__/link.test.tsx.snap
+++ b/packages/eui/src/components/link/__snapshots__/link.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`EuiLink accent is rendered 1`] = `
 
 exports[`EuiLink button respects the type property 1`] = `
 <button
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   type="submit"
 />
 `;
@@ -30,14 +30,14 @@ exports[`EuiLink ghost is rendered 1`] = `
 
 exports[`EuiLink if href is not specified, it renders a button of type=button 1`] = `
 <button
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   type="button"
 />
 `;
 
 exports[`EuiLink it is an external link 1`] = `
 <a
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   href="/baz/bing"
   rel="noreferrer"
 >
@@ -57,7 +57,7 @@ exports[`EuiLink it is an external link 1`] = `
 exports[`EuiLink it passes the default props through 1`] = `
 <button
   aria-label="aria-label"
-  class="euiLink testClass1 testClass2 emotion-euiLink-primary-euiTestCss"
+  class="euiLink testClass1 testClass2 emotion-euiLink-euiTestCss"
   data-test-subj="test subject string"
   type="button"
 />
@@ -65,7 +65,7 @@ exports[`EuiLink it passes the default props through 1`] = `
 
 exports[`EuiLink it supports both href and onClick 1`] = `
 <a
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   href="/imalink"
   rel="noreferrer"
 />
@@ -73,7 +73,7 @@ exports[`EuiLink it supports both href and onClick 1`] = `
 
 exports[`EuiLink primary is rendered 1`] = `
 <button
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   type="button"
 />
 `;
@@ -94,7 +94,7 @@ exports[`EuiLink success is rendered 1`] = `
 
 exports[`EuiLink supports children 1`] = `
 <a
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   href="#"
   rel="noreferrer"
 >
@@ -114,7 +114,7 @@ exports[`EuiLink supports disabled 1`] = `
 
 exports[`EuiLink supports href 1`] = `
 <a
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   href="/baz/bing"
   rel="noreferrer"
 />
@@ -122,7 +122,7 @@ exports[`EuiLink supports href 1`] = `
 
 exports[`EuiLink supports rel 1`] = `
 <a
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   href="hoi"
   rel="noreferrer stylesheet"
 />
@@ -130,7 +130,7 @@ exports[`EuiLink supports rel 1`] = `
 
 exports[`EuiLink supports target 1`] = `
 <a
-  class="euiLink emotion-euiLink-primary"
+  class="euiLink emotion-euiLink"
   href="#"
   rel="noopener noreferrer"
   target="_blank"
@@ -150,7 +150,7 @@ exports[`EuiLink supports target 1`] = `
 
 exports[`EuiLink text is rendered 1`] = `
 <button
-  class="euiLink emotion-euiLink-text"
+  class="euiLink emotion-euiLink"
   type="button"
 />
 `;

--- a/packages/eui/src/components/link/link.styles.ts
+++ b/packages/eui/src/components/link/link.styles.ts
@@ -22,6 +22,7 @@ export const euiLinkCSS = (euiThemeContext: UseEuiTheme) => {
     ${logicalTextAlignCSS('left')}
     color: ${euiTheme.colors.textParagraph};
     text-decoration: underline dotted;
+    text-decoration-thickness: from-font;
 
     &:hover,
     &:focus {

--- a/packages/eui/src/components/link/link.styles.ts
+++ b/packages/eui/src/components/link/link.styles.ts
@@ -21,21 +21,16 @@ export const euiLinkCSS = (euiThemeContext: UseEuiTheme) => {
     font-weight: ${euiTheme.font.weight.medium};
     ${logicalTextAlignCSS('left')}
     color: ${euiTheme.colors.textParagraph};
-    text-decoration: underline;
-    text-decoration-style: dotted;
+    text-decoration: underline dotted;
 
     &:hover,
     &:focus {
       color: ${euiTheme.colors.textPrimary};
-    }
-
-    &:hover {
-      text-decoration-style: solid;
+      text-decoration: underline solid;
     }
 
     &:focus {
       ${euiFocusRing(euiThemeContext, 'outset')}
-      text-decoration-style: solid;
       text-decoration-thickness: ${euiTheme.border.width.thick};
     }
   `;

--- a/packages/eui/src/components/link/link.styles.ts
+++ b/packages/eui/src/components/link/link.styles.ts
@@ -10,19 +10,32 @@ import { css } from '@emotion/react';
 import { UseEuiTheme } from '../../services';
 import { euiFocusRing, logicalTextAlignCSS } from '../../global_styling';
 
+/**
+ * Shared link chrome used by EuiLink and bare anchors in EuiText.
+ * Default interaction: paragraph color + dotted underline at rest;
+ * primary color on hover/focus.
+ */
 export const euiLinkCSS = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
   return `
     font-weight: ${euiTheme.font.weight.medium};
     ${logicalTextAlignCSS('left')}
+    color: ${euiTheme.colors.textParagraph};
+    text-decoration: underline;
+    text-decoration-style: dotted;
+
+    &:hover,
+    &:focus {
+      color: ${euiTheme.colors.textPrimary};
+    }
 
     &:hover {
-      text-decoration: underline;
+      text-decoration-style: solid;
     }
 
     &:focus {
       ${euiFocusRing(euiThemeContext, 'outset')}
-      text-decoration: underline;
+      text-decoration-style: solid;
       text-decoration-thickness: ${euiTheme.border.width.thick};
     }
   `;
@@ -41,6 +54,8 @@ export const euiLinkStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     disabled: css`
       font-weight: inherit;
+      color: inherit;
+      text-decoration: none;
 
       &:hover {
         cursor: auto;
@@ -49,24 +64,28 @@ export const euiLinkStyles = (euiThemeContext: UseEuiTheme) => {
       &:hover,
       &:focus,
       &:target {
+        color: inherit;
         text-decoration: none;
       }
     `,
-    // Color styles
-    primary: css(_colorCSS(euiTheme.colors.textPrimary)),
-    subdued: css(_colorCSS(euiTheme.colors.textSubdued)),
-    success: css(_colorCSS(euiTheme.colors.textSuccess)),
-    accent: css(_colorCSS(euiTheme.colors.textAccent)),
-    danger: css(_colorCSS(euiTheme.colors.textDanger)),
-    warning: css(_colorCSS(euiTheme.colors.textWarning)),
-    ghost: css(_colorCSS(euiTheme.colors.textGhost)),
-    text: css(_colorCSS(euiTheme.colors.textParagraph)),
+    // Color styles — `primary`/`text` use the interactive default from euiLinkCSS
+    subdued: css(_staticColorCSS(euiTheme.colors.textSubdued)),
+    success: css(_staticColorCSS(euiTheme.colors.textSuccess)),
+    accent: css(_staticColorCSS(euiTheme.colors.textAccent)),
+    danger: css(_staticColorCSS(euiTheme.colors.textDanger)),
+    warning: css(_staticColorCSS(euiTheme.colors.textWarning)),
+    ghost: css(_staticColorCSS(euiTheme.colors.textGhost)),
   };
 };
 
-const _colorCSS = (color: string) => {
+const _staticColorCSS = (color: string) => {
   return `
     color: ${color};
+
+    &:hover,
+    &:focus {
+      color: ${color};
+    }
 
     &:target {
       color: darken(${color}, 10%);

--- a/packages/eui/src/components/link/link.tsx
+++ b/packages/eui/src/components/link/link.tsx
@@ -39,7 +39,10 @@ export type EuiLinkColor = (typeof COLORS)[number];
 export interface LinkButtonProps {
   type?: EuiLinkType;
   /**
-   * Any of our named colors.
+   * Named color.
+   * `primary` and `text` share the default interactive treatment (paragraph color + dotted underline at rest; primary on hover/focus).
+   * Other values are static semantic colors.
+   * @default primary
    */
   color?: EuiLinkColor;
   onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -53,7 +56,10 @@ export interface EuiLinkButtonProps
 export interface LinkAnchorProps {
   type?: EuiLinkType;
   /**
-   * Any of our named colors.
+   * Named color.
+   * `primary` and `text` share the default interactive treatment (paragraph color + dotted underline at rest; primary on hover/focus).
+   * Other values are static semantic colors.
+   * @default primary
    */
   color?: EuiLinkColor;
   /**
@@ -97,6 +103,9 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
   ) => {
     const styles = useEuiMemoizedStyles(euiLinkStyles);
     const cssStyles = [styles.euiLink];
+    // `primary` and `text` share the interactive default baked into euiLinkCSS
+    const colorStyles =
+      color === 'primary' || color === 'text' ? undefined : styles[color];
 
     const isHrefValid = !href || validateHref(href);
     const disabled = _disabled || !isHrefValid;
@@ -104,7 +113,7 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
     if (href === undefined || !isHrefValid) {
       const buttonProps = {
         className: classNames('euiLink', className),
-        css: [cssStyles, disabled ? [styles.disabled] : styles[color]],
+        css: [cssStyles, disabled ? styles.disabled : colorStyles],
         type,
         onClick,
         disabled,
@@ -125,7 +134,7 @@ const EuiLink = forwardRef<HTMLAnchorElement | HTMLButtonElement, EuiLinkProps>(
 
     const anchorProps = {
       className: classNames('euiLink', className),
-      css: [cssStyles, styles[color]],
+      css: [cssStyles, colorStyles],
       href,
       target,
       rel: secureRel,

--- a/packages/eui/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
+++ b/packages/eui/src/components/page/page_header/__snapshots__/page_header.test.tsx.snap
@@ -242,7 +242,7 @@ exports[`EuiPageHeader props page content props are passed down is rendered 1`] 
           data-test-subj="euiBreadcrumb"
         >
           <a
-            class="euiLink euiBreadcrumb__content customClass emotion-euiLink-primary-euiBreadcrumb__content-page-isTruncated-isInteractive"
+            class="euiLink euiBreadcrumb__content customClass emotion-euiLink-euiBreadcrumb__content-page-isTruncated-isInteractive"
             data-test-subj="breadcrumbsAnimals"
             href="#"
             rel="noreferrer"

--- a/packages/eui/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
+++ b/packages/eui/src/components/page/page_header/__snapshots__/page_header_content.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`EuiPageHeaderContent props breadcrumbs is rendered 1`] = `
         data-test-subj="euiBreadcrumb"
       >
         <a
-          class="euiLink euiBreadcrumb__content customClass emotion-euiLink-primary-euiBreadcrumb__content-page-isTruncated-isInteractive"
+          class="euiLink euiBreadcrumb__content customClass emotion-euiLink-euiBreadcrumb__content-page-isTruncated-isInteractive"
           data-test-subj="breadcrumbsAnimals"
           href="#"
           rel="noreferrer"

--- a/packages/website/docs/components/navigation/link.mdx
+++ b/packages/website/docs/components/navigation/link.mdx
@@ -65,7 +65,9 @@ export default () => (
 
 ## Coloring links
 
-Like any other [button component](./buttons/button.mdx), links can be passed a `color`. Note that the `ghost` type should only be used on dark backgrounds (regardless of theming) as it will always create a white link.
+The default (`primary`, also accepted as `text`) uses paragraph-colored text with a dotted underline at rest, and shifts to primary blue on hover/focus — so links sit with body copy until interaction, and filled primary CTAs stay visually distinct.
+
+Other `color` values are static semantic paints. Note that `ghost` should only be used on dark backgrounds (regardless of theming) as it will always create a white link.
 
 ```tsx interactive
 import React from 'react';
@@ -91,6 +93,7 @@ export default () => (
             href="#/navigation/link"
           >
             {value.charAt(0).toUpperCase() + value.slice(1)}
+            {value === 'text' ? ' (alias of primary)' : ''}
           </EuiLink>
         </li>
       ))}


### PR DESCRIPTION
## Summary

Related to #9899 (visual refresh) — **EuiLink default interaction** slice. Delivers the global quieter-link treatment; optional transparent row backgrounds remain open on that issue. Sibling action-icon quieting: #9902.

- Default / `color="primary"` / `color="text"`: `textParagraph` + **dotted** underline at rest → **primary** on hover/focus (solid underline)
- `primary` and `text` now share that interactive treatment
- Other semantic colors (`subdued`, `danger`, etc.) stay static and override the hover→primary shift
- Shared `euiLinkCSS` (also used by bare anchors in `EuiText`) gets the same default chrome
- Docs updated to describe the new default + alias

## Test plan

- [ ] EuiLink Playground — default looks like body text with dotted underline; hover turns primary blue
- [ ] Color docs demo — `primary` and `text` look the same; semantic colors unchanged at rest/hover
- [ ] Links inside EuiText (component + bare `<a>`) match the quieter treatment
- [ ] Focus ring still visible; disabled links lose underline/color chrome
- [ ] Unit snapshots updated
- [ ] VRT for Navigation/EuiLink after Storybook deploys
- [x] Changelog `packages/eui/changelogs/upcoming/9904.md`


Made with [Cursor](https://cursor.com)