### PR TITLE
fix(EuiInputPopover): forward form-control attributes to input element instead of anchor div (Fixes #9914)

### DIFF
--- a/packages/eui/src/components/popover/input_popover.tsx
+++ b/packages/eui/src/components/popover/input_popover.tsx
@@ -80,6 +80,9 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
   inputRef: _inputRef,
   panelRef: _panelRef,
   offset = 2,
+  id,
+  disabled,
+  'aria-describedby': ariaDescribedBy,
   ...props
 }) => {
   const classes = classnames('euiInputPopover', className);
@@ -223,12 +226,29 @@ export const EuiInputPopover: FunctionComponent<EuiInputPopoverProps> = ({
     }
   }, [closeOnScroll, closePopover, panelEl, inputEl]);
 
+  // Forward form-control attributes (id, disabled, aria-describedby) from EuiFormRow
+  // to the input element instead of letting them fall through to the anchor div.
+  // See https://github.com/elastic/eui/issues/9914
+  const inputWithFormProps = useMemo(() => {
+    if (input == null) return input;
+    if (React.isValidElement(input)) {
+      const injectedProps: Record<string, any> = {};
+      if (id !== undefined) injectedProps.id = id;
+      if (disabled !== undefined) injectedProps.disabled = disabled;
+      if (ariaDescribedBy !== undefined) injectedProps['aria-describedby'] = ariaDescribedBy;
+      if (Object.keys(injectedProps).length > 0) {
+        return React.cloneElement(input, injectedProps);
+      }
+    }
+    return input;
+  }, [input, id, disabled, ariaDescribedBy]);
+
   return (
     <EuiPopover
       className={classes}
       css={css(fullWidth ? undefined : logicalCSS('max-width', formMaxWidth))}
       display={display}
-      button={input}
+      button={inputWithFormProps}
       popoverRef={inputRef}
       panelRef={panelRef}
       ref={popoverClassRef}


### PR DESCRIPTION
## Summary

Fixes #9914

When `EuiInputPopover` is used as a form control inside `EuiFormRow`, the `EuiFormRow` injects `id`, `disabled`, and `aria-describedby` attributes via `cloneElement`. However, `EuiInputPopover` was not destructuring these props, so they fell through to `...props` and were spread onto the `EuiPopover` component, ultimately landing on the anchor `div` instead of the actual `input` element.

This violates WCAG 3.3.1 (Error Identification) and WCAG 4.1.2 (Name, Role, Value).

### What changed

- Destructure `id`, `disabled`, and `aria-describedby` from `EuiInputPopover` props
- Forward them to the `input` element via `React.cloneElement`
- Prevent them from reaching the anchor div via the `...props` spread

### Before
- `id` → applied to anchor div
- `disabled` → applied to anchor div (invalid HTML attribute on div)
- `aria-describedby` → applied to anchor div (not associated with the input)

### After
- `id` → applied to the actual input element
- `disabled` → applied to the actual input element
- `aria-describedby` → applied to the actual input element

### Test plan
- Existing Cypress tests should continue to pass
- When `EuiInputPopover` is wrapped in `EuiFormRow`, the input should receive `id` and `aria-describedby` attributes`
- No breaking changes to public API

### Checklist
- [x] Check against issue requirements
- [x] Follow [WCAG 3.3.1](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html) and [WCAG 4.1.2](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)