### PR TITLE
[Docs] Fix version switcher

### DIFF
--- a/packages/docusaurus-theme/changelogs/upcoming/9925.md
+++ b/packages/docusaurus-theme/changelogs/upcoming/9925.md
@@ -1,0 +1,1 @@
+- Fixed overlapping rows and inconsistent hover highlighting in `VersionSwitcher`

--- a/packages/docusaurus-theme/changelogs/upcoming/9925.md
+++ b/packages/docusaurus-theme/changelogs/upcoming/9925.md
@@ -1,1 +1,3 @@
+**Bug fixes**
+
 - Fixed overlapping rows and inconsistent hover highlighting in `VersionSwitcher`

--- a/packages/docusaurus-theme/package.json
+++ b/packages/docusaurus-theme/package.json
@@ -44,15 +44,13 @@
     "@elastic/eui-theme-borealis": "workspace:^",
     "@emotion/css": "^11.11.2",
     "@emotion/react": "^11.11.4",
-    "@types/react-window": "^1.8.8",
     "clsx": "^2.1.1",
     "dedent": "^1.5.3",
     "lz-string": "^1.5.0",
     "moment": "^2.30.1",
     "prism-react-renderer": "^2.3.1",
     "react-is": "^18.3.1",
-    "react-live": "patch:react-live@npm%3A4.1.7#~/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch",
-    "react-window": "^1.8.10"
+    "react-live": "patch:react-live@npm%3A4.1.7#~/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/docusaurus-theme/src/components/version_switcher/index.tsx
+++ b/packages/docusaurus-theme/src/components/version_switcher/index.tsx
@@ -11,6 +11,7 @@ import { css } from '@emotion/react';
 import {
   EuiButtonEmpty,
   euiFocusRing,
+  EuiListGroup,
   EuiListGroupItem,
   EuiPopover,
   useEuiMemoizedStyles,
@@ -26,10 +27,7 @@ const getStyles = (euiThemeContext: UseEuiTheme) => {
       color: ${euiTheme.colors.primary};
     `,
     list: css`
-      inline-size: 120px;
       max-block-size: 200px;
-      margin: 0;
-      padding: 0;
       overflow-y: auto;
     `,
     listItem: css`
@@ -150,7 +148,7 @@ export const VersionSwitcher = ({
       panelPaddingSize="xs"
       aria-label={ariaLabel}
     >
-      <ul className="eui-yScroll" css={styles.list}>
+      <EuiListGroup css={styles.list}>
         {allVersions.map((version) => {
           const isCurrentVersion = version === currentVersion;
           const screenReaderVersion = pronounceVersion(version);
@@ -173,7 +171,7 @@ export const VersionSwitcher = ({
             />
           );
         })}
-      </ul>
+      </EuiListGroup>
     </EuiPopover>
   );
 };

--- a/packages/docusaurus-theme/src/components/version_switcher/index.tsx
+++ b/packages/docusaurus-theme/src/components/version_switcher/index.tsx
@@ -15,6 +15,7 @@ import {
   EuiListGroupItem,
   EuiPopover,
   useEuiMemoizedStyles,
+  useEuiYScroll,
   UseEuiTheme,
 } from '@elastic/eui';
 
@@ -28,7 +29,6 @@ const getStyles = (euiThemeContext: UseEuiTheme) => {
     `,
     list: css`
       max-block-size: 200px;
-      overflow-y: auto;
     `,
     listItem: css`
       .euiListGroupItem__button:focus-visible {
@@ -148,7 +148,7 @@ export const VersionSwitcher = ({
       panelPaddingSize="xs"
       aria-label={ariaLabel}
     >
-      <EuiListGroup css={styles.list}>
+      <EuiListGroup css={[styles.list, useEuiYScroll()]}>
         {allVersions.map((version) => {
           const isCurrentVersion = version === currentVersion;
           const screenReaderVersion = pronounceVersion(version);

--- a/packages/docusaurus-theme/src/components/version_switcher/index.tsx
+++ b/packages/docusaurus-theme/src/components/version_switcher/index.tsx
@@ -8,7 +8,6 @@
 
 import { ComponentProps, useEffect, useState } from 'react';
 import { css } from '@emotion/react';
-import { FixedSizeList } from 'react-window';
 import {
   EuiButtonEmpty,
   euiFocusRing,
@@ -25,6 +24,13 @@ const getStyles = (euiThemeContext: UseEuiTheme) => {
     button: css`
       font-weight: ${euiTheme.font.weight.bold};
       color: ${euiTheme.colors.primary};
+    `,
+    list: css`
+      inline-size: 120px;
+      max-block-size: 200px;
+      margin: 0;
+      padding: 0;
+      overflow-y: auto;
     `,
     listItem: css`
       .euiListGroupItem__button:focus-visible {
@@ -144,18 +150,10 @@ export const VersionSwitcher = ({
       panelPaddingSize="xs"
       aria-label={ariaLabel}
     >
-      <FixedSizeList
-        className="eui-yScroll"
-        itemCount={allVersions.length}
-        itemSize={24}
-        height={200}
-        width={120}
-        innerElementType="ul"
-      >
-        {({ index, style }) => {
-          const version = allVersions[index];
+      <ul className="eui-yScroll" css={styles.list}>
+        {allVersions.map((version) => {
           const isCurrentVersion = version === currentVersion;
-          const screenReaderVersion = pronounceVersion(version!);
+          const screenReaderVersion = pronounceVersion(version);
 
           const url =
             version === latestVersion
@@ -164,8 +162,8 @@ export const VersionSwitcher = ({
 
           return (
             <EuiListGroupItem
+              key={version}
               css={styles.listItem}
-              style={style}
               label={`v${version}`}
               aria-label={screenReaderVersion}
               href={url}
@@ -174,8 +172,8 @@ export const VersionSwitcher = ({
               extraAction={extraAction?.(version)}
             />
           );
-        }}
-      </FixedSizeList>
+        })}
+      </ul>
     </EuiPopover>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7045,7 +7045,6 @@ __metadata:
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
     "@types/react-is": "npm:^18"
-    "@types/react-window": "npm:^1.8.8"
     clsx: "npm:^2.1.1"
     dedent: "npm:^1.5.3"
     lz-string: "npm:^1.5.0"
@@ -7053,7 +7052,6 @@ __metadata:
     prism-react-renderer: "npm:^2.3.1"
     react-is: "npm:^18.3.1"
     react-live: "patch:react-live@npm%3A4.1.7#~/.yarn/patches/react-live-npm-4.1.7-7b41625faa.patch"
-    react-window: "npm:^1.8.10"
     typedoc: "npm:^0.28.4"
     typescript: "npm:~5.5.4"
   peerDependencies:


### PR DESCRIPTION
## Summary

The issue started after #9515 changed `EuiListGroupItem` sizing and structure: row are now 32px tall, while `react-window` still used 24px and positioned the inner link instead of its wrapper.

This PR removes unnecessary version list virtualization so `EuiListGroupItem` can control its own layout, preventing overlapping rows and inconsistent hover highlighting. 

> [!NOTE]
> This change cannot be added retroactively to the previous docs versions without overriding the source directly. It's not a critical bug so I won't do it.

### Screenshots

| Before | After |
|---|---|
| <img width="686" height="350" alt="Kapture 2026-08-18 at 14 53 33" src="https://github.com/user-attachments/assets/9aa21e50-cd45-4c72-b44f-199460d734a1" /> | WIP |

## QA

- [x] Verify the version switcher works correctly ([PR preview](https://eui.elastic.co/pr_9925/))

Made with [Cursor](https://cursor.com) (_partially_)