### PR TITLE
[EuiTreeView] Migrate to a function component

### DIFF
--- a/packages/eui/src/components/tree_view/tree_view.spec.tsx
+++ b/packages/eui/src/components/tree_view/tree_view.spec.tsx
@@ -10,84 +10,273 @@
 /// <reference types="cypress-real-events" />
 /// <reference types="../../../cypress/support" />
 
-import React from 'react';
-import { EuiTreeView, EuiTreeViewProps } from './tree_view';
+import React, { useState } from 'react';
+import { EuiTreeView, Node } from './tree_view';
 
-const TreeView = () => {
-  const items = [
-    {
-      label: 'Item One',
-      id: 'item_one',
-      isExpanded: true,
-      children: [
-        {
-          label: 'Item A',
-          id: 'item_a',
-        },
-        {
-          label: 'Item B',
-          id: 'item_b',
-          children: [
-            {
-              label: 'A Cloud',
-              id: 'item_cloud',
-            },
-            {
-              label: "I'm a Bug",
-              id: 'item_bug',
-              className: 'classForBug',
-            },
-          ],
-        },
-        {
-          label: 'Item C',
-          id: 'item_c',
-          children: [
-            {
-              label: 'Another Cloud',
-              id: 'item_cloud2',
-            },
-            {
-              label: 'Another Bug',
-              id: 'item_bug2',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      label: 'Item Two',
-      id: 'item_two',
-    },
-  ];
+const getItems = (childBranchCallback?: () => string): Node[] => [
+  {
+    label: 'Root Branch',
+    id: 'root_branch',
+    isExpanded: true,
+    children: [
+      {
+        label: 'Child Leaf',
+        id: 'child_leaf',
+      },
+      {
+        label: 'Child Branch',
+        id: 'child_branch',
+        callback: childBranchCallback,
+        children: [
+          {
+            label: 'Grandchild Leaf',
+            id: 'grandchild_leaf',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Sibling Branch',
+    id: 'sibling_branch',
+    children: [
+      {
+        label: 'Sibling Child',
+        id: 'sibling_child',
+      },
+    ],
+  },
+  {
+    label: 'Root Leaf',
+    id: 'root_leaf',
+  },
+];
 
-  const defaultTreeViewProps: EuiTreeViewProps = {
-    items: items,
-    'aria-label': 'Sample folder tree',
-  };
+const TreeView = ({
+  childBranchCallback,
+}: {
+  childBranchCallback?: () => string;
+}) => (
+  <div style={{ width: '20rem' }}>
+    <EuiTreeView
+      id="tree"
+      items={getItems(childBranchCallback)}
+      aria-label="Sample folder tree"
+    />
+  </div>
+);
+
+const RerenderingTreeView = () => {
+  const [label, setLabel] = useState('Sample folder tree');
 
   return (
-    <div style={{ width: '20rem' }}>
-      <EuiTreeView {...defaultTreeViewProps} />
-    </div>
+    <>
+      <TreeView />
+      <button
+        data-test-subj="rerenderTree"
+        onClick={() => setLabel('Updated folder tree')}
+      >
+        Update
+      </button>
+      <span>{label}</span>
+    </>
   );
 };
 
 describe('EuiTreeView', () => {
-  describe('Keyboard functionality', () => {
-    it('Expands and collapses children correctly', () => {
+  describe('vertical keyboard navigation', () => {
+    beforeEach(() => {
       cy.realMount(<TreeView />);
-      cy.get('ul.euiTreeView').should('exist');
-      cy.repeatRealPress('Tab', 3);
-      cy.focused().contains('Item B');
+    });
+
+    it('moves through visible root and nested buttons in DOM order', () => {
+      cy.get('#root_branch').focus().realPress('ArrowDown');
+      cy.focused().should('have.id', 'child_leaf').realPress('ArrowDown');
+      cy.focused().should('have.id', 'child_branch').realPress('ArrowDown');
+      cy.focused().should('have.id', 'sibling_branch').realPress('ArrowDown');
+      cy.focused().should('have.id', 'root_leaf');
+
+      cy.realPress('ArrowUp');
+      cy.focused().should('have.id', 'sibling_branch').realPress('ArrowUp');
+      cy.focused().should('have.id', 'child_branch').realPress('ArrowUp');
+      cy.focused().should('have.id', 'child_leaf').realPress('ArrowUp');
+      cy.focused().should('have.id', 'root_branch');
+    });
+
+    it('includes newly mounted descendants and does not change the active item', () => {
+      cy.get('#child_branch').focus().realPress('ArrowRight');
+      cy.get('#child_branch')
+        .should('have.attr', 'aria-expanded', 'true')
+        .and('have.class', 'euiTreeView__node--active')
+        .realPress('ArrowDown');
+
+      cy.focused()
+        .should('have.id', 'grandchild_leaf')
+        .and('not.have.class', 'euiTreeView__node--active')
+        .realPress('ArrowDown');
+      cy.focused().should('have.id', 'sibling_branch');
+      cy.get('#child_branch').should('have.class', 'euiTreeView__node--active');
+    });
+
+    it('does not wrap at the first or final visible button', () => {
+      cy.get('#root_branch').focus().realPress('ArrowUp');
+      cy.focused().should('have.id', 'root_branch');
+
+      cy.get('#root_leaf').focus().realPress('ArrowDown');
+      cy.focused().should('have.id', 'root_leaf');
+    });
+  });
+
+  describe('horizontal keyboard expansion', () => {
+    it('ArrowRight opens a branch locally, preserves focus, and skips its callback', () => {
+      const callback = cy.stub().returns('');
+      cy.realMount(<TreeView childBranchCallback={callback} />);
+
+      cy.get('#child_branch').focus().realPress('ArrowRight');
+      cy.focused()
+        .should('have.id', 'child_branch')
+        .and('have.attr', 'aria-expanded', 'true');
+      cy.get('#grandchild_leaf').should('exist');
+      cy.wrap(callback).should('not.have.been.called');
+
+      cy.realPress('ArrowRight');
+      cy.focused()
+        .should('have.id', 'child_branch')
+        .and('have.attr', 'aria-expanded', 'true');
+      cy.wrap(callback).should('not.have.been.called');
+    });
+
+    it('ArrowRight gives a leaf active styling without expansion semantics or a callback', () => {
+      const callback = cy.stub().returns('');
+      const items = getItems();
+      items[0].children![0].callback = callback;
+      cy.realMount(<EuiTreeView id="tree" items={items} aria-label="Tree" />);
+
+      cy.get('#child_leaf').focus().realPress('ArrowRight');
+
+      cy.focused()
+        .should('have.id', 'child_leaf')
+        .and('have.class', 'euiTreeView__node--active')
+        .and('not.have.attr', 'aria-expanded');
+      cy.wrap(callback).should('not.have.been.called');
+    });
+
+    it('ArrowLeft closes an open child locally before a second press bubbles to its parent', () => {
+      const callback = cy.stub().returns('');
+      cy.realMount(<TreeView childBranchCallback={callback} />);
+      cy.get('#child_branch').focus().realPress('ArrowRight');
+
+      cy.realPress('ArrowLeft');
+      cy.focused()
+        .should('have.id', 'child_branch')
+        .and('have.attr', 'aria-expanded', 'false');
+      cy.get('#grandchild_leaf').should('not.exist');
+      cy.wrap(callback).should('not.have.been.called');
+
+      cy.realPress('ArrowLeft');
+      cy.focused().should('have.id', 'root_branch');
+      cy.wrap(callback).should('not.have.been.called');
+    });
+  });
+
+  describe('native button behavior', () => {
+    it('Enter toggles a branch, preserves focus, and calls back once per toggle', () => {
+      const callback = cy.stub().returns('');
+      cy.realMount(<TreeView childBranchCallback={callback} />);
+
+      cy.get('#child_branch').focus().realPress('Enter');
+      cy.focused()
+        .should('have.id', 'child_branch')
+        .and('have.attr', 'aria-expanded', 'true');
+      cy.wrap(callback).should('have.been.calledOnce');
+
       cy.realPress('Enter');
-      cy.get('li.euiTreeView__node').contains('A Cloud').should('exist');
-      cy.realPress('Enter');
-      cy.get('li.euiTreeView__node').contains('A Cloud').should('not.exist');
-      cy.realPress('Tab');
-      cy.focused().contains('Item C');
-      cy.realPress('Enter');
-      cy.get('li.euiTreeView__node').contains('Another Cloud').should('exist');
+      cy.focused()
+        .should('have.id', 'child_branch')
+        .and('have.attr', 'aria-expanded', 'false');
+      cy.wrap(callback).should('have.been.calledTwice');
+    });
+
+    it('Space toggles a branch and calls back exactly once', () => {
+      const callback = cy.stub().returns('');
+      cy.realMount(<TreeView childBranchCallback={callback} />);
+
+      cy.get('#child_branch').focus().realPress('Space');
+
+      cy.focused()
+        .should('have.id', 'child_branch')
+        .and('have.attr', 'aria-expanded', 'true');
+      cy.wrap(callback).should('have.been.calledOnce');
+    });
+
+    it('Tab follows the native order of every visible button', () => {
+      cy.realMount(<TreeView />);
+
+      cy.get('#root_branch').focus().realPress('Tab');
+      cy.focused().should('have.id', 'child_leaf').realPress('Tab');
+      cy.focused().should('have.id', 'child_branch').realPress('Tab');
+      cy.focused().should('have.id', 'sibling_branch').realPress('Tab');
+      cy.focused().should('have.id', 'root_leaf');
+      cy.get('#tree button').should('not.have.attr', 'tabindex');
+    });
+
+    it('mouse expansion and collapse preserve focus and call back once per click', () => {
+      const callback = cy.stub().returns('');
+      cy.realMount(<TreeView childBranchCallback={callback} />);
+
+      cy.get('#child_branch').realClick();
+      cy.focused()
+        .should('have.id', 'child_branch')
+        .and('have.attr', 'aria-expanded', 'true');
+      cy.wrap(callback).should('have.been.calledOnce');
+
+      cy.get('#child_branch').realClick();
+      cy.focused()
+        .should('have.id', 'child_branch')
+        .and('have.attr', 'aria-expanded', 'false');
+      cy.wrap(callback).should('have.been.calledTwice');
+    });
+  });
+
+  describe('ID and rerender behavior', () => {
+    it('gives independent trees distinct generated root and instruction IDs', () => {
+      cy.mount(
+        <>
+          <EuiTreeView
+            items={[{ label: 'First Leaf', id: 'first_leaf' }]}
+            aria-label="First tree"
+          />
+          <EuiTreeView
+            items={[{ label: 'Second Leaf', id: 'second_leaf' }]}
+            aria-label="Second tree"
+          />
+        </>
+      );
+
+      cy.get('ul.euiTreeView').then(($trees) => {
+        const firstId = $trees.eq(0).attr('id');
+        const secondId = $trees.eq(1).attr('id');
+
+        expect(firstId).not.to.equal(secondId);
+        expect($trees.eq(0)).to.have.attr(
+          'aria-describedby',
+          `${firstId}--instruction`
+        );
+        expect($trees.eq(1)).to.have.attr(
+          'aria-describedby',
+          `${secondId}--instruction`
+        );
+      });
+    });
+
+    it('preserves the focused tree button through an ordinary rerender', () => {
+      cy.realMount(<RerenderingTreeView />);
+      cy.get('#child_branch').focus();
+
+      cy.get('[data-test-subj="rerenderTree"]').invoke('click');
+
+      cy.contains('Updated folder tree');
+      cy.focused().should('have.id', 'child_branch');
     });
   });
 });

--- a/packages/eui/src/components/tree_view/tree_view.test.tsx
+++ b/packages/eui/src/components/tree_view/tree_view.test.tsx
@@ -15,9 +15,9 @@ import { requiredProps } from '../../test/required_props';
 import { EuiIcon } from '../icon';
 import { EuiToken } from '../token';
 
-import { EuiTreeView } from './tree_view';
+import { EuiTreeView, Node } from './tree_view';
 
-const items = [
+const getItems = (): Node[] => [
   {
     label: 'Item One',
     id: 'item_one',
@@ -75,53 +75,402 @@ const items = [
   },
 ];
 
+const getCharacterizationItems = (): Node[] => [
+  {
+    label: 'Branch One',
+    id: 'branch_one',
+    children: [
+      {
+        label: 'Child Leaf',
+        id: 'child_leaf',
+      },
+      {
+        label: 'Child Branch',
+        id: 'child_branch',
+        children: [
+          {
+            label: 'Grandchild Leaf',
+            id: 'grandchild_leaf',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    label: 'Branch Two',
+    id: 'branch_two',
+    children: [
+      {
+        label: 'Second Child',
+        id: 'second_child',
+      },
+    ],
+  },
+  {
+    label: 'Root Leaf',
+    id: 'root_leaf',
+  },
+];
+
 describe('EuiTreeView', () => {
-  shouldRenderCustomStyles(<EuiTreeView items={items} />);
+  shouldRenderCustomStyles(
+    <EuiTreeView items={getItems()} aria-label="Tree" />
+  );
 
   test('is rendered', () => {
     const { container } = render(
-      <EuiTreeView items={items} {...requiredProps} />
+      <EuiTreeView items={getItems()} {...requiredProps} />
     );
 
     expect(container).toMatchSnapshot();
   });
 
-  test('item expansion', () => {
-    const { container, getByText } = render(
-      <EuiTreeView items={items} aria-label="Tree" />
+  test('forwards its ref to the root list', () => {
+    const ref = React.createRef<HTMLUListElement>();
+    const { container, unmount } = render(
+      <EuiTreeView ref={ref} items={getItems()} aria-label="Tree" />
     );
-    const getExpandedItems = () =>
-      container.querySelectorAll('[aria-expanded="true"]');
-    expect(getExpandedItems()).toHaveLength(1);
 
-    fireEvent.click(getByText('Item B'));
-    expect(getExpandedItems()).toHaveLength(2);
+    expect(ref.current).toBe(container.querySelector('ul'));
+
+    unmount();
+    expect(ref.current).toBeNull();
   });
 
-  test('active item', () => {
-    const { container, getByText } = render(
-      <EuiTreeView items={items} aria-label="Tree" />
-    );
-    const getActiveItem = () =>
-      container.querySelector('.euiTreeView__node--active');
-    expect(getActiveItem()).not.toBeInTheDocument();
+  describe('uncontrolled expansion', () => {
+    test('isExpanded seeds branch state only on initial mount', () => {
+      const items = getCharacterizationItems();
+      items[0].isExpanded = true;
+      items[2].isExpanded = true;
 
-    fireEvent.click(getByText('Item Two')!);
-    expect(getActiveItem()).toBeInTheDocument();
+      const { getByRole } = render(
+        <EuiTreeView items={items} aria-label="Tree" />
+      );
+
+      expect(getByRole('button', { name: 'Branch One' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByRole('button', { name: 'Branch Two' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+      expect(getByRole('button', { name: 'Root Leaf' })).not.toHaveAttribute(
+        'aria-expanded'
+      );
+    });
+
+    test('isExpanded prop changes do not resynchronize open state', () => {
+      const initialItems = getCharacterizationItems();
+      initialItems[0].isExpanded = true;
+      const { getByRole, rerender } = render(
+        <EuiTreeView items={initialItems} aria-label="Tree" />
+      );
+
+      const updatedItems = getCharacterizationItems();
+      updatedItems[0].isExpanded = false;
+      updatedItems[1].isExpanded = true;
+      rerender(<EuiTreeView items={updatedItems} aria-label="Tree" />);
+
+      expect(getByRole('button', { name: 'Branch One' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByRole('button', { name: 'Branch Two' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+    });
+
+    test('expandByDefault recursively expands every branch on initialization', () => {
+      const { getByRole, getByText } = render(
+        <EuiTreeView
+          items={getCharacterizationItems()}
+          expandByDefault
+          aria-label="Tree"
+        />
+      );
+
+      expect(getByRole('button', { name: 'Branch One' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByRole('button', { name: 'Child Branch' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByRole('button', { name: 'Branch Two' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByText('Grandchild Leaf')).toBeInTheDocument();
+    });
+
+    test('expandByDefault is not applied when enabled after mount', () => {
+      const items = getCharacterizationItems();
+      const { getByRole, queryByText, rerender } = render(
+        <EuiTreeView items={items} aria-label="Tree" />
+      );
+
+      rerender(<EuiTreeView items={items} expandByDefault aria-label="Tree" />);
+
+      expect(getByRole('button', { name: 'Branch One' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+      expect(queryByText('Child Leaf')).not.toBeInTheDocument();
+    });
+
+    test('rerenders do not reapply expandByDefault after a branch is closed', () => {
+      const items = getCharacterizationItems();
+      const { getByRole, queryByText, rerender } = render(
+        <EuiTreeView items={items} expandByDefault aria-label="Tree" />
+      );
+      fireEvent.click(getByRole('button', { name: 'Branch One' }));
+
+      rerender(
+        <EuiTreeView
+          items={items}
+          expandByDefault
+          aria-label="Updated tree label"
+        />
+      );
+
+      expect(getByRole('button', { name: 'Branch One' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+      expect(queryByText('Child Leaf')).not.toBeInTheDocument();
+    });
+
+    test('multiple sibling branches remain open simultaneously', () => {
+      const { getByRole, getByText } = render(
+        <EuiTreeView items={getCharacterizationItems()} aria-label="Tree" />
+      );
+
+      fireEvent.click(getByRole('button', { name: 'Branch One' }));
+      fireEvent.click(getByRole('button', { name: 'Branch Two' }));
+
+      expect(getByText('Child Leaf')).toBeInTheDocument();
+      expect(getByText('Second Child')).toBeInTheDocument();
+    });
+
+    test('reopening an ancestor restores descendant expansion from mutated nodes', () => {
+      const items = getCharacterizationItems();
+      items[0].isExpanded = true;
+      const { getByRole, getByText, queryByText } = render(
+        <EuiTreeView items={items} aria-label="Tree" />
+      );
+
+      fireEvent.click(getByRole('button', { name: 'Child Branch' }));
+      expect(getByText('Grandchild Leaf')).toBeInTheDocument();
+
+      fireEvent.click(getByRole('button', { name: 'Branch One' }));
+      expect(queryByText('Child Branch')).not.toBeInTheDocument();
+      expect(queryByText('Grandchild Leaf')).not.toBeInTheDocument();
+
+      fireEvent.click(getByRole('button', { name: 'Branch One' }));
+      expect(getByRole('button', { name: 'Child Branch' })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
+      expect(getByText('Grandchild Leaf')).toBeInTheDocument();
+    });
+
+    test('reopening an ancestor does not restore descendants expanded only by expandByDefault', () => {
+      const { getByRole, queryByText } = render(
+        <EuiTreeView
+          items={getCharacterizationItems()}
+          expandByDefault
+          aria-label="Tree"
+        />
+      );
+      expect(queryByText('Grandchild Leaf')).toBeInTheDocument();
+
+      fireEvent.click(getByRole('button', { name: 'Branch One' }));
+      fireEvent.click(getByRole('button', { name: 'Branch One' }));
+
+      expect(getByRole('button', { name: 'Child Branch' })).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      );
+      expect(queryByText('Grandchild Leaf')).not.toBeInTheDocument();
+    });
   });
 
-  test('open node changes', () => {
-    const { queryByText, getByText } = render(
-      <EuiTreeView items={items} aria-label="Tree" />
-    );
-    expect(queryByText('Item C')).toBeInTheDocument();
-    expect(queryByText('Another Bug')).not.toBeInTheDocument();
+  describe('node mutation and callbacks', () => {
+    test('mouse expansion and collapse mutate isExpanded and call back once', () => {
+      const callback = jest.fn(() => 'called');
+      const items = getCharacterizationItems();
+      items[0].callback = callback;
+      const { getByRole } = render(
+        <EuiTreeView items={items} aria-label="Tree" />
+      );
+      const branch = getByRole('button', { name: 'Branch One' });
 
-    fireEvent.click(getByText('Item C'));
-    expect(queryByText('Another Bug')).toBeInTheDocument();
+      fireEvent.click(branch);
+      expect(items[0].isExpanded).toBe(true);
+      expect(callback).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(getByText('Item One'));
-    expect(queryByText('Item C')).not.toBeInTheDocument();
-    expect(queryByText('Another Bug')).not.toBeInTheDocument();
+      fireEvent.click(branch);
+      expect(items[0].isExpanded).toBe(false);
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    test('leaf clicks mutate state and call back without adding aria-expanded', () => {
+      const callback = jest.fn(() => 'called');
+      const items = getCharacterizationItems();
+      items[2].callback = callback;
+      const { getByRole } = render(
+        <EuiTreeView items={items} aria-label="Tree" />
+      );
+      const leaf = getByRole('button', { name: 'Root Leaf' });
+
+      fireEvent.click(leaf);
+
+      expect(items[2].isExpanded).toBe(true);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(leaf).not.toHaveAttribute('aria-expanded');
+      expect(leaf).toHaveClass('euiTreeView__node--active');
+
+      fireEvent.click(leaf);
+      expect(items[2].isExpanded).toBe(false);
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(leaf).not.toHaveAttribute('aria-expanded');
+      expect(leaf).toHaveClass('euiTreeView__node--active');
+    });
+  });
+
+  describe('active item', () => {
+    test('active items are local to recursive tree levels', () => {
+      const { getByRole } = render(
+        <EuiTreeView items={getCharacterizationItems()} aria-label="Tree" />
+      );
+      const parent = getByRole('button', { name: 'Branch One' });
+      fireEvent.click(parent);
+      const child = getByRole('button', { name: 'Child Branch' });
+      fireEvent.click(child);
+
+      expect(parent).toHaveClass('euiTreeView__node--active');
+      expect(child).toHaveClass('euiTreeView__node--active');
+    });
+  });
+
+  describe('IDs and prop updates', () => {
+    test('generated tree and control IDs remain stable across rerenders', () => {
+      const items = getCharacterizationItems();
+      const { container, getByRole, rerender } = render(
+        <EuiTreeView items={items} aria-label="Tree" />
+      );
+      const initialTreeId = container.querySelector('ul')!.id;
+      const initialControls = getByRole('button', {
+        name: 'Branch One',
+      }).getAttribute('aria-controls');
+
+      rerender(<EuiTreeView items={items} aria-label="Updated tree" />);
+
+      expect(container.querySelector('ul')).toHaveAttribute(
+        'id',
+        initialTreeId
+      );
+      expect(getByRole('button', { name: 'Branch One' })).toHaveAttribute(
+        'aria-controls',
+        initialControls
+      );
+      expect(document.getElementById(initialControls!)).toBeInTheDocument();
+    });
+
+    test('changing id updates the root and instruction IDs', () => {
+      const items = getCharacterizationItems();
+      const { container, getByText, rerender } = render(
+        <EuiTreeView items={items} id="first-tree" aria-label="Tree" />
+      );
+
+      rerender(
+        <EuiTreeView items={items} id="second-tree" aria-label="Tree" />
+      );
+
+      expect(container.querySelector('ul')).toHaveAttribute(
+        'id',
+        'second-tree'
+      );
+      expect(container.querySelector('ul')).toHaveAttribute(
+        'aria-describedby',
+        'second-tree--instruction'
+      );
+      expect(getByText(/quickly navigate/)).toHaveAttribute(
+        'id',
+        'second-tree--instruction'
+      );
+    });
+
+    test('mounted nested levels retain the original shared navigation ID after root id changes', () => {
+      const items = getCharacterizationItems();
+      items[0].isExpanded = true;
+      const { getByRole, rerender } = render(
+        <EuiTreeView items={items} id="first-tree" aria-label="Tree" />
+      );
+
+      rerender(
+        <EuiTreeView items={items} id="second-tree" aria-label="Tree" />
+      );
+
+      expect(getByRole('button', { name: 'Branch One' })).toHaveAttribute(
+        'data-test-subj',
+        'euiTreeViewButton-second-tree'
+      );
+      expect(getByRole('button', { name: 'Child Leaf' })).toHaveAttribute(
+        'data-test-subj',
+        'euiTreeViewButton-first-tree'
+      );
+    });
+  });
+
+  describe('DOM and accessibility semantics', () => {
+    test('uses list markup, button controls, and root-only instructions', () => {
+      const items = getCharacterizationItems();
+      items[0].isExpanded = true;
+      const { container, getAllByRole, getByRole, getByText } = render(
+        <EuiTreeView items={items} id="tree" aria-label="Tree" />
+      );
+
+      const lists = getAllByRole('list');
+      expect(lists).toHaveLength(2);
+      expect(lists[0]).toHaveAttribute('id', 'tree');
+      expect(lists[0]).toHaveAttribute('aria-describedby', 'tree--instruction');
+      expect(lists[1]).not.toHaveAttribute('id');
+      expect(lists[1]).not.toHaveAttribute('aria-describedby');
+      expect(getAllByRole('listitem')).toHaveLength(5);
+      expect(getAllByRole('button')).toHaveLength(5);
+      expect(getByText(/quickly navigate/)).toHaveAttribute(
+        'id',
+        'tree--instruction'
+      );
+      expect(container.querySelectorAll('#tree--instruction')).toHaveLength(1);
+      expect(container.querySelector('[role="tree"]')).not.toBeInTheDocument();
+      expect(
+        container.querySelector('[role="treeitem"]')
+      ).not.toBeInTheDocument();
+      expect(container.querySelector('[role="group"]')).not.toBeInTheDocument();
+
+      const branch = getByRole('button', { name: 'Branch One' });
+      const childWrapper = document.getElementById(
+        branch.getAttribute('aria-controls')!
+      );
+      expect(branch).toHaveAttribute('aria-expanded', 'true');
+      expect(childWrapper?.tagName).toBe('DIV');
+
+      const controlIds = getAllByRole('button')
+        .map((button) => button.getAttribute('aria-controls'))
+        .filter((id): id is string => id !== null);
+      expect(new Set(controlIds).size).toBe(controlIds.length);
+      expect(controlIds).not.toContain('tree');
+      expect(controlIds).not.toContain('tree--instruction');
+
+      const leaf = getByRole('button', { name: 'Root Leaf' });
+      expect(leaf).not.toHaveAttribute('aria-expanded');
+      expect(leaf).not.toHaveAttribute('aria-controls');
+      expect(leaf).not.toHaveAttribute('tabindex');
+    });
   });
 });

--- a/packages/eui/src/components/tree_view/tree_view.tsx
+++ b/packages/eui/src/components/tree_view/tree_view.tsx
@@ -7,19 +7,17 @@
  */
 
 import React, {
-  Component,
   HTMLAttributes,
   createContext,
-  ContextType,
+  forwardRef,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
 } from 'react';
 import classNames from 'classnames';
 
-import {
-  withEuiTheme,
-  WithEuiThemeProps,
-  keys,
-  htmlIdGenerator,
-} from '../../services';
+import { keys, htmlIdGenerator, useEuiTheme } from '../../services';
 import { CommonProps } from '../common';
 import { EuiI18n } from '../i18n';
 import { EuiScreenReaderOnly } from '../accessibility';
@@ -75,13 +73,6 @@ export interface Node {
 
 export type EuiTreeViewDisplayOptions = 'default' | 'compressed';
 
-interface EuiTreeViewState {
-  openItems: string[];
-  activeItem: string;
-  treeID: string;
-  expandChildNodes: boolean;
-}
-
 export type CommonTreeProps = CommonProps &
   HTMLAttributes<HTMLUListElement> & {
     /**
@@ -114,171 +105,157 @@ export type EuiTreeViewProps = Omit<
 > &
   ({ 'aria-label': string } | { 'aria-labelledby': string });
 
-export class EuiTreeViewClass extends Component<
-  EuiTreeViewProps & WithEuiThemeProps,
-  EuiTreeViewState
-> {
-  treeIdGenerator = htmlIdGenerator('euiTreeView');
-
-  static contextType = EuiTreeViewContext;
-  declare context: ContextType<typeof EuiTreeViewContext>;
-
-  isNested: boolean;
-
-  constructor(
-    props: EuiTreeViewProps & WithEuiThemeProps,
-    // Without the optional ? typing, TS will throw errors on JSX component errors
-    // @see https://github.com/facebook/react/issues/13944#issuecomment-1183693239
-    context?: ContextType<typeof EuiTreeViewContext>
-  ) {
-    // TODO: context in constructor has been deprecated.
-    // We should likely convert this to a function component
-    super(props, context);
-
-    this.isNested = !!this.context;
-    this.state = {
-      openItems: this.props.expandByDefault
-        ? this.props.items
-            .map<string>(({ id, children }) =>
-              children ? id : (null as unknown as string)
-            )
-            .filter((x) => x != null)
-        : this.props.items
-            .map<string>(({ id, children, isExpanded }) =>
-              children && isExpanded ? id : (null as unknown as string)
-            )
-            .filter((x) => x != null),
-      activeItem: '',
-      treeID: getTreeId(this.props.id, context, this.treeIdGenerator),
-      expandChildNodes: this.props.expandByDefault || false,
-    };
-  }
-
-  componentDidUpdate(prevProps: EuiTreeViewProps) {
-    if (this.props.id !== prevProps.id) {
-      this.setState({
-        treeID: getTreeId(this.props.id, this.context, this.treeIdGenerator),
-      });
-    }
-  }
-
-  buttonRef: Array<HTMLButtonElement | undefined> = [];
-
-  setButtonRef = (
-    ref: HTMLButtonElement | HTMLAnchorElement | null,
-    index: number
-  ) => {
-    this.buttonRef[index] = ref as HTMLButtonElement;
-  };
-
-  handleNodeClick = (node: Node, ignoreCallback: boolean = false) => {
-    const index = this.state.openItems.indexOf(node.id);
-
-    this.setState({
-      expandChildNodes: false,
-    });
-
-    node.isExpanded = !node.isExpanded;
-
-    if (!ignoreCallback && node.callback !== undefined) {
-      node.callback();
-    }
-
-    if (this.isNodeOpen(node)) {
-      // if the node is part of openItems[] then remove it
-      this.setState({
-        openItems: this.state.openItems.filter((_, i) => i !== index),
-      });
-    } else {
-      // if the node isn't part of openItems[] then add it
-      this.setState((prevState) => ({
-        openItems: [...prevState.openItems, node.id],
-        activeItem: node.id,
-      }));
-    }
-  };
-
-  // check if the node is included in openItems[]
-  isNodeOpen = (node: Node) => {
-    return this.state.openItems.includes(node.id);
-  };
-
-  // Enable keyboard navigation
-  onKeyDown = (event: React.KeyboardEvent, node: Node) => {
-    switch (event.key) {
-      case keys.ARROW_DOWN: {
-        const nodeButtons = Array.from(
-          document.querySelectorAll(
-            `[data-test-subj="euiTreeViewButton-${this.state.treeID}"]`
-          )
-        );
-        const currentIndex = nodeButtons.indexOf(event.currentTarget);
-        if (currentIndex > -1) {
-          const nextButton = nodeButtons[currentIndex + 1] as HTMLElement;
-          if (nextButton) {
-            event.preventDefault();
-            event.stopPropagation();
-            nextButton.focus();
-          }
-        }
-        break;
-      }
-      case keys.ARROW_UP: {
-        const nodeButtons = Array.from(
-          document.querySelectorAll(
-            `[data-test-subj="euiTreeViewButton-${this.state.treeID}"]`
-          )
-        );
-        const currentIndex = nodeButtons.indexOf(event.currentTarget);
-        if (currentIndex > -1) {
-          const prevButton = nodeButtons[currentIndex + -1] as HTMLElement;
-          if (prevButton) {
-            event.preventDefault();
-            event.stopPropagation();
-            prevButton.focus();
-          }
-        }
-        break;
-      }
-      case keys.ARROW_RIGHT: {
-        if (!this.isNodeOpen(node)) {
-          event.preventDefault();
-          event.stopPropagation();
-          this.handleNodeClick(node, true);
-        }
-        break;
-      }
-      case keys.ARROW_LEFT: {
-        if (this.isNodeOpen(node)) {
-          event.preventDefault();
-          event.stopPropagation();
-          this.handleNodeClick(node, true);
-        }
-      }
-      default:
-        break;
-    }
-  };
-
-  onChildrenKeydown = (event: React.KeyboardEvent, index: number) => {
-    if (event.key === keys.ARROW_LEFT) {
-      event.preventDefault();
-      event.stopPropagation();
-      this.buttonRef[index]!.focus();
-    }
-  };
-
-  render() {
-    const {
+const EuiTreeViewComponent = forwardRef<HTMLUListElement, CommonTreeProps>(
+  (
+    {
       children,
       className,
       items,
       display = 'default',
       expandByDefault,
       showExpansionArrows,
-      theme,
+      id,
       ...rest
-    } = this.props;
+    },
+    ref
+  ) => {
+    const contextId = useContext(EuiTreeViewContext);
+    const isNested = useRef(!!contextId).current;
+    const theme = useEuiTheme();
+
+    const treeIdGeneratorRef = useRef<
+      ReturnType<typeof htmlIdGenerator> | undefined
+    >(undefined);
+    if (treeIdGeneratorRef.current === undefined) {
+      treeIdGeneratorRef.current = htmlIdGenerator('euiTreeView');
+    }
+    const treeIdGenerator = treeIdGeneratorRef.current;
+
+    const [openItems, setOpenItems] = useState<string[]>(() =>
+      expandByDefault
+        ? items
+            .map<string>(({ id, children }) =>
+              children ? id : (null as unknown as string)
+            )
+            .filter((x) => x != null)
+        : items
+            .map<string>(({ id, children, isExpanded }) =>
+              children && isExpanded ? id : (null as unknown as string)
+            )
+            .filter((x) => x != null)
+    );
+    const [activeItem, setActiveItem] = useState('');
+    const [treeID, setTreeID] = useState(() =>
+      getTreeId(id, contextId, treeIdGenerator)
+    );
+    const [expandChildNodes, setExpandChildNodes] = useState(
+      expandByDefault || false
+    );
+    const previousId = useRef(id);
+
+    useEffect(() => {
+      if (id !== previousId.current) {
+        previousId.current = id;
+        setTreeID(getTreeId(id, contextId, treeIdGenerator));
+      }
+    }, [contextId, id, treeIdGenerator]);
+
+    const buttonRef = useRef<Array<HTMLButtonElement | undefined>>([]);
+
+    const setButtonRef = (
+      ref: HTMLButtonElement | HTMLAnchorElement | null,
+      index: number
+    ) => {
+      buttonRef.current[index] = ref as HTMLButtonElement;
+    };
+
+    const isNodeOpen = (node: Node) => openItems.includes(node.id);
+
+    const handleNodeClick = (node: Node, ignoreCallback: boolean = false) => {
+      const index = openItems.indexOf(node.id);
+
+      setExpandChildNodes(false);
+
+      node.isExpanded = !node.isExpanded;
+
+      if (!ignoreCallback && node.callback !== undefined) {
+        node.callback();
+      }
+
+      if (isNodeOpen(node)) {
+        // if the node is part of openItems[] then remove it
+        setOpenItems(openItems.filter((_, i) => i !== index));
+      } else {
+        // if the node isn't part of openItems[] then add it
+        setOpenItems((prevOpenItems) => [...prevOpenItems, node.id]);
+        setActiveItem(node.id);
+      }
+    };
+
+    // Enable keyboard navigation
+    const onKeyDown = (event: React.KeyboardEvent, node: Node) => {
+      switch (event.key) {
+        case keys.ARROW_DOWN: {
+          const nodeButtons = Array.from(
+            document.querySelectorAll(
+              `[data-test-subj="euiTreeViewButton-${treeID}"]`
+            )
+          );
+          const currentIndex = nodeButtons.indexOf(event.currentTarget);
+          if (currentIndex > -1) {
+            const nextButton = nodeButtons[currentIndex + 1] as HTMLElement;
+            if (nextButton) {
+              event.preventDefault();
+              event.stopPropagation();
+              nextButton.focus();
+            }
+          }
+          break;
+        }
+        case keys.ARROW_UP: {
+          const nodeButtons = Array.from(
+            document.querySelectorAll(
+              `[data-test-subj="euiTreeViewButton-${treeID}"]`
+            )
+          );
+          const currentIndex = nodeButtons.indexOf(event.currentTarget);
+          if (currentIndex > -1) {
+            const prevButton = nodeButtons[currentIndex + -1] as HTMLElement;
+            if (prevButton) {
+              event.preventDefault();
+              event.stopPropagation();
+              prevButton.focus();
+            }
+          }
+          break;
+        }
+        case keys.ARROW_RIGHT: {
+          if (!isNodeOpen(node)) {
+            event.preventDefault();
+            event.stopPropagation();
+            handleNodeClick(node, true);
+          }
+          break;
+        }
+        case keys.ARROW_LEFT: {
+          if (isNodeOpen(node)) {
+            event.preventDefault();
+            event.stopPropagation();
+            handleNodeClick(node, true);
+          }
+        }
+        default:
+          break;
+      }
+    };
+
+    const onChildrenKeydown = (event: React.KeyboardEvent, index: number) => {
+      if (event.key === keys.ARROW_LEFT) {
+        event.preventDefault();
+        event.stopPropagation();
+        buttonRef.current[index]!.focus();
+      }
+    };
 
     const styles = euiTreeViewStyles(theme);
     const cssStyles = [styles.euiTreeView, styles[display]];
@@ -286,11 +263,11 @@ export class EuiTreeViewClass extends Component<
     // Computed classNames
     const classes = classNames('euiTreeView', className);
 
-    const instructionsId = `${this.state.treeID}--instruction`;
+    const instructionsId = `${treeID}--instruction`;
 
     return (
-      <EuiTreeViewContext.Provider value={this.state.treeID}>
-        {!this.isNested && (
+      <EuiTreeViewContext.Provider value={treeID}>
+        {!isNested && (
           <EuiI18n
             token="euiTreeView.listNavigationInstructions"
             default="You can quickly navigate this list using arrow keys."
@@ -304,19 +281,18 @@ export class EuiTreeViewClass extends Component<
         )}
         {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
         <ul
+          ref={ref}
           css={cssStyles}
           className={classes}
-          id={!this.isNested ? this.state.treeID : undefined}
-          aria-describedby={!this.isNested ? instructionsId : undefined}
+          id={!isNested ? treeID : undefined}
+          aria-describedby={!isNested ? instructionsId : undefined}
           role="list" // VoiceOver doesn't parse lists with `list-style: none` as the correct role - @see https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
           {...rest}
         >
           {items.map((node, index) => {
             const buttonId = node.id;
-            const wrappingId = this.treeIdGenerator(buttonId);
-            const isNodeExpanded = node.children
-              ? this.isNodeOpen(node)
-              : undefined; // Determines the `aria-expanded` attribute
+            const wrappingId = treeIdGenerator(buttonId);
+            const isNodeExpanded = node.children ? isNodeOpen(node) : undefined; // Determines the `aria-expanded` attribute
 
             let icon = node.icon;
             if (node.iconWhenExpanded && isNodeExpanded) {
@@ -331,33 +307,33 @@ export class EuiTreeViewClass extends Component<
                 id={buttonId}
                 className={node.className}
                 css={node.css}
-                buttonRef={(ref) => this.setButtonRef(ref, index)}
+                buttonRef={(ref) => setButtonRef(ref, index)}
                 aria-controls={node.children ? wrappingId : undefined}
                 label={node.label}
                 icon={icon}
                 hasArrow={showExpansionArrows}
                 isExpanded={isNodeExpanded}
-                isActive={this.state.activeItem === node.id}
+                isActive={activeItem === node.id}
                 display={display}
-                data-test-subj={`euiTreeViewButton-${this.state.treeID}`}
+                data-test-subj={`euiTreeViewButton-${treeID}`}
                 onKeyDown={(event: React.KeyboardEvent) =>
-                  this.onKeyDown(event, node)
+                  onKeyDown(event, node)
                 }
-                onClick={() => this.handleNodeClick(node)}
+                onClick={() => handleNodeClick(node)}
               >
                 {node.children && (
                   <div
                     id={wrappingId}
                     onKeyDown={(event: React.KeyboardEvent) =>
-                      this.onChildrenKeydown(event, index)
+                      onChildrenKeydown(event, index)
                     }
                   >
                     {isNodeExpanded && (
-                      <EuiTreeView
+                      <EuiTreeViewComponent
                         items={node.children}
                         display={display}
                         showExpansionArrows={showExpansionArrows}
-                        expandByDefault={this.state.expandChildNodes}
+                        expandByDefault={expandChildNodes}
                       />
                     )}
                   </div>
@@ -369,12 +345,18 @@ export class EuiTreeViewClass extends Component<
       </EuiTreeViewContext.Provider>
     );
   }
-}
+);
+
+const EuiTreeViewPublicComponent =
+  EuiTreeViewComponent as React.ForwardRefExoticComponent<
+    EuiTreeViewProps & React.RefAttributes<HTMLUListElement>
+  >;
+
+EuiTreeViewComponent.displayName = 'EuiTreeView';
 
 /**
  * @see {@link https://eui.elastic.co/docs/components/navigation/tree-view/|EuiTreeView documentation}
  */
-export const EuiTreeView = Object.assign(
-  withEuiTheme<EuiTreeViewProps>(EuiTreeViewClass),
-  { Item: EuiTreeViewItem }
-);
+export const EuiTreeView = Object.assign(EuiTreeViewPublicComponent, {
+  Item: EuiTreeViewItem,
+});


### PR DESCRIPTION
## Summary

Migrates `EuiTreeView` from a class component to a function component.

- Replaces class state and lifecycle logic with React hooks.
- Replaces `withEuiTheme` with `useEuiTheme`.
- Preserves the existing uncontrolled expansion behavior, keyboard navigation, focus behavior, recursive state, IDs, DOM structure, and ARIA semantics.
- Preserves `EuiTreeView.Item`.
- Removes `EuiTreeViewClass`, as discussed in #9496.
- Preserves ref support by forwarding refs to the root `<ul>`.
- Adds regression coverage for expansion state, IDs, recursion, keyboard navigation, focus, callbacks, and refs.

Closes #9496.

## Compatibility

Current Kibana `main` was audited for `EuiTreeView` usage.

- No `EuiTreeViewClass` consumers were found.
- No `EuiTreeView` ref consumers were found.
- Existing uses of `expandByDefault`, `isExpanded`, callbacks, `Node`, DOM/classes, and `EuiTreeView.Item` remain compatible.

No source-breaking Kibana usage was identified.

## Testing

- Jest React 18: 18 tests passed
- Jest React 17: 18 tests passed
- Cypress React 18: 12 tests passed
- Cypress React 17: 12 tests passed
- Axe: 2 tests passed, 0 violations
- TypeScript passed
- Storybook TypeScript passed
- ESLint passed with no errors
- `git diff --check` passed
- Full `yarn pre-push` passed
- No snapshots changed

## Screenshots

No visual changes are expected.

The migrated component was manually validated in Storybook for mouse interaction, nested expansion, `expandByDefault`, expansion arrows, keyboard navigation, and focus behavior.