### PR TITLE
[Chore] Document kibana-prep-commits in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -54,6 +54,10 @@ Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/
 - [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
 - [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.
 
+<!--
+If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL to `packages/release-cli/kibana-prep-commits` (one URL per line). The nightly Kibana integration run cherry-picks those commits onto its draft PR. Entries are cleared automatically during the EUI release process.
+-->
+
 **Impact level:** 🟢 None / 🟢 Low / 🟡 Moderate / 🔴 High
 
 ## Release Readiness


### PR DESCRIPTION
## Summary

The [`kibana-prep-commits`](https://github.com/elastic/eui/blob/main/packages/release-cli/kibana-prep-commits) file (added in #9871) lets us list Kibana PR commits that the nightly Kibana integration run cherry-picks onto its draft PR, so EUI PRs that need an accompanying Kibana change keep the nightly integration test green. Entries are cleared automatically during the EUI release process.

This mechanism wasn't surfaced anywhere in the PR template, so contributors have no way to discover it. This PR adds a short guidance comment under the **Impact Assessment → Hard to integrate** item — the section that already covers staging Kibana integrations.

No functional change; template comment only.

### QA instructions for reviewer

- [ ] Verify the template is correct (no syntax errors, clear language)

🤖 Generated with [Claude Code](https://claude.com/claude-code)