### PR TITLE
[EuiDataGrid] Fix header cell actions popover not opening on pressing Enter on the menu button

### DIFF
--- a/packages/eui/changelogs/upcoming/9931.md
+++ b/packages/eui/changelogs/upcoming/9931.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDataGrid` header cell actions popover not opening when pressing Enter on a focused actions button

--- a/packages/eui/cypress/support/component.tsx
+++ b/packages/eui/cypress/support/component.tsx
@@ -30,7 +30,7 @@ import './helpers/wait_for_position_to_settle';
 // @see https://github.com/quasarframework/quasar/issues/2233#issuecomment-492975745
 // @see also https://github.com/cypress-io/cypress/issues/20341
 Cypress.on('uncaught:exception', (err) => {
-  if (err.message.includes('> ResizeObserver loop')) {
+  if (err.message.includes('ResizeObserver loop')) {
     return false;
   }
 });

--- a/packages/eui/src/components/datagrid/body/cell/focus_utils.spec.tsx
+++ b/packages/eui/src/components/datagrid/body/cell/focus_utils.spec.tsx
@@ -82,6 +82,7 @@ describe('Cell focus utils', () => {
       // Keyboard behavior
       cy.realPress('Escape');
       cy.get(headerCellPopover).should('not.exist');
+      cy.get(headerCellActionsButton).should('be.focused');
       cy.realPress('Enter');
       cy.get(headerCellPopover).should('exist');
     });

--- a/packages/eui/src/components/datagrid/body/header/column_actions.tsx
+++ b/packages/eui/src/components/datagrid/body/header/column_actions.tsx
@@ -123,7 +123,9 @@ export const ColumnActions: FunctionComponent<
       "Press the Enter key to view this column's actions"
     );
     const openActionsPopoverOnEnter: KeyboardEventHandler = useCallback((e) => {
-      if (e.key === keys.ENTER) {
+      // Only handle Enter when the cell div itself is focused,
+      // not when it bubbles up from the nested button
+      if (e.key === keys.ENTER && e.target === e.currentTarget) {
         setIsPopoverOpen(true);
       }
     }, []);

--- a/packages/eui/src/components/datagrid/body/header/draggable_columns.spec.tsx
+++ b/packages/eui/src/components/datagrid/body/header/draggable_columns.spec.tsx
@@ -229,7 +229,7 @@ describe('draggable columns', () => {
     it('should close its own column actions popover', () => {
       cy.realMount(<StatefulDataGrid />);
 
-      cy.get('[data-test-subj=dataGridHeaderCell-a]').realClick();
+      cy.get('[data-test-subj=dataGridHeaderCell-a]').click();
       cy.realPress('Enter');
       cy.get('[data-popover-open]').should('have.focus');
 

--- a/packages/eui/src/components/datagrid/body/header/draggable_columns.spec.tsx
+++ b/packages/eui/src/components/datagrid/body/header/draggable_columns.spec.tsx
@@ -229,7 +229,8 @@ describe('draggable columns', () => {
     it('should close its own column actions popover', () => {
       cy.realMount(<StatefulDataGrid />);
 
-      cy.get('[data-test-subj=dataGridHeaderCell-a]').click();
+      cy.get('[data-test-subj=dataGridHeaderCell-a]').realClick();
+      cy.get('[data-test-subj=dataGridHeaderCell-a]').should('have.focus');
       cy.realPress('Enter');
       cy.get('[data-popover-open]').should('have.focus');
 


### PR DESCRIPTION
## Summary

- **What:** Fixes the header cell executing two individual handlers on `Enter` press that control the popover open state.
- **Why:** 
  - On pressing `Enter` on the focused action menu button, two handlers would execute that both set the popover state via `setIsPopoverOpen` which would result in the popover opening and closing immediately.
  - This likely was a cause for the flaky cypress test behavior in `focus_utils.spec.tsx` (e.g. seen [here](https://buildkite.com/elastic/eui-pull-request-test/builds/7365#01a01589-200f-4bd3-8cc4-09d837d51add))
- **How:** 
  - Adds a `e.target === e.currentTarget` guard to `openActionsPopoverOnEnter` in `ColumnActions`.
- Additional notes:
  - this PR also attempts to stabilize `draggable_columns.spec.ts` (e.g. seen [here](https://buildkite.com/elastic/eui-pull-request-test/builds/7395#01a01e49-40e6-4185-ae28-32e9b7edaf4d))

### API Changes

⚪  No API changes

## Screenshots

| Before         | After         |
| -------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/9d73caca-b94b-4e11-ac33-a25bf5544d72" /> | <video src="https://github.com/user-attachments/assets/97eaa80c-6ed4-4e74-8c6a-3837c59d2da1" /> |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

<!--
If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL to `packages/release-cli/kibana-prep-commits` (one URL per line). The nightly Kibana integration run cherry-picks those commits onto its draft PR. Entries are cleared automatically during the EUI release process.
-->

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] ~~**Documentation:** {link to docs page(s)}~~
- [ ] ~~**Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}~~
- [ ] ~~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~~
- [ ] ~~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where}~~ <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [ ] verify the menu popover opens on `Enter` key press when the action menu button is focused:
  - click a header cell
  - click the action menu button -> popover should open
  - press `Escape` -> popover should close and menu button should be focused
  - press `Enter` -> popover should open (this step does not work on production)
- [x] multiple CI runs finish green without failure in `focus_utils.spec.tsx` and `draggable_columns.spec.tsx`

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
