### PR TITLE
[EuiFlyout] Keep body accessible at short viewport heights

### DIFF
--- a/packages/eui/changelogs/upcoming/9944.md
+++ b/packages/eui/changelogs/upcoming/9944.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiFlyoutBody` content becoming inaccessible at short viewport heights

--- a/packages/eui/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
+++ b/packages/eui/src/components/collapsible_nav/__snapshots__/collapsible_nav.test.tsx.snap
@@ -43,6 +43,10 @@ exports[`EuiCollapsibleNav close button can be hidden 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
     </nav>
   </div>
   <div
@@ -100,6 +104,10 @@ exports[`EuiCollapsibleNav is rendered 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
     </nav>
   </div>
   <div
@@ -150,6 +158,10 @@ exports[`EuiCollapsibleNav props accepts EuiFlyout props 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
     </nav>
   </div>
   <div
@@ -208,6 +220,10 @@ exports[`EuiCollapsibleNav props button 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
     </nav>
   </div>
   <div
@@ -261,6 +277,10 @@ exports[`EuiCollapsibleNav props dockedBreakpoint 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
     </nav>
   </div>
   <div
@@ -285,7 +305,12 @@ exports[`EuiCollapsibleNav props isDocked 1`] = `
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
       id="id"
       style="inline-size: 320px; z-index: 1000;"
-    />
+    >
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
+    </nav>
   </div>
   <div
     data-focus-guard="true"
@@ -338,6 +363,10 @@ exports[`EuiCollapsibleNav props onClose 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
     </nav>
   </div>
   <div
@@ -367,7 +396,12 @@ exports[`EuiCollapsibleNav props showButtonIfDocked 1`] = `
       class="euiFlyout euiCollapsibleNav emotion-euiFlyout-none-noMaxWidth-push-left-noAnimation-left-euiCollapsibleNav-push"
       id="id"
       style="inline-size: 320px; z-index: 1000;"
-    />
+    >
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
+    </nav>
   </div>
   <div
     data-focus-guard="true"
@@ -420,6 +454,10 @@ exports[`EuiCollapsibleNav props size 1`] = `
           data-euiicon-type="cross"
         />
       </button>
+      <div
+        class="euiFlyout__content css-113dg8o-content"
+        data-test-subj="euiFlyoutContent"
+      />
     </nav>
   </div>
   <div

--- a/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`EuiFlyout is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -109,7 +109,7 @@ exports[`EuiFlyout props accepts div props 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -169,7 +169,7 @@ exports[`EuiFlyout props closeButtonPosition can be outside 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -229,7 +229,7 @@ exports[`EuiFlyout props closeButtonProps 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -276,7 +276,7 @@ exports[`EuiFlyout props hideCloseButton 1`] = `
            
         </p>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -337,7 +337,7 @@ exports[`EuiFlyout props is rendered as nav 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </nav>
@@ -398,7 +398,7 @@ exports[`EuiFlyout props maxWidth can be set to a custom number 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -459,7 +459,7 @@ exports[`EuiFlyout props maxWidth can be set to a custom value and measurement 1
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -520,7 +520,7 @@ exports[`EuiFlyout props maxWidth can be set to a default 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -581,7 +581,7 @@ exports[`EuiFlyout props outsideClickCloses 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -642,7 +642,7 @@ exports[`EuiFlyout props ownFocus can alter mask props with maskProps without th
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -700,7 +700,7 @@ exports[`EuiFlyout props ownFocus can be false 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -761,7 +761,7 @@ exports[`EuiFlyout props paddingSize l is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -822,7 +822,7 @@ exports[`EuiFlyout props paddingSize m is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -883,7 +883,7 @@ exports[`EuiFlyout props paddingSize none is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -944,7 +944,7 @@ exports[`EuiFlyout props paddingSize s is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -978,7 +978,7 @@ exports[`EuiFlyout props push flyouts renders 1`] = `
     />
   </button>
   <div
-    class="euiFlyout__content css-1kuti6u-content"
+    class="euiFlyout__content css-113dg8o-content"
     data-test-subj="euiFlyoutContent"
   />
 </div>
@@ -1030,7 +1030,7 @@ exports[`EuiFlyout props sides left is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -1090,7 +1090,7 @@ exports[`EuiFlyout props sides right is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -1151,7 +1151,7 @@ exports[`EuiFlyout props size accepts custom number 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -1212,7 +1212,7 @@ exports[`EuiFlyout props size fill is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -1273,7 +1273,7 @@ exports[`EuiFlyout props size l is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -1334,7 +1334,7 @@ exports[`EuiFlyout props size m is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -1395,7 +1395,7 @@ exports[`EuiFlyout props size s is rendered 1`] = `
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>
@@ -1463,7 +1463,7 @@ exports[`EuiFlyout renders extra screen reader instructions when fixed EuiHeader
           />
         </button>
         <div
-          class="euiFlyout__content css-1kuti6u-content"
+          class="euiFlyout__content css-113dg8o-content"
           data-test-subj="euiFlyoutContent"
         />
       </div>

--- a/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
+++ b/packages/eui/src/components/flyout/__snapshots__/flyout.test.tsx.snap
@@ -47,6 +47,10 @@ exports[`EuiFlyout is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -104,6 +108,10 @@ exports[`EuiFlyout props accepts div props 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -160,6 +168,10 @@ exports[`EuiFlyout props closeButtonPosition can be outside 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -216,6 +228,10 @@ exports[`EuiFlyout props closeButtonProps 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -259,6 +275,10 @@ exports[`EuiFlyout props hideCloseButton 1`] = `
           You are in a modal dialog. Press Escape or tap/click outside the dialog on the shadowed overlay to close.
            
         </p>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -316,6 +336,10 @@ exports[`EuiFlyout props is rendered as nav 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </nav>
     </div>
     <div
@@ -373,6 +397,10 @@ exports[`EuiFlyout props maxWidth can be set to a custom number 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -430,6 +458,10 @@ exports[`EuiFlyout props maxWidth can be set to a custom value and measurement 1
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -487,6 +519,10 @@ exports[`EuiFlyout props maxWidth can be set to a default 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -544,6 +580,10 @@ exports[`EuiFlyout props outsideClickCloses 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -601,6 +641,10 @@ exports[`EuiFlyout props ownFocus can alter mask props with maskProps without th
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -655,6 +699,10 @@ exports[`EuiFlyout props ownFocus can be false 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -712,6 +760,10 @@ exports[`EuiFlyout props paddingSize l is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -769,6 +821,10 @@ exports[`EuiFlyout props paddingSize m is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -826,6 +882,10 @@ exports[`EuiFlyout props paddingSize none is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -883,6 +943,10 @@ exports[`EuiFlyout props paddingSize s is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -913,6 +977,10 @@ exports[`EuiFlyout props push flyouts renders 1`] = `
       data-euiicon-type="cross"
     />
   </button>
+  <div
+    class="euiFlyout__content css-1kuti6u-content"
+    data-test-subj="euiFlyoutContent"
+  />
 </div>
 `;
 
@@ -961,6 +1029,10 @@ exports[`EuiFlyout props sides left is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -1017,6 +1089,10 @@ exports[`EuiFlyout props sides right is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -1074,6 +1150,10 @@ exports[`EuiFlyout props size accepts custom number 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -1131,6 +1211,10 @@ exports[`EuiFlyout props size fill is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -1188,6 +1272,10 @@ exports[`EuiFlyout props size l is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -1245,6 +1333,10 @@ exports[`EuiFlyout props size m is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -1302,6 +1394,10 @@ exports[`EuiFlyout props size s is rendered 1`] = `
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div
@@ -1366,6 +1462,10 @@ exports[`EuiFlyout renders extra screen reader instructions when fixed EuiHeader
             data-euiicon-type="cross"
           />
         </button>
+        <div
+          class="euiFlyout__content css-1kuti6u-content"
+          data-test-subj="euiFlyoutContent"
+        />
       </div>
     </div>
     <div

--- a/packages/eui/src/components/flyout/flyout.component.tsx
+++ b/packages/eui/src/components/flyout/flyout.component.tsx
@@ -1156,7 +1156,13 @@ export const EuiFlyoutComponent = forwardRef(
                 onKeyDown={onKeyDownResizableButton}
               />
             )}
-            <EuiFlyoutParentProvider>{children}</EuiFlyoutParentProvider>
+            <div
+              className="euiFlyout__content"
+              css={styles.content}
+              data-test-subj="euiFlyoutContent"
+            >
+              <EuiFlyoutParentProvider>{children}</EuiFlyoutParentProvider>
+            </div>
           </Element>
         </EuiFocusTrap>
       </EuiFlyoutOverlay>

--- a/packages/eui/src/components/flyout/flyout.spec.tsx
+++ b/packages/eui/src/components/flyout/flyout.spec.tsx
@@ -43,6 +43,8 @@ const childrenDefault = (
   </>
 );
 
+const shortViewport = { viewportWidth: 640, viewportHeight: 360 };
+
 const Flyout = ({
   children = childrenDefault,
   hasTrigger = false,
@@ -75,8 +77,7 @@ const Flyout = ({
 
 describe('EuiFlyout', () => {
   describe('Layout behavior', () => {
-    it('keeps the body accessible when the viewport is shorter than the flyout chrome', () => {
-      cy.viewport(640, 360);
+    it('keeps body accessible in short viewports', shortViewport, () => {
       cy.mount(
         <Flyout>
           <EuiFlyoutHeader data-test-subj="flyoutHeader">
@@ -116,7 +117,12 @@ describe('EuiFlyout', () => {
         expect($body[0].scrollHeight).to.be.greaterThan($body[0].clientHeight);
       });
       cy.get('[data-test-subj="flyoutHeader"]').should('be.visible');
-      cy.get('[data-test-subj="flyoutFooter"]').should('be.visible');
+      cy.get('[data-test-subj="flyoutFooter"]')
+        .scrollIntoView()
+        .should('be.visible');
+      cy.get('[data-test-subj="flyoutSpec"]')
+        .its('0.scrollTop')
+        .should('be.greaterThan', 0);
       cy.get('[data-test-subj="bodyAction"]')
         .scrollIntoView()
         .should('be.visible');

--- a/packages/eui/src/components/flyout/flyout.spec.tsx
+++ b/packages/eui/src/components/flyout/flyout.spec.tsx
@@ -77,6 +77,14 @@ const Flyout = ({
 
 describe('EuiFlyout', () => {
   describe('Layout behavior', () => {
+    it('does not create a scroll container for flyouts without a body', () => {
+      cy.mount(<Flyout>Flyout content</Flyout>);
+
+      cy.get('[data-test-subj="euiFlyoutContent"]')
+        .should('have.css', 'overflow-x', 'visible')
+        .and('have.css', 'overflow-y', 'visible');
+    });
+
     it('keeps body accessible in short viewports', shortViewport, () => {
       cy.mount(
         <Flyout closeButtonPosition="outside" resizable>

--- a/packages/eui/src/components/flyout/flyout.spec.tsx
+++ b/packages/eui/src/components/flyout/flyout.spec.tsx
@@ -18,6 +18,7 @@ import { EuiCollapsibleNav, EuiCollapsibleNavGroup } from '../collapsible_nav';
 import { EuiFlexGroup } from '../flex';
 import { EuiFlyout } from './flyout';
 import { EuiFlyoutBody } from './flyout_body';
+import { EuiFlyoutFooter } from './flyout_footer';
 import { EuiFlyoutHeader } from './flyout_header';
 import { EuiGlobalToastList } from '../toast';
 import {
@@ -73,6 +74,58 @@ const Flyout = ({
 };
 
 describe('EuiFlyout', () => {
+  describe('Layout behavior', () => {
+    it('keeps the body accessible when the viewport is shorter than the flyout chrome', () => {
+      cy.viewport(640, 360);
+      cy.mount(
+        <Flyout>
+          <EuiFlyoutHeader data-test-subj="flyoutHeader">
+            <div
+              css={css`
+                block-size: 160px;
+              `}
+            >
+              Header content
+            </div>
+          </EuiFlyoutHeader>
+          <EuiFlyoutBody>
+            <div
+              css={css`
+                block-size: 400px;
+                display: flex;
+                align-items: flex-end;
+              `}
+            >
+              <button data-test-subj="bodyAction">Body action</button>
+            </div>
+          </EuiFlyoutBody>
+          <EuiFlyoutFooter data-test-subj="flyoutFooter">
+            <div
+              css={css`
+                block-size: 160px;
+              `}
+            >
+              Footer content
+            </div>
+          </EuiFlyoutFooter>
+        </Flyout>
+      );
+
+      cy.get('[data-test-subj="euiFlyoutBodyOverflow"]').should(($body) => {
+        expect($body[0].clientHeight).to.be.greaterThan(0);
+        expect($body[0].scrollHeight).to.be.greaterThan($body[0].clientHeight);
+      });
+      cy.get('[data-test-subj="flyoutHeader"]').should('be.visible');
+      cy.get('[data-test-subj="flyoutFooter"]').should('be.visible');
+      cy.get('[data-test-subj="bodyAction"]')
+        .scrollIntoView()
+        .should('be.visible');
+      cy.get('[data-test-subj="euiFlyoutBodyOverflow"]')
+        .its('0.scrollTop')
+        .should('be.greaterThan', 0);
+    });
+  });
+
   describe('Focus behavior', () => {
     it('focuses the flyout wrapper by default', () => {
       cy.mount(<Flyout />);

--- a/packages/eui/src/components/flyout/flyout.spec.tsx
+++ b/packages/eui/src/components/flyout/flyout.spec.tsx
@@ -79,7 +79,7 @@ describe('EuiFlyout', () => {
   describe('Layout behavior', () => {
     it('keeps body accessible in short viewports', shortViewport, () => {
       cy.mount(
-        <Flyout>
+        <Flyout closeButtonPosition="outside" resizable>
           <EuiFlyoutHeader data-test-subj="flyoutHeader">
             <div
               css={css`
@@ -116,13 +116,24 @@ describe('EuiFlyout', () => {
         expect($body[0].clientHeight).to.be.greaterThan(0);
         expect($body[0].scrollHeight).to.be.greaterThan($body[0].clientHeight);
       });
+      cy.get('[data-test-subj="flyoutSpec"]')
+        .should('have.css', 'overflow-x', 'visible')
+        .and('have.css', 'overflow-y', 'visible')
+        .its('0.scrollTop')
+        .should('equal', 0);
+      cy.get('[data-test-subj="euiFlyoutCloseButton"]').should('be.visible');
+      cy.get('[data-test-subj="euiResizableButton"]').should('be.visible');
       cy.get('[data-test-subj="flyoutHeader"]').should('be.visible');
       cy.get('[data-test-subj="flyoutFooter"]')
         .scrollIntoView()
         .should('be.visible');
-      cy.get('[data-test-subj="flyoutSpec"]')
+      cy.get('[data-test-subj="euiFlyoutContent"]')
         .its('0.scrollTop')
         .should('be.greaterThan', 0);
+      cy.get('[data-test-subj="euiFlyoutCloseButton"]').should('be.visible');
+      cy.get('[data-test-subj="flyoutSpec"]')
+        .its('0.scrollTop')
+        .should('equal', 0);
       cy.get('[data-test-subj="bodyAction"]')
         .scrollIntoView()
         .should('be.visible');

--- a/packages/eui/src/components/flyout/flyout.styles.ts
+++ b/packages/eui/src/components/flyout/flyout.styles.ts
@@ -19,6 +19,7 @@ import {
   euiMaxBreakpoint,
   euiMinBreakpoint,
   logicalCSS,
+  logicalCSSWithFallback,
   logicalStyles,
   mathWithUnits,
 } from '../../global_styling';
@@ -89,6 +90,8 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       display: flex;
       flex-direction: column;
       align-items: stretch;
+      /* Keep all flyout regions reachable when their minimum heights exceed the viewport */
+      ${logicalCSSWithFallback('overflow-y', 'auto')}
 
       &:focus {
         /* Remove focus ring because of tabindex=0 */

--- a/packages/eui/src/components/flyout/flyout.styles.ts
+++ b/packages/eui/src/components/flyout/flyout.styles.ts
@@ -109,7 +109,10 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       flex-direction: column;
       align-items: stretch;
       min-block-size: 0;
-      ${logicalCSSWithFallback('overflow-y', 'auto')}
+
+      &:has(.euiFlyoutBody) {
+        ${logicalCSSWithFallback('overflow-y', 'auto')}
+      }
     `,
 
     // Flyout sizes (media queries + % sizing)

--- a/packages/eui/src/components/flyout/flyout.styles.ts
+++ b/packages/eui/src/components/flyout/flyout.styles.ts
@@ -90,8 +90,6 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       display: flex;
       flex-direction: column;
       align-items: stretch;
-      /* Keep all flyout regions reachable when their minimum heights exceed the viewport */
-      ${logicalCSSWithFallback('overflow-y', 'auto')}
 
       &:focus {
         /* Remove focus ring because of tabindex=0 */
@@ -103,6 +101,15 @@ export const euiFlyoutStyles = (euiThemeContext: UseEuiTheme) => {
       }
 
       ${maxedFlyoutWidth(euiThemeContext)}
+    `,
+
+    content: css`
+      display: flex;
+      flex: 1 1 auto;
+      flex-direction: column;
+      align-items: stretch;
+      min-block-size: 0;
+      ${logicalCSSWithFallback('overflow-y', 'auto')}
     `,
 
     // Flyout sizes (media queries + % sizing)
@@ -319,6 +326,8 @@ const composeFlyoutPadding = (
   };
 
   return `
+    --euiFlyoutBodyPadding: ${paddingModifierMap[paddingSize]};
+
     .euiFlyoutHeader {
       ${logicalCSS('padding-horizontal', paddingModifierMap[paddingSize])}
       ${logicalCSS('padding-top', paddingModifierMap[paddingSize])}

--- a/packages/eui/src/components/flyout/flyout_body.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_body.styles.ts
@@ -13,16 +13,18 @@ import {
   logicalCSSWithFallback,
   euiYScrollWithShadows,
 } from '../../global_styling';
+import { euiFormVariables } from '../form/form.styles';
 
 export const euiFlyoutBodyStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
+  const { controlHeight } = euiFormVariables(euiThemeContext);
 
   return {
     euiFlyoutBody: css`
       ${logicalCSSWithFallback('overflow-y', 'hidden')}
       ${logicalCSS('height', '100%')}
       /* Preserve enough space for one standard control at short viewport heights */
-      ${logicalCSS('min-height', euiTheme.size.xxl)}
+      ${logicalCSS('min-height', controlHeight)}
     `,
     overflow: {
       euiFlyoutBody__overflow: css``,

--- a/packages/eui/src/components/flyout/flyout_body.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_body.styles.ts
@@ -13,18 +13,19 @@ import {
   logicalCSSWithFallback,
   euiYScrollWithShadows,
 } from '../../global_styling';
-import { euiFormVariables } from '../form/form.styles';
 
 export const euiFlyoutBodyStyles = (euiThemeContext: UseEuiTheme) => {
   const { euiTheme } = euiThemeContext;
-  const { controlHeight } = euiFormVariables(euiThemeContext);
 
   return {
     euiFlyoutBody: css`
       ${logicalCSSWithFallback('overflow-y', 'hidden')}
       ${logicalCSS('height', '100%')}
-      /* Preserve enough space for one standard control at short viewport heights */
-      ${logicalCSS('min-height', controlHeight)}
+      /* Preserve a standard control plus the content padding and scroll fade */
+      ${logicalCSS(
+        'min-height',
+        `calc(${euiTheme.size.xxl} + var(--euiFlyoutBodyPadding, 0px) + var(--euiFlyoutBodyPadding, 0px) + ${euiTheme.size.s})`
+      )}
     `,
     overflow: {
       euiFlyoutBody__overflow: css``,

--- a/packages/eui/src/components/flyout/flyout_body.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_body.styles.ts
@@ -21,6 +21,8 @@ export const euiFlyoutBodyStyles = (euiThemeContext: UseEuiTheme) => {
     euiFlyoutBody: css`
       ${logicalCSSWithFallback('overflow-y', 'hidden')}
       ${logicalCSS('height', '100%')}
+      /* Preserve enough space for one standard control at short viewport heights */
+      ${logicalCSS('min-height', euiTheme.size.xxl)}
     `,
     overflow: {
       euiFlyoutBody__overflow: css``,

--- a/packages/eui/src/components/flyout/flyout_footer.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_footer.styles.ts
@@ -18,6 +18,7 @@ export const euiFlyoutFooterStyles = (euiThemeContext: UseEuiTheme) => {
     euiFlyoutFooter: css`
       background-color: ${euiTheme.components.flyoutFooterBackground};
       flex-grow: 0;
+      flex-shrink: 0;
       ${highContrastModeStyles(euiThemeContext, {
         preferred: logicalCSS('border-top', euiTheme.border.thin),
       })}

--- a/packages/eui/src/components/flyout/flyout_header.styles.ts
+++ b/packages/eui/src/components/flyout/flyout_header.styles.ts
@@ -16,6 +16,7 @@ export const euiFlyoutHeaderStyles = (euiThemeContext: UseEuiTheme) => {
   return {
     euiFlyoutHeader: css`
       flex-grow: 0;
+      flex-shrink: 0;
     `,
     hasBorder: css`
       ${logicalCSS('border-bottom', euiTheme.border.thin)}


### PR DESCRIPTION
## Summary

- Prevents `EuiFlyoutBody` from collapsing to zero height when a short viewport cannot fit a large header and footer.
- Keeps flyout headers and footers from shrinking, preserves one standard-control row for the body, and makes the flyout container scroll when the combined minimum heights exceed the viewport.
- Adds Cypress coverage for a 640 × 360 CSS-pixel viewport and verifies that body content remains scrollable and reachable.

Fixes #9881.

### API Changes

None.

## Screenshots

The regression is layout-dependent and covered by the Cypress component test. Before the fix, the body has a `0px` client height; after the fix, it retains a scrollable region and all three flyout regions remain reachable.

## Impact Assessment

- [ ] 🔴 **Breaking changes**
- [x] 💅 **Visual changes** — Limited to constrained-height flyouts whose body would otherwise collapse.
- [ ] 🧪 **Test impact**
- [ ] 🔧 **Hard to integrate**

**Impact level:** 🟢 Low

## Release Readiness

- ~~Documentation: no public API or usage change.~~
- ~~Figma: no design-system change.~~
- ~~Migration guide: no migration required.~~
- ~~Adoption plan: bug fix to existing behavior.~~

### QA instructions for reviewer

1. Render a flyout with a tall header, scrollable body, and tall footer.
2. Set the viewport to approximately 640 × 360 CSS pixels, equivalent to a 2560 × 1440 display at 400% zoom.
3. Confirm the header and footer retain their content height.
4. Confirm the body remains visible and can scroll to its final interactive element.
5. Run `yarn test-cypress --spec "**/flyout.spec.tsx" --headless` from `packages/eui`.

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [ ] **QA:** Tested light/dark modes, high contrast, mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in CodeSandbox and Kibana
- [x] **QA:** Tested docs changes — not applicable
- [x] **Tests:** Added Cypress regression coverage; existing flyout Jest suite passes
- [x] **Changelog:** Added changelog entry
- [x] **Breaking changes:** Not applicable