### PR TITLE
[EuiSelectable] Expose invalid state to assistive technology

### DIFF
--- a/packages/eui/changelogs/upcoming/9922.md
+++ b/packages/eui/changelogs/upcoming/9922.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Added invalid state accessibility metadata to `EuiSelectable` search inputs and listboxes

--- a/packages/eui/src/components/selectable/selectable.test.tsx
+++ b/packages/eui/src/components/selectable/selectable.test.tsx
@@ -106,6 +106,36 @@ describe('EuiSelectable', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
 
+    test('isInvalid', () => {
+      const renderSelectable = (isInvalid: boolean) => (
+        <EuiSelectable options={options} searchable isInvalid={isInvalid}>
+          {(list, search) => (
+            <>
+              {search}
+              {list}
+            </>
+          )}
+        </EuiSelectable>
+      );
+      const { getByPlaceholderText, getByRole, rerender } = render(
+        renderSelectable(true)
+      );
+
+      expect(getByPlaceholderText('Filter options')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+      expect(getByRole('listbox')).toHaveAttribute('aria-invalid', 'true');
+
+      rerender(renderSelectable(false));
+
+      expect(getByPlaceholderText('Filter options')).not.toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+      expect(getByRole('listbox')).not.toHaveAttribute('aria-invalid', 'true');
+    });
+
     test('height can be forced', () => {
       const { container } = render(
         <EuiSelectable options={options} height={200} />

--- a/packages/eui/src/components/selectable/selectable.tsx
+++ b/packages/eui/src/components/selectable/selectable.tsx
@@ -145,6 +145,10 @@ export type EuiSelectableProps<T = {}> = CommonProps &
      */
     isLoading?: boolean;
     /**
+     * Marks the search input and options list as invalid for assistive technology
+     */
+    isInvalid?: boolean;
+    /**
      * Sets the max height in pixels or pass `full` to allow
      * the whole group to fill the height of its container and
      * allows the list grow as well
@@ -560,6 +564,7 @@ export class EuiSelectable<T = {}> extends Component<
       searchProps,
       singleSelection,
       isLoading,
+      isInvalid,
       listProps,
       renderOption,
       height,
@@ -775,6 +780,7 @@ export class EuiSelectable<T = {}> extends Component<
                 ? searchAccessibleName
                 : { 'aria-label': placeholderName })}
               {...cleanedSearchProps}
+              isInvalid={isInvalid || cleanedSearchProps.isInvalid}
             />
 
             <EuiScreenReaderOnly>
@@ -858,6 +864,7 @@ export class EuiSelectable<T = {}> extends Component<
                   ? listAccessibleName
                   : searchable && { 'aria-label': placeholderName })}
                 {...cleanedListProps}
+                isInvalid={isInvalid}
                 {...virtualizedProps}
               />
             )}

--- a/packages/eui/src/components/selectable/selectable_list/selectable_list.tsx
+++ b/packages/eui/src/components/selectable/selectable_list/selectable_list.tsx
@@ -163,6 +163,7 @@ export type EuiSelectableListProps<T> = EuiSelectableOptionsListProps & {
    */
   allowExclusions?: boolean;
   searchable?: boolean;
+  isInvalid?: boolean;
   isPreFiltered?: EuiSelectableProps['isPreFiltered'];
   makeOptionId: (index: number | undefined) => string;
   listId: string;
@@ -272,6 +273,18 @@ export class EuiSelectableList<T> extends Component<
         // use last stack execution to prevent potential focus order issues
         setTimeout(() => ref.focus());
       }
+
+      this.updateListBoxAriaInvalid();
+    }
+  };
+
+  updateListBoxAriaInvalid = () => {
+    if (!this.listBoxRef) return;
+
+    if (this.props.isInvalid) {
+      this.listBoxRef.setAttribute('aria-invalid', 'true');
+    } else {
+      this.listBoxRef.removeAttribute('aria-invalid');
     }
   };
 
@@ -318,6 +331,7 @@ export class EuiSelectableList<T> extends Component<
       onFocusBadge,
       searchable,
       singleSelection,
+      isInvalid,
     } = this.props;
 
     if (prevProps.activeOptionIndex !== activeOptionIndex) {
@@ -347,6 +361,10 @@ export class EuiSelectableList<T> extends Component<
           }
         }
       }
+    }
+
+    if (prevProps.isInvalid !== isInvalid) {
+      this.updateListBoxAriaInvalid();
     }
 
     const optionArray = visibleOptions || options;
@@ -762,6 +780,7 @@ export class EuiSelectableList<T> extends Component<
       textWrap,
       truncationProps,
       autoFocus,
+      isInvalid: _isInvalid,
       ...rest
     } = this.props;
 


### PR DESCRIPTION
## Summary

- Adds a top-level `isInvalid` prop to `EuiSelectable`.
- Applies the invalid state to both the searchable input and the listbox so screen readers can identify either control as invalid.
- Keeps the listbox attribute synchronized when `isInvalid` changes.

Fixes #8991.

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| EuiSelectable | isInvalid | Added | Marks the search input and options list as invalid for assistive technology |

## Screenshots

Not applicable; this changes accessibility metadata without changing the visual presentation.

## Impact Assessment

- [ ] 🔴 **Breaking changes**
- [ ] 💅 **Visual changes**
- [x] 🧪 **Test impact** — Adds focused assertions for the search input and listbox.
- [ ] 🔧 **Hard to integrate**

**Impact level:** 🟢 Low

## Release Readiness

- Documentation: The public prop description is included in the generated API documentation.
- Figma: Not applicable.
- Migration guide: Not applicable; the prop is optional.
- Adoption plan: Resolves the accessibility use case tracked in #8991 and elastic/kibana#219379.

### QA instructions for reviewer

- Render a searchable `EuiSelectable` with `isInvalid`.
- Confirm the search input and `role="listbox"` both have `aria-invalid="true"`.
- Toggle `isInvalid` off and confirm neither element remains marked invalid.

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [x] **QA:** No visual behavior changed; the DOM accessibility state is covered by unit tests.
- [x] **Tests:** Added Jest coverage for both affected controls and prop updates.
- [x] **Changelog:** Added `packages/eui/changelogs/upcoming/9922.md`.
- [x] **Breaking changes:** None.
