### PR TITLE
[EuiSplitButton] Fix inline-size behavior

### DIFF
--- a/packages/eui/changelogs/upcoming/9917.md
+++ b/packages/eui/changelogs/upcoming/9917.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiSplitButton` having a wrong `inline-size` when `textProps={false}` is set on an action button that has `iconType`

--- a/packages/eui/src/components/button/split_button/split_button.styles.ts
+++ b/packages/eui/src/components/button/split_button/split_button.styles.ts
@@ -44,6 +44,7 @@ export const euiSplitButtonStyles = (
       display: inline-flex;
       align-items: center;
       flex-wrap: nowrap;
+      max-inline-size: fit-content;
       padding: ${euiTheme.size.xs};
       border-radius: ${euiTheme.border.radius.small};
       background-color: ${backgroundColor};
@@ -128,11 +129,11 @@ export const euiSplitButtonActionStyles = (
       ${commonStyles}
       z-index: ${euiTheme.levels.content};
 
-      &:not(:has(svg:only-child)) {
+      &:not(.euiButtonIcon) {
         min-inline-size: ${buttonMinWidth}px;
       }
 
-      &:has(svg:only-child) {
+      &.euiButtonIcon {
         inline-size: ${buttonSize};
       }
     `,


### PR DESCRIPTION
## Summary

- **What:** Fixes `EuiSplitButton` width collapsing for icon + text usage.
- **Why:** This is a follow-up to changes done in https://github.com/elastic/eui/pull/9865.
- **How:** 
  - Replaces the `:only-child` selector with a direct class selector. The issue is that `:only-child` counts nodes, but if `textProps={false}` is set on buttons, the inner `EuiButtonDisplayContent` skips the render node and renders text as string. That would result in icon-only inline-size being applied and the button looking collapsed.
  - adds a `max-inline-size` to the group element to prevent unwanted stretching

### API Changes

⚪ No API changes

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| <img width="1259" height="431" alt="Screenshot 2026-08-14 at 10 26 42" src="https://github.com/user-attachments/assets/b09d5a63-fc16-4cbb-8d7a-7869da0335bf" /> | <img width="1259" height="431" alt="Screenshot 2026-08-14 at 10 31 42" src="https://github.com/user-attachments/assets/83e3a2b2-b63e-4904-b4d4-d8ce1715f971" /> |
| <img width="333" height="133" alt="Screenshot 2026-08-14 at 10 42 52" src="https://github.com/user-attachments/assets/01f9f5b3-5d52-4036-bf3e-e83b2725ad2a" /> | <img width="331" height="136" alt="Screenshot 2026-08-14 at 10 43 10" src="https://github.com/user-attachments/assets/ced08388-3d37-4051-b3cc-afb4d6383f4a" /> |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

<!--
If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL to `packages/release-cli/kibana-prep-commits` (one URL per line). The nightly Kibana integration run cherry-picks those commits onto its draft PR. Entries are cleared automatically during the EUI release process.
-->

**Impact level:** 🟢 None

🧪 The changes have been run in Kibana CI (🟢 [build](https://buildkite.com/elastic/kibana-pull-request/builds/485780))

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

💻 [Storybook](https://eui.elastic.co/pr_9917/storybook/?path=/story/navigation-euisplitbutton--playground)

- [ ] verify there are no unexpected regressions with production
- [ ] (optional) checkout this PR and manually verify the new style fixes the issues:
  - update e.g. the "Playground" story to render `<EuiSplitButton.ActionPrimary iconType="faceHappy" textProps={false}>`
  - revert the PR style changes and compare styles between previous and new state and verify the `:has(svg:only-child)` style is not applied

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [x] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
