### PR TITLE
[EuiFilePicker] Fix missing removeFiles reference 

### DIFF
--- a/packages/eui/changelogs/upcoming/9930.md
+++ b/packages/eui/changelogs/upcoming/9930.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFilePicker` losing imperative `ref` support when migrated from class to function component ([#9879](https://github.com/elastic/eui/pull/9879)). Use `useRef<EuiFilePickerRef>()` where `useRef<EuiFilePickerClass>()` was previously used.

--- a/packages/eui/src/components/form/file_picker/file_picker.test.tsx
+++ b/packages/eui/src/components/form/file_picker/file_picker.test.tsx
@@ -6,14 +6,14 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import React, { createRef } from 'react';
+import { act, fireEvent } from '@testing-library/react';
 import { requiredProps } from '../../../test';
 import { render, screen } from '../../../test/rtl';
 import { shouldRenderCustomStyles } from '../../../test/internal';
 
 import { EuiForm } from '../form';
-import { EuiFilePicker } from './file_picker';
+import { EuiFilePicker, EuiFilePickerRef } from './file_picker';
 
 const createMockFiles = (fileNames: string[]): File[] => {
   return fileNames.map(
@@ -46,6 +46,48 @@ describe('EuiFilePicker', () => {
 
       const filePicker = container.querySelector('.euiFilePicker');
       expect(filePicker!.className).toContain('fullWidth');
+    });
+  });
+
+  describe('ref', () => {
+    it('exposes removeFiles', () => {
+      const ref = createRef<EuiFilePickerRef>();
+      const handleChange = jest.fn();
+      render(
+        <EuiFilePicker
+          ref={ref}
+          initialPromptText="Select a file"
+          onChange={handleChange}
+        />
+      );
+
+      expect(ref.current).not.toBeNull();
+      expect(typeof ref.current!.removeFiles).toBe('function');
+      expect(ref.current!.input).toBeInstanceOf(HTMLInputElement);
+    });
+
+    it('removeFiles clears the prompt and calls onChange with null', () => {
+      const ref = createRef<EuiFilePickerRef>();
+      const handleChange = jest.fn();
+      const files = createMockFiles(['test-file.txt']);
+      render(
+        <EuiFilePicker
+          ref={ref}
+          files={files}
+          initialPromptText="Select a file"
+          onChange={handleChange}
+        />
+      );
+
+      expect(screen.getByText('test-file.txt')).toBeInTheDocument();
+
+      act(() => {
+        ref.current!.removeFiles();
+      });
+
+      expect(screen.queryByText('test-file.txt')).not.toBeInTheDocument();
+      expect(screen.getByText('Select a file')).toBeInTheDocument();
+      expect(handleChange).toHaveBeenCalledWith(null);
     });
   });
 

--- a/packages/eui/src/components/form/file_picker/file_picker.tsx
+++ b/packages/eui/src/components/form/file_picker/file_picker.tsx
@@ -7,12 +7,13 @@
  */
 
 import React, {
-  FunctionComponent,
+  forwardRef,
   InputHTMLAttributes,
   MouseEvent,
   ReactNode,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useRef,
   useState,
 } from 'react';
@@ -32,6 +33,11 @@ import { EuiValidatableControl } from '../validatable_control';
 import { EuiFormControlLayoutClearButton } from '../form_control_layout/form_control_layout_clear_button';
 
 import { euiFilePickerStyles } from './file_picker.styles';
+
+export interface EuiFilePickerRef {
+  removeFiles: () => void;
+  input: HTMLInputElement | null;
+}
 
 export interface EuiFilePickerProps
   extends CommonProps,
@@ -101,233 +107,243 @@ const getPromptTextFromFileList = (files: File[] | null): ReactNode | null => {
 /**
  * @see {@link https://eui.elastic.co/docs/components/forms/other/file-picker/|EuiFilePicker documentation}
  */
-export const EuiFilePicker: FunctionComponent<EuiFilePickerProps> = (props) => {
-  const { defaultFullWidth } = useFormContext();
-  const {
-    id,
-    name,
-    initialPromptText = (
-      <EuiI18n
-        token="euiFilePicker.promptText"
-        default="Select or drag and drop a file"
-      />
-    ),
-    className,
-    disabled,
-    compressed = false,
-    onChange,
-    isInvalid,
-    fullWidth = defaultFullWidth,
-    isLoading,
-    display = 'large',
-    files, // Extracted to prevent passing to input element
-    ...rest
-  } = props;
+export const EuiFilePicker = forwardRef<EuiFilePickerRef, EuiFilePickerProps>(
+  (props, ref) => {
+    const { defaultFullWidth } = useFormContext();
+    const {
+      id,
+      name,
+      initialPromptText = (
+        <EuiI18n
+          token="euiFilePicker.promptText"
+          default="Select or drag and drop a file"
+        />
+      ),
+      className,
+      disabled,
+      compressed = false,
+      onChange,
+      isInvalid,
+      fullWidth = defaultFullWidth,
+      isLoading,
+      display = 'large',
+      files, // Extracted to prevent passing to input element
+      ...rest
+    } = props;
 
-  const removeSelectedAriaLabel = useEuiI18n(
-    'euiFilePicker.removeSelectedAriaLabel',
-    'Remove selected files'
-  );
+    const removeSelectedAriaLabel = useEuiI18n(
+      'euiFilePicker.removeSelectedAriaLabel',
+      'Remove selected files'
+    );
 
-  const fileInput = useRef<HTMLInputElement | null>(null);
+    const fileInput = useRef<HTMLInputElement | null>(null);
 
-  const [promptText, setPromptText] = useState<ReactNode | null>(() =>
-    files ? getPromptTextFromFileList(files) : null
-  );
-  const [isHoveringDrop, setIsHoveringDrop] = useState(false);
+    const [promptText, setPromptText] = useState<ReactNode | null>(() =>
+      files ? getPromptTextFromFileList(files) : null
+    );
+    const [isHoveringDrop, setIsHoveringDrop] = useState(false);
 
-  // Update prompt text when the `files` prop changes. The ref guard keeps this
-  // from re-running on mount, where the initial state is already derived above.
-  const prevFiles = useRef(files);
-  useEffect(() => {
-    if (prevFiles.current !== files) {
-      prevFiles.current = files;
-      setPromptText(getPromptTextFromFileList(files ?? null));
-    }
-  }, [files]);
-
-  const handleChange = useCallback(() => {
-    if (!fileInput.current) return;
-
-    if (fileInput.current.files && fileInput.current.files.length === 1) {
-      setPromptText(fileInput.current.value.split('\\').pop());
-    } else {
-      setPromptText(
-        getPromptTextFromFileList(
-          fileInput.current.files ? Array.from(fileInput.current.files) : null
-        )
-      );
-    }
-
-    if (onChange) {
-      onChange(
-        fileInput.current.files && fileInput.current.files.length > 0
-          ? fileInput.current.files
-          : null
-      );
-    }
-  }, [onChange]);
-
-  const removeFiles = useCallback(
-    (e?: MouseEvent<HTMLButtonElement>) => {
-      if (e) {
-        e.stopPropagation();
-        e.preventDefault();
+    // Update prompt text when the `files` prop changes. The ref guard keeps this
+    // from re-running on mount, where the initial state is already derived above.
+    const prevFiles = useRef(files);
+    useEffect(() => {
+      if (prevFiles.current !== files) {
+        prevFiles.current = files;
+        setPromptText(getPromptTextFromFileList(files ?? null));
       }
+    }, [files]);
 
+    const handleChange = useCallback(() => {
       if (!fileInput.current) return;
 
-      fileInput.current.value = '';
-      handleChange();
-    },
-    [handleChange]
-  );
+      if (fileInput.current.files && fileInput.current.files.length === 1) {
+        setPromptText(fileInput.current.value.split('\\').pop());
+      } else {
+        setPromptText(
+          getPromptTextFromFileList(
+            fileInput.current.files ? Array.from(fileInput.current.files) : null
+          )
+        );
+      }
 
-  const showDrop = () => !disabled && setIsHoveringDrop(true);
+      if (onChange) {
+        onChange(
+          fileInput.current.files && fileInput.current.files.length > 0
+            ? fileInput.current.files
+            : null
+        );
+      }
+    }, [onChange]);
 
-  const hideDrop = () => setIsHoveringDrop(false);
+    const removeFiles = useCallback(
+      (e?: MouseEvent<HTMLButtonElement>) => {
+        if (e) {
+          e.stopPropagation();
+          e.preventDefault();
+        }
 
-  const generatedId = useGeneratedHtmlId();
-  const promptId = `${id || generatedId}-filePicker__prompt`;
+        if (!fileInput.current) return;
 
-  const isOverridingInitialPrompt = promptText != null;
-
-  const normalFormControl = display === 'default';
-
-  const classes = classNames(
-    'euiFilePicker',
-    {
-      'euiFilePicker-isDroppingFile': isHoveringDrop,
-      'euiFilePicker-isInvalid': isInvalid,
-      'euiFilePicker-isLoading': isLoading,
-      'euiFilePicker-hasFiles': isOverridingInitialPrompt,
-    },
-    className
-  );
-
-  const styles = useEuiMemoizedStyles(euiFilePickerStyles);
-  const cssStyles = [
-    styles.euiFilePicker,
-    fullWidth ? styles.fullWidth : styles.formWidth,
-    isHoveringDrop && styles.isDroppingFile,
-    isInvalid && !disabled && styles.invalid,
-    isOverridingInitialPrompt && !disabled && styles.hasFiles,
-    isLoading && styles.loading,
-  ];
-
-  const inputStyles = [
-    styles.input.euiFilePicker__input,
-    !normalFormControl && !disabled && styles.input.largeInteractive,
-  ];
-
-  const promptStyles = [
-    styles.euiFilePicker__prompt,
-    disabled && styles.disabled,
-    ...(normalFormControl
-      ? [compressed ? styles.compressed : styles.uncompressed]
-      : [
-          styles.large.large,
-          compressed ? styles.large.compressed : styles.large.uncompressed,
-        ]),
-  ];
-
-  const iconStyles = [
-    styles.icon.euiFilePicker__icon,
-    ...(normalFormControl
-      ? [
-          styles.icon.normal,
-          compressed ? styles.icon.compressed : styles.icon.uncompressed,
-        ]
-      : [styles.icon.large]),
-  ];
-
-  const rightIconStyles = normalFormControl
-    ? [
-        styles.rightIcon.euiFilePicker__rightIcon,
-        compressed
-          ? styles.rightIcon.compressed
-          : styles.rightIcon.uncompressed,
-      ]
-    : undefined;
-
-  let clearButton;
-  if (isLoading && normalFormControl) {
-    // Override clear button with loading spinner if it is in loading state
-    clearButton = (
-      <EuiLoadingSpinner
-        css={rightIconStyles}
-        className="euiFilePicker__loadingSpinner"
-        size={compressed ? 's' : 'm'}
-      />
+        fileInput.current.value = '';
+        handleChange();
+      },
+      [handleChange]
     );
-  } else if (isOverridingInitialPrompt && !disabled) {
-    if (normalFormControl) {
+
+    useImperativeHandle(
+      ref,
+      () => ({ removeFiles, input: fileInput.current }),
+      [removeFiles]
+    );
+
+    const showDrop = () => !disabled && setIsHoveringDrop(true);
+
+    const hideDrop = () => setIsHoveringDrop(false);
+
+    const generatedId = useGeneratedHtmlId();
+    const promptId = `${id || generatedId}-filePicker__prompt`;
+
+    const isOverridingInitialPrompt = promptText != null;
+
+    const normalFormControl = display === 'default';
+
+    const classes = classNames(
+      'euiFilePicker',
+      {
+        'euiFilePicker-isDroppingFile': isHoveringDrop,
+        'euiFilePicker-isInvalid': isInvalid,
+        'euiFilePicker-isLoading': isLoading,
+        'euiFilePicker-hasFiles': isOverridingInitialPrompt,
+      },
+      className
+    );
+
+    const styles = useEuiMemoizedStyles(euiFilePickerStyles);
+    const cssStyles = [
+      styles.euiFilePicker,
+      fullWidth ? styles.fullWidth : styles.formWidth,
+      isHoveringDrop && styles.isDroppingFile,
+      isInvalid && !disabled && styles.invalid,
+      isOverridingInitialPrompt && !disabled && styles.hasFiles,
+      isLoading && styles.loading,
+    ];
+
+    const inputStyles = [
+      styles.input.euiFilePicker__input,
+      !normalFormControl && !disabled && styles.input.largeInteractive,
+    ];
+
+    const promptStyles = [
+      styles.euiFilePicker__prompt,
+      disabled && styles.disabled,
+      ...(normalFormControl
+        ? [compressed ? styles.compressed : styles.uncompressed]
+        : [
+            styles.large.large,
+            compressed ? styles.large.compressed : styles.large.uncompressed,
+          ]),
+    ];
+
+    const iconStyles = [
+      styles.icon.euiFilePicker__icon,
+      ...(normalFormControl
+        ? [
+            styles.icon.normal,
+            compressed ? styles.icon.compressed : styles.icon.uncompressed,
+          ]
+        : [styles.icon.large]),
+    ];
+
+    const rightIconStyles = normalFormControl
+      ? [
+          styles.rightIcon.euiFilePicker__rightIcon,
+          compressed
+            ? styles.rightIcon.compressed
+            : styles.rightIcon.uncompressed,
+        ]
+      : undefined;
+
+    let clearButton;
+    if (isLoading && normalFormControl) {
+      // Override clear button with loading spinner if it is in loading state
       clearButton = (
-        <EuiFormControlLayoutClearButton
-          aria-label={removeSelectedAriaLabel}
-          css={[styles.euiFilePicker__clearButton, rightIconStyles]}
-          className="euiFilePicker__clearButton"
-          onClick={removeFiles}
+        <EuiLoadingSpinner
+          css={rightIconStyles}
+          className="euiFilePicker__loadingSpinner"
           size={compressed ? 's' : 'm'}
         />
       );
+    } else if (isOverridingInitialPrompt && !disabled) {
+      if (normalFormControl) {
+        clearButton = (
+          <EuiFormControlLayoutClearButton
+            aria-label={removeSelectedAriaLabel}
+            css={[styles.euiFilePicker__clearButton, rightIconStyles]}
+            className="euiFilePicker__clearButton"
+            onClick={removeFiles}
+            size={compressed ? 's' : 'm'}
+          />
+        );
+      } else {
+        clearButton = (
+          <EuiButtonEmpty
+            aria-label={removeSelectedAriaLabel}
+            css={styles.euiFilePicker__clearButton}
+            className="euiFilePicker__clearButton"
+            size="xs"
+            onClick={removeFiles}
+          >
+            <EuiI18n token="euiFilePicker.removeSelected" default="Remove" />
+          </EuiButtonEmpty>
+        );
+      }
     } else {
-      clearButton = (
-        <EuiButtonEmpty
-          aria-label={removeSelectedAriaLabel}
-          css={styles.euiFilePicker__clearButton}
-          className="euiFilePicker__clearButton"
-          size="xs"
-          onClick={removeFiles}
-        >
-          <EuiI18n token="euiFilePicker.removeSelected" default="Remove" />
-        </EuiButtonEmpty>
-      );
+      clearButton = null;
     }
-  } else {
-    clearButton = null;
-  }
 
-  const loader = !normalFormControl && isLoading && (
-    <EuiProgress size="xs" color="accent" position="absolute" />
-  );
+    const loader = !normalFormControl && isLoading && (
+      <EuiProgress size="xs" color="accent" position="absolute" />
+    );
 
-  const iconColor = isInvalid ? 'danger' : disabled ? 'disabled' : 'text';
+    const iconColor = isInvalid ? 'danger' : disabled ? 'disabled' : 'text';
 
-  return (
-    <div css={cssStyles} className={classes}>
-      <EuiValidatableControl isInvalid={isInvalid}>
-        <input
-          type="file"
-          id={id}
-          name={name}
-          css={inputStyles}
-          className="euiFilePicker__input"
-          onChange={handleChange}
-          ref={fileInput}
-          onDragOver={showDrop}
-          onDragLeave={hideDrop}
-          onDrop={hideDrop}
-          disabled={disabled}
-          aria-describedby={promptId}
-          {...rest}
-        />
-      </EuiValidatableControl>
-      <div css={promptStyles} className="euiFilePicker__prompt" id={promptId}>
-        <EuiIcon
-          css={iconStyles}
-          className="euiFilePicker__icon"
-          color={iconColor}
-          type={isInvalid ? 'warning' : disabled ? 'minusCircle' : 'upload'}
-          size={normalFormControl ? 'm' : 'l'}
-          aria-hidden="true"
-        />
-        <span className="euiFilePicker__promptText">
-          {promptText || initialPromptText}
-        </span>
-        {clearButton}
-        {loader}
+    return (
+      <div css={cssStyles} className={classes}>
+        <EuiValidatableControl isInvalid={isInvalid}>
+          <input
+            type="file"
+            id={id}
+            name={name}
+            css={inputStyles}
+            className="euiFilePicker__input"
+            onChange={handleChange}
+            ref={fileInput}
+            onDragOver={showDrop}
+            onDragLeave={hideDrop}
+            onDrop={hideDrop}
+            disabled={disabled}
+            aria-describedby={promptId}
+            {...rest}
+          />
+        </EuiValidatableControl>
+        <div css={promptStyles} className="euiFilePicker__prompt" id={promptId}>
+          <EuiIcon
+            css={iconStyles}
+            className="euiFilePicker__icon"
+            color={iconColor}
+            type={isInvalid ? 'warning' : disabled ? 'minusCircle' : 'upload'}
+            size={normalFormControl ? 'm' : 'l'}
+            aria-hidden="true"
+          />
+          <span className="euiFilePicker__promptText">
+            {promptText || initialPromptText}
+          </span>
+          {clearButton}
+          {loader}
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
+
+EuiFilePicker.displayName = 'EuiFilePicker';

--- a/packages/eui/src/components/form/file_picker/index.ts
+++ b/packages/eui/src/components/form/file_picker/index.ts
@@ -6,5 +6,5 @@
  * Side Public License, v 1.
  */
 
-export type { EuiFilePickerProps } from './file_picker';
+export type { EuiFilePickerProps, EuiFilePickerRef } from './file_picker';
 export { EuiFilePicker } from './file_picker';

--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -4,3 +4,5 @@
 #
 # Entries are cleared as part of the EUI release process.
 https://github.com/elastic/kibana/pull/244898/commits/f3a7f97976213c6f2f5334aafd112455ff94d8f9
+https://github.com/elastic/kibana/pull/235177/commits/63b73732214e2cb2aa82b30bc2762bed8703c428
+https://github.com/elastic/kibana/pull/235177/commits/1d2d213025ef53336a6f366b1b6031e2a96b1817


### PR DESCRIPTION
## Summary

- **What:** Add `forwardRef` + `useImperativeHandle` to `EuiFilePicker`, exposing `removeFiles()`.
- **Why:** This is a follow-up fix to https://github.com/elastic/eui/pull/9879. The previous `EuiFilePickerClass` class component natively allowed consumers to attach a `ref` and call `ref.current.removeFiles()` to programmatically clear the picker after a file was processed. This was not migrated in the migration PR and caused a functionality gap in Kibana usages.
- **How:** 
  -  Converted the component to `React.forwardRef<EuiFilePickerRef, EuiFilePickerProps>` and added `useImperativeHandle` to expose the existing `removeFiles` callback for consumers. 
  - Additionally adds the input ref as `ref.current.input` as well

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| `EuiFilePicker` | `ref` | Added | Returns `ref` as `EuiFilePickerRef` containing `removeFiles` and `input` |

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| {Before image} | {After image} |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [x] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

<!--
If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL to `packages/release-cli/kibana-prep-commits` (one URL per line). The nightly Kibana integration run cherry-picks those commits onto its draft PR. Entries are cleared automatically during the EUI release process.
-->

**Impact level:** 🟢 Low

Requires Kibana changes: commits added [here](https://github.com/elastic/eui/pull/9930/commits/ceccd60afb7b900935a440aba1cbe95fc70c2a07)
🧪 The changes have been run in Kibana CI (🟢  [build](https://buildkite.com/elastic/kibana-pull-request/builds/487940))

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~~**Documentation:** {link to docs page(s)}~~
- [ ] ~~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~~
- [ ] ~~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~~
- [ ] ~~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [ ] verify `removeFiles` is available and works as expected (to clear the internal input)
- [ ] verify `input` returns the correct HTML element (input element)
- [ ] verify there is no unexpected regression with production

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [x] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
