### PR TITLE
[test-helpers] Add EuiBasicTableObject

### DIFF
--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -51,6 +51,7 @@ their own version at runtime.
 | `EuiSuperSelectObject` | [src/components/form/super_select/README.md](src/components/form/super_select/README.md) |
 | `EuiGlobalToastListObject` | [src/components/toast/README.md](src/components/toast/README.md) |
 | `EuiSelectableObject` | [src/components/selectable/README.md](src/components/selectable/README.md) |
+| `EuiBasicTableObject` | [src/components/basic_table/README.md](src/components/basic_table/README.md) |
 
 ## Contributing
 

--- a/packages/test-helpers/changelogs/upcoming/9933.md
+++ b/packages/test-helpers/changelogs/upcoming/9933.md
@@ -1,0 +1,1 @@
+- Added `EuiBasicTableObject` with `rows` and `cells(field)`

--- a/packages/test-helpers/src/components/basic_table/README.md
+++ b/packages/test-helpers/src/components/basic_table/README.md
@@ -1,0 +1,30 @@
+# EuiBasicTableObject
+
+Playwright Component Object for [EuiBasicTable](https://eui.elastic.co/docs/components/tabular-content/tables/). Also covers `EuiInMemoryTable`, which renders a `EuiBasicTable` underneath and passes the `data-test-subj` straight through — there is no separate object for it.
+
+## Usage
+
+```ts
+import { EuiBasicTableObject } from '@elastic/eui-test-helpers';
+
+const table = new EuiBasicTableObject(page, 'myTable');
+expect(await table.rows).toHaveCount(3);
+expect(await table.cells('status')).toHaveText(['Running', 'Finished', 'Archived']);
+```
+
+Set `data-test-subj` on the `<EuiBasicTable>`/`<EuiInMemoryTable>` (EUI spreads it onto the `.euiBasicTable` root, which the component-type guard verifies).
+
+## API
+
+| Member | Description |
+|---|---|
+| `rows` | `Locator` for the table's data rows, excluding EUI's own "no items found"/error-message row. |
+| `cells(field)` | `Locator` for a field-data column's cells across all rows, resolved from EUI's own header `data-test-subj`. |
+
+`rows` excludes EUI's empty/error message row by filtering out any row whose cell carries a `colspan` — real data rows don't set one, EUI's own placeholder row always does (it spans every column).
+
+`cells(field)` resolves the column's position from the header cell EUI renders as `tableHeaderCell_<field>_<index>` (matched exactly, so a column named `status` won't also match a `status_detail` header), then reads the cell at that position in every row. This holds regardless of a leading selection-checkbox column, since the checkbox column is a real cell in both the header and body rows, and it matches both `<td>` and `<th>` since EUI renders a `rowHeader` column's body cell as `<th scope="row">`. Throws if no column with that `field` is rendered.
+
+## Deliberately excluded
+
+Row actions (consumer-supplied popovers/buttons), sorting, and pagination are not covered. They are either app-specific wiring rather than EUI-internal DOM knowledge, or had no evidenced consumer need at the time this was written. Open an issue with a concrete use case if you need one of them.

--- a/packages/test-helpers/src/components/basic_table/selectors.ts
+++ b/packages/test-helpers/src/components/basic_table/selectors.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/tabular-content/tables/|EuiBasicTable}
+ * (also covers `EuiInMemoryTable`, which renders a `EuiBasicTable` underneath).
+ * `*_SELECTOR` values are CSS.
+ */
+export const EuiBasicTableSelectors = {
+  /** Root element (the `.euiBasicTable` container carrying the consumer's `data-test-subj`). */
+  ROOT_SELECTOR: '.euiBasicTable',
+
+  /** A data row. Also matches EUI's own empty/error message row — callers must exclude those. */
+  ROW_SELECTOR: '.euiTableRow',
+
+  /**
+   * A field-data column's header cell. `%s` is the column's `field`. EUI appends a
+   * positional index (`tableHeaderCell_<field>_<index>`), so this is a prefix match.
+   */
+  HEADER_CELL_SELECTOR_PREFIX: 'tableHeaderCell_',
+};

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -12,3 +12,4 @@ export { EuiDataGridObject } from './playwright/components/datagrid/object';
 export { EuiSuperSelectObject } from './playwright/components/form/super_select/object';
 export { EuiGlobalToastListObject } from './playwright/components/toast/object';
 export { EuiSelectableObject } from './playwright/components/selectable/object';
