### PR TITLE
[test-helpers] Correlate flake detection by component path, including selectors

### DIFF
--- a/.buildkite/scripts/pipelines/pipeline_test_helpers_flaky.sh
+++ b/.buildkite/scripts/pipelines/pipeline_test_helpers_flaky.sh
@@ -32,23 +32,28 @@ fi
 changed_files="$(git diff --name-only "${base_sha}" HEAD)"
 
 # A shared file affects every helper, so run the whole suite. Otherwise a helper
-# is affected when this PR touched its component source or its own specs —
-# correlated by directory name: <helper>/<name> maps to
-# packages/eui/src/components/<name>.
+# is affected when this PR touched its component source, its own specs, or its
+# selectors — correlated by the helper's path relative to HELPERS_DIR (`<name>`,
+# which may be nested, e.g. `form/super_select`). That same `<name>` maps to the
+# EUI component source `packages/eui/src/components/<name>` and the selectors
+# `packages/test-helpers/src/components/<name>`. Helpers are enumerated by their
+# `object.ts` so nested helpers resolve to their real (leaf) directory rather
+# than an over-broad first-level parent.
 if grep -qE "${SHARED_REGEXP}" <<< "${changed_files}"; then
   echo "Shared test-helpers file changed — running all helper specs."
   affected="src/playwright/components"
 else
   affected=""
-  for helper_path in "${HELPERS_DIR}"/*/; do
-    [[ -d "${helper_path}" ]] || continue
-    name="$(basename "${helper_path}")"
-    helper_specs="${helper_path%/}"
-    if grep -qE "^(${COMPONENTS_DIR}/${name}|${helper_specs})/" <<< "${changed_files}"; then
+  while IFS= read -r object_file; do
+    helper_specs="$(dirname "${object_file}")"
+    name="${helper_specs#"${HELPERS_DIR}/"}"
+    component_src="${COMPONENTS_DIR}/${name}"
+    helper_selectors="packages/test-helpers/src/components/${name}"
+    if grep -qE "^(${component_src}|${helper_specs}|${helper_selectors})/" <<< "${changed_files}"; then
       # Playwright filters are resolved from the package dir, so strip the prefix.
       affected+="${helper_specs#packages/test-helpers/} "
     fi
-  done
+  done < <(find "${HELPERS_DIR}" -type f -name 'object.ts' | sort)
   affected="$(echo "${affected}" | xargs)"
 fi
 

--- a/packages/test-helpers/CONTRIBUTING.md
+++ b/packages/test-helpers/CONTRIBUTING.md
@@ -129,4 +129,4 @@ Repin Kibana to the official release before merging its PR — snapshots are mov
 
 These tests run in EUI's Buildkite CI on every PR, with flake detection when a component changes. See [Testing → EUI test helpers](../../wiki/contributing-to-eui/testing/eui-test-helpers.md) in the wiki.
 
-Flake detection correlates a component to its helper **by directory name**: a change under `packages/eui/src/components/<name>` re-runs the specs in `src/playwright/components/<name>`. Keep that directory parity when adding a Component Object and no extra wiring is needed.
+Flake detection correlates a component to its helper **by directory path**: a change under `packages/eui/src/components/<name>`, the helper's specs in `src/playwright/components/<name>`, or its selectors in `src/components/<name>` re-runs that helper's specs. `<name>` is the path relative to the components directory and may be nested (e.g. `form/super_select`), matching the EUI source layout. Keep that directory parity when adding a Component Object and no extra wiring is needed.

--- a/wiki/contributing-to-eui/testing/eui-test-helpers.md
+++ b/wiki/contributing-to-eui/testing/eui-test-helpers.md
@@ -25,4 +25,4 @@ See the package [CONTRIBUTING](../../../packages/test-helpers/CONTRIBUTING.md) f
 
 ### Component ↔ helper correlation
 
-The correlation is **by directory name**: a change under `packages/eui/src/components/<name>` (or the helper's own specs) re-runs `packages/test-helpers/src/playwright/components/<name>`. Keeping that directory parity is all that is required — there is no map to maintain.
+The correlation is by directory path, so keeping the helper's directory in parity with the EUI component's is all that is required. See [Flake detection in the package CONTRIBUTING guide](../../../packages/test-helpers/CONTRIBUTING.md#ci-integration) for the exact rule.


### PR DESCRIPTION
## Summary

Fix the `@elastic/eui-test-helpers` flake-detection correlation so it also covers a helper's **selectors** and resolves **nested** helpers precisely.

Closes https://github.com/elastic/apps-dx/issues/69.

## Problem

`.buildkite/scripts/pipelines/pipeline_test_helpers_flaky.sh` only re-ran a helper's specs when the PR touched the helper's EUI component source or its own spec dir, keyed on a **first-level** directory name. Two gaps:

1. **Selectors dir missed**: a helper's selectors live at `packages/test-helpers/src/components/<name>/selectors.ts`. Editing them matched neither the component source nor the spec dir, so a selectors change never triggered its own flake run.
2. **Nested helpers imprecise**: `form/super_select` was only seen as its first-level parent `form`, so it correlated with *any* `form/*` component change (over-broad) and its own nested path was never matched directly.

## Fix

Enumerate helpers by their `object.ts` so `<name>` is the real, possibly-nested path (`combo_box`, `datagrid`, `form/super_select`, `toast`). That same `<name>` maps to the EUI source `packages/eui/src/components/<name>`, the specs `src/playwright/components/<name>`, and the selectors `src/components/<name>`. A change to any of the three re-runs that helper's specs. Docs updated (`CONTRIBUTING.md`, wiki).

## Validation

Local simulation of the new correlation over the real directory tree:

| Change | Old | New |
|---|---|---|
| `eui/.../datagrid/*` | datagrid | datagrid |
| `test-helpers/src/components/datagrid/selectors.ts` | (missed) | **datagrid** |
| `eui/.../form/super_select/*` | via broad `form` | **form/super_select** |
| `test-helpers/src/components/form/super_select/selectors.ts` | (missed) | **form/super_select** |
| `eui/.../form/checkbox/*` | wrongly hit super_select via `form` | **(none)** |

The **last commit is temporary** (touches `form/super_select/selectors.ts`) purely so CI exercises the new path end to end — it should make the flake step run the super_select specs 25×, proving both the selectors correlation and nested resolution. **It will be dropped before merge.**