+export { EuiBasicTableObject } from './playwright/components/basic_table/object';

--- a/packages/test-helpers/src/playwright/components/basic_table/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/basic_table/object.props.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiBasicTableObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+/**
+ * Validates `EuiBasicTableObject` against non-default configurations. The
+ * `EmptyTable` story renders zero items with a "No users found" message —
+ * EUI still renders that as a single `.euiTableRow`, so this is what proves
+ * `rows` correctly excludes it instead of reporting a count of 1.
+ */
+
+const TEST_SUBJ = 'testBasicTable';
+
+const EMPTY_TABLE_URL = storyUrl(
+  'tabular-content-euibasictable--empty-table',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiBasicTableObject (empty)', () => {
+  test('rows excludes the "no items found" placeholder row', async ({ page }) => {
+    await page.goto(EMPTY_TABLE_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    const table = new EuiBasicTableObject(page, TEST_SUBJ);
+
+    await expect(table.rows).toHaveCount(0);
+  });
+});

--- a/packages/test-helpers/src/playwright/components/basic_table/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/basic_table/object.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiBasicTableObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+/**
+ * Validates `EuiBasicTableObject` against the live component in EUI Storybook.
+ * The Playground story renders a selection checkbox column, several
+ * field-data columns, and paginates at 3 rows per page — exercising the
+ * checkbox-offset column resolution and confirming `rows` reflects only the
+ * current page. `data-test-subj` is injected via Storybook's `args` URL
+ * parameter onto the `.euiBasicTable` root.
+ */
+
+const TEST_SUBJ = 'testBasicTable';
+
+const PLAYGROUND_URL = storyUrl(
+  'tabular-content-euibasictable--playground',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiBasicTableObject', () => {
+  let table: EuiBasicTableObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    table = new EuiBasicTableObject(page, TEST_SUBJ);
+  });
+
+  test.describe('rows', () => {
+    test('exposes only the current page of data rows', async () => {
+      // Playground paginates at 3 rows per page.
+      await expect(table.rows).toHaveCount(3);
+    });
+  });
+
+  test.describe('cells', () => {
+    test('reads a field-data column past the leading selection checkbox', async () => {
+      const cells = await table.cells('firstName');
+
+      await expect(cells).toHaveCount(3);
+    });
+
+    test('reads a different field-data column correctly (not off-by-one)', async () => {
+      const firstNameCells = await table.cells('firstName');
+      const lastNameCells = await table.cells('lastName');
+
+      const [firstNames, lastNames] = await Promise.all([
+        firstNameCells.allTextContents(),
+        lastNameCells.allTextContents(),
+      ]);
+
+      expect(firstNames).not.toEqual(lastNames);
+    });
+
+    test('rejects an unknown field', async () => {
+      await expect(table.cells('doesNotExist')).rejects.toThrow(/no column with field/);
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/basic_table/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/basic_table/object.spec.ts
@@ -65,5 +65,12 @@ test.describe('EuiBasicTableObject', () => {
     test('rejects an unknown field', async () => {
       await expect(table.cells('doesNotExist')).rejects.toThrow(/no column with field/);
     });
+
+    test('the rejection message includes the original field, not an escaped regex', async () => {
+      // "a.b" contains a regex-special character the implementation escapes
+      // internally for matching — the error message must surface the field
+      // as the caller passed it, not the escaped pattern used internally.
+      await expect(table.cells('a.b')).rejects.toThrow('"a.b"');
+    });
   });
 });

--- a/packages/test-helpers/src/playwright/components/basic_table/object.ts
+++ b/packages/test-helpers/src/playwright/components/basic_table/object.ts
@@ -57,11 +57,18 @@ export class EuiBasicTableObject extends BaseObject {
    * renders the `rowHeader` column's body cell as a `<th scope="row">` for
    * accessibility, not a `<td>`. Throws if no column with that `field` is
    * rendered.
+   *
+   * EUI generates a computed column's header test-subj from its `name` using
+   * this exact same `tableHeaderCell_<name>_<index>` shape (there's no `field`
+   * to key on), so a computed column whose `name` happens to equal another
+   * column's `field` can resolve ambiguously — this method can't distinguish
+   * the two from the DOM alone. Not expected in practice; call it out if you
+   * hit it.
    */
   async cells(field: string): Promise<Locator> {
     const escaped = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const cellIndex = await this.root.evaluate(
-      (tableEl, { prefix, pattern }) => {
+      (tableEl, { prefix, pattern, field: originalField }) => {
         const regex = new RegExp(`^${prefix}${pattern}_\\d+$`);
         const headers = Array.from(tableEl.querySelectorAll('thead th, thead td'));
         const header = headers.find((el) =>
@@ -69,12 +76,12 @@ export class EuiBasicTableObject extends BaseObject {
         ) as HTMLTableCellElement | undefined;
         if (!header) {
           throw new Error(
-            `EuiBasicTableObject.cells: no column with field "${pattern}" found in this table's header.`
+            `EuiBasicTableObject.cells: no column with field "${originalField}" found in this table's header.`
           );
         }
         return header.cellIndex;
       },
-      { prefix: EuiBasicTableSelectors.HEADER_CELL_SELECTOR_PREFIX, pattern: escaped }
+      { prefix: EuiBasicTableSelectors.HEADER_CELL_SELECTOR_PREFIX, pattern: escaped, field }
     );
     return this.rows.locator(`:is(td, th):nth-child(${cellIndex + 1})`);
   }

--- a/packages/test-helpers/src/playwright/components/basic_table/object.ts
+++ b/packages/test-helpers/src/playwright/components/basic_table/object.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiBasicTableSelectors } from '../../../components/basic_table/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/tabular-content/tables/ EuiBasicTable}
+ * (also covers `EuiInMemoryTable`, which renders a `EuiBasicTable` underneath and
+ * passes the `data-test-subj` straight through — there is no separate object for it).
+ *
+ * `testSubj` must match the `data-test-subj` set by the consumer on the
+ * `<EuiBasicTable>`/`<EuiInMemoryTable>` (EUI spreads it onto the `.euiBasicTable`
+ * root).
+ *
+ * Deliberately minimal: only {@link rows} and {@link cells} are exposed. Row
+ * actions (consumer-supplied popovers/buttons), sorting, and pagination are not
+ * covered — they are either app-specific wiring rather than EUI-internal DOM
+ * knowledge, or have no evidenced consumer need yet. Open an issue if you have a
+ * real use case one of those would resolve.
+ */
+export class EuiBasicTableObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiBasicTableSelectors.ROOT_SELECTOR);
+  }
+
+  /**
+   * The table's data rows, as a `Locator` so callers keep Playwright auto-retry
+   * for count and content assertions (e.g. `expect(table.rows).toHaveCount(3)`).
+   *
+   * Excludes EUI's own "no items found" (and error-message) row: when the table
+   * is empty, EUI still renders a single `.euiTableRow` whose one cell spans
+   * every column (`colSpan` on `EuiTableRowCell`, the `td[colspan]` HTML
+   * attribute). Real data rows don't set `colspan` on their cells, so filtering
+   * it out is what keeps `toHaveCount(0)` correct on an empty table instead of
+   * reading `1`.
+   */
+  public get rows(): Locator {
+    return this.root
+      .locator(EuiBasicTableSelectors.ROW_SELECTOR)
+      .filter({ hasNot: this.root.page().locator('td[colspan]') });
+  }
+
+  /**
+   * The cells of the given field-data column, one per row, as a `Locator` for
+   * retrying content/count assertions (e.g.
+   * `expect(await table.cells('status')).toHaveText(['Running'])`).
+   *
+   * Resolves the column's position from EUI's own header cell
+   * (`tableHeaderCell_<field>_<index>`, matched exactly so a column named e.g.
+   * `status` doesn't also match a `status_detail` header) via its native
+   * `cellIndex`, then reads the cell at that position in every row — the same
+   * positional alignment EUI itself relies on, so it holds regardless of a
+   * leading selection-checkbox column. Matches both `<td>` and `<th>`: EUI
+   * renders the `rowHeader` column's body cell as a `<th scope="row">` for
+   * accessibility, not a `<td>`. Throws if no column with that `field` is
+   * rendered.
+   */
+  async cells(field: string): Promise<Locator> {
+    const escaped = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const cellIndex = await this.root.evaluate(
+      (tableEl, { prefix, pattern }) => {
+        const regex = new RegExp(`^${prefix}${pattern}_\\d+$`);
+        const headers = Array.from(tableEl.querySelectorAll('thead th, thead td'));
+        const header = headers.find((el) =>
+          regex.test(el.getAttribute('data-test-subj') ?? '')
+        ) as HTMLTableCellElement | undefined;
+        if (!header) {
+          throw new Error(
+            `EuiBasicTableObject.cells: no column with field "${pattern}" found in this table's header.`
+          );
+        }
+        return header.cellIndex;
+      },
+      { prefix: EuiBasicTableSelectors.HEADER_CELL_SELECTOR_PREFIX, pattern: escaped }
+    );
+    return this.rows.locator(`:is(td, th):nth-child(${cellIndex + 1})`);
+  }
+}

--- a/packages/test-helpers/src/playwright/components/basic_table/object.ts
+++ b/packages/test-helpers/src/playwright/components/basic_table/object.ts
@@ -19,13 +19,7 @@ import { EuiBasicTableSelectors } from '../../../components/basic_table/selector
  *
  * `testSubj` must match the `data-test-subj` set by the consumer on the
  * `<EuiBasicTable>`/`<EuiInMemoryTable>` (EUI spreads it onto the `.euiBasicTable`
- * root).
- *
- * Deliberately minimal: only {@link rows} and {@link cells} are exposed. Row
- * actions (consumer-supplied popovers/buttons), sorting, and pagination are not
- * covered — they are either app-specific wiring rather than EUI-internal DOM
- * knowledge, or have no evidenced consumer need yet. Open an issue if you have a
- * real use case one of those would resolve.
+ * root). See the package README for what's deliberately excluded from v1.
  */
 export class EuiBasicTableObject extends BaseObject {
   constructor(scope: ObjectScope, testSubj: string) {


### PR DESCRIPTION
## Summary

Adds `EuiBasicTableObject`, a Playwright Component Object for `EuiBasicTable` (also covers `EuiInMemoryTable`, which renders a `EuiBasicTable` underneath and passes `data-test-subj` straight through), following the package's [CONTRIBUTING guide](https://github.com/elastic/eui/blob/main/packages/test-helpers/CONTRIBUTING.md).

Prototyped and validated against a real Kibana consumer first per the guide's lifecycle. Kibana PR: https://github.com/elastic/kibana/pull/285999 (CI green, 8/8 + 24/24 on a repeat-3 flake check).

## API

Deliberately minimal, per the package's "minimal public API" principle — only what the validating consumer (a maintenance windows table) actually needed:

- `rows`: a `Locator` for the table's data rows, excluding EUI's own "no items found"/error-message row (detected via the `colspan` HTML attribute EUI sets on that row's single cell — real data rows don't set it).
- `cells(field)`: a `Locator` for a field-data column's cells across all rows, resolved from EUI's own header test-subj (`tableHeaderCell_<field>_<digits>`, matched exactly to avoid a `status`/`status_detail`-style collision) via the header's native `cellIndex`, then read positionally — matches both `<td>` and `<th>` since a `rowHeader` column renders as `<th scope="row">`.

Both return `Locator`s rather than value snapshots, so callers get retrying assertions for free.

## Deliberately excluded from v1

- **Row actions**: app-supplied test-subjs from a custom-rendered column in the validating consumer, not EUI-internal DOM.
- **Sorting**: no evidenced Scout consumer sorts a table yet.
- **Pagination**: the one candidate consumer is closer to testing EUI's own pagination through the app than app behavior, and its test-subjs are already stable/EUI-owned.

## Testing

`tsc --noEmit` clean. Playwright validation specs pass against Storybook (`Tabular Content/EuiBasicTable` Playground + EmptyTable stories): 5/5, covering checkbox-offset column resolution, the `rowHeader`/`<th>` case (caught a real off-by-selector-tag bug during authoring — fixed), the empty-state row exclusion, and an unknown-field rejection.