### PR TITLE
[EuiButton] Remove default minimum width

### DIFF
--- a/packages/eui/changelogs/upcoming/9946.md
+++ b/packages/eui/changelogs/upcoming/9946.md
@@ -1,0 +1,4 @@
+**Breaking changes**
+
+- Removed the default minimum width from `EuiButton` and `EuiFacetButton`. Use the `minWidth` prop to keep the button width stable when needed, e.g. when the label changes between states
+- Removed the default minimum width from `EuiSplitButton` primary actions

--- a/packages/eui/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
+++ b/packages/eui/src/components/accessibility/skip_link/__snapshots__/skip_link.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiSkipLink is rendered 1`] = `
 <a
   aria-label="aria-label"
-  class="euiButton euiSkipLink testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus-euiTestCss"
+  class="euiButton euiSkipLink testClass1 testClass2 emotion-euiButtonDisplay-s-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus-euiTestCss"
   data-test-subj="test subject string"
   href="#somewhere"
   rel="noreferrer"
@@ -22,7 +22,7 @@ exports[`EuiSkipLink is rendered 1`] = `
 
 exports[`EuiSkipLink props position absolute is rendered 1`] = `
 <a
-  class="euiButton euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-fill-primary-euiSkipLink-absolute-euiScreenReaderOnly-showOnFocus"
+  class="euiButton euiSkipLink emotion-euiButtonDisplay-s-fill-primary-euiSkipLink-absolute-euiScreenReaderOnly-showOnFocus"
   href="#somewhere"
   rel="noreferrer"
 >
@@ -34,7 +34,7 @@ exports[`EuiSkipLink props position absolute is rendered 1`] = `
 
 exports[`EuiSkipLink props position fixed is rendered 1`] = `
 <a
-  class="euiButton euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-fill-primary-euiSkipLink-fixed-euiScreenReaderOnly-showOnFocus"
+  class="euiButton euiSkipLink emotion-euiButtonDisplay-s-fill-primary-euiSkipLink-fixed-euiScreenReaderOnly-showOnFocus"
   href="#somewhere"
   rel="noreferrer"
   tabindex="0"
@@ -47,7 +47,7 @@ exports[`EuiSkipLink props position fixed is rendered 1`] = `
 
 exports[`EuiSkipLink props position static is rendered 1`] = `
 <a
-  class="euiButton euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus"
+  class="euiButton euiSkipLink emotion-euiButtonDisplay-s-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus"
   href="#somewhere"
   rel="noreferrer"
 >
@@ -59,7 +59,7 @@ exports[`EuiSkipLink props position static is rendered 1`] = `
 
 exports[`EuiSkipLink props tabIndex is rendered 1`] = `
 <a
-  class="euiButton euiSkipLink emotion-euiButtonDisplay-s-defaultMinWidth-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus"
+  class="euiButton euiSkipLink emotion-euiButtonDisplay-s-fill-primary-euiSkipLink-euiScreenReaderOnly-showOnFocus"
   href="#somewhere"
   rel="noreferrer"
   tabindex="-1"

--- a/packages/eui/src/components/button/__snapshots__/button.test.tsx.snap
+++ b/packages/eui/src/components/button/__snapshots__/button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiButton is rendered 1`] = `
 <button
   aria-label="aria-label"
-  class="euiButton testClass1 testClass2 emotion-euiButtonDisplay-m-defaultMinWidth-base-primary-euiTestCss"
+  class="euiButton testClass1 testClass2 emotion-euiButtonDisplay-m-base-primary-euiTestCss"
   data-test-subj="test subject string"
   type="button"
 >
@@ -21,7 +21,7 @@ exports[`EuiButton is rendered 1`] = `
 
 exports[`EuiButton props color accent is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-accent"
+  class="euiButton emotion-euiButtonDisplay-m-base-accent"
   type="button"
 >
   <span
@@ -32,7 +32,7 @@ exports[`EuiButton props color accent is rendered 1`] = `
 
 exports[`EuiButton props color accentSecondary is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-accentSecondary"
+  class="euiButton emotion-euiButtonDisplay-m-base-accentSecondary"
   type="button"
 >
   <span
@@ -43,7 +43,7 @@ exports[`EuiButton props color accentSecondary is rendered 1`] = `
 
 exports[`EuiButton props color danger is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-danger"
+  class="euiButton emotion-euiButtonDisplay-m-base-danger"
   type="button"
 >
   <span
@@ -54,7 +54,7 @@ exports[`EuiButton props color danger is rendered 1`] = `
 
 exports[`EuiButton props color primary is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -65,7 +65,7 @@ exports[`EuiButton props color primary is rendered 1`] = `
 
 exports[`EuiButton props color success is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-success"
+  class="euiButton emotion-euiButtonDisplay-m-base-success"
   type="button"
 >
   <span
@@ -76,7 +76,7 @@ exports[`EuiButton props color success is rendered 1`] = `
 
 exports[`EuiButton props color text is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-text"
+  class="euiButton emotion-euiButtonDisplay-m-base-text"
   type="button"
 >
   <span
@@ -87,7 +87,7 @@ exports[`EuiButton props color text is rendered 1`] = `
 
 exports[`EuiButton props color warning is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-warning"
+  class="euiButton emotion-euiButtonDisplay-m-base-warning"
   type="button"
 >
   <span
@@ -98,7 +98,7 @@ exports[`EuiButton props color warning is rendered 1`] = `
 
 exports[`EuiButton props contentProps is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -117,7 +117,7 @@ exports[`EuiButton props contentProps is rendered 1`] = `
 
 exports[`EuiButton props fill is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
+  class="euiButton emotion-euiButtonDisplay-m-fill-primary"
   type="button"
 >
   <span
@@ -128,7 +128,7 @@ exports[`EuiButton props fill is rendered 1`] = `
 
 exports[`EuiButton props fullWidth is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-fullWidth-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-fullWidth-base-primary"
   type="button"
 >
   <span
@@ -139,7 +139,7 @@ exports[`EuiButton props fullWidth is rendered 1`] = `
 
 exports[`EuiButton props href secures the rel attribute when the target is _blank 1`] = `
 <a
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   href="#"
   rel="noopener noreferrer"
   target="_blank"
@@ -152,7 +152,7 @@ exports[`EuiButton props href secures the rel attribute when the target is _blan
 
 exports[`EuiButton props iconSide left is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -173,7 +173,7 @@ exports[`EuiButton props iconSide left is rendered 1`] = `
 
 exports[`EuiButton props iconSide right is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -194,7 +194,7 @@ exports[`EuiButton props iconSide right is rendered 1`] = `
 
 exports[`EuiButton props iconSize m is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -215,7 +215,7 @@ exports[`EuiButton props iconSize m is rendered 1`] = `
 
 exports[`EuiButton props iconSize s is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -236,7 +236,7 @@ exports[`EuiButton props iconSize s is rendered 1`] = `
 
 exports[`EuiButton props iconType is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -252,7 +252,7 @@ exports[`EuiButton props iconType is rendered 1`] = `
 
 exports[`EuiButton props isDisabled is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-isDisabled-base-disabled"
+  class="euiButton emotion-euiButtonDisplay-m-isDisabled-base-disabled"
   data-test-subj="button"
   disabled=""
   type="button"
@@ -265,7 +265,7 @@ exports[`EuiButton props isDisabled is rendered 1`] = `
 
 exports[`EuiButton props isDisabled renders a button even when href is defined 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-isDisabled-base-disabled"
+  class="euiButton emotion-euiButtonDisplay-m-isDisabled-base-disabled"
   disabled=""
   type="button"
 >
@@ -277,7 +277,7 @@ exports[`EuiButton props isDisabled renders a button even when href is defined 1
 
 exports[`EuiButton props isDisabled renders if passed as disabled 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-isDisabled-base-disabled"
+  class="euiButton emotion-euiButtonDisplay-m-isDisabled-base-disabled"
   disabled=""
   type="button"
 >
@@ -289,7 +289,7 @@ exports[`EuiButton props isDisabled renders if passed as disabled 1`] = `
 
 exports[`EuiButton props isLoading is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-isDisabled-base-disabled"
+  class="euiButton emotion-euiButtonDisplay-m-isDisabled-base-disabled"
   disabled=""
   type="button"
 >
@@ -309,7 +309,7 @@ exports[`EuiButton props isLoading is rendered 1`] = `
 exports[`EuiButton props isSelected is rendered as false 1`] = `
 <button
   aria-pressed="false"
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -321,7 +321,7 @@ exports[`EuiButton props isSelected is rendered as false 1`] = `
 exports[`EuiButton props isSelected is rendered as true 1`] = `
 <button
   aria-pressed="true"
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -343,7 +343,7 @@ exports[`EuiButton props minWidth is rendered 1`] = `
 
 exports[`EuiButton props size m is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span
@@ -354,7 +354,7 @@ exports[`EuiButton props size m is rendered 1`] = `
 
 exports[`EuiButton props size s is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-s-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-s-base-primary"
   type="button"
 >
   <span
@@ -365,7 +365,7 @@ exports[`EuiButton props size s is rendered 1`] = `
 
 exports[`EuiButton props textProps is rendered 1`] = `
 <button
-  class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+  class="euiButton emotion-euiButtonDisplay-m-base-primary"
   type="button"
 >
   <span

--- a/packages/eui/src/components/button/button_display/__snapshots__/_button_display.test.tsx.snap
+++ b/packages/eui/src/components/button/button_display/__snapshots__/_button_display.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiButtonDisplay renders 1`] = `
 <button
   aria-label="aria-label"
-  class="testClass1 testClass2 emotion-euiButtonDisplay-m-defaultMinWidth-euiTestCss"
+  class="testClass1 testClass2 emotion-euiButtonDisplay-m-euiTestCss"
   data-test-subj="test subject string"
   type="button"
 >

--- a/packages/eui/src/components/button/button_display/_button_display.styles.ts
+++ b/packages/eui/src/components/button/button_display/_button_display.styles.ts
@@ -70,19 +70,6 @@ export const euiButtonDisplayStyles = (euiThemeContext: UseEuiTheme) => {
       display: block;
       ${logicalCSS('width', '100%')}
     `,
-    defaultMinWidth: {
-      defaultMinWidth: css``,
-      // Skip css`` for the sizes as we already add classes for sizes and defaultMinWidth
-      xs: `
-        ${logicalCSS('min-width', `${sizes.xs.minWidth}px`)}
-      `,
-      s: `
-        ${logicalCSS('min-width', `${sizes.s.minWidth}px`)}
-      `,
-      m: `
-        ${logicalCSS('min-width', `${sizes.m.minWidth}px`)}
-      `,
-    },
     // Sizes
     xs: css(_buttonSize('xs')),
     s: css(_buttonSize('s')),

--- a/packages/eui/src/components/button/button_display/_button_display.test.tsx
+++ b/packages/eui/src/components/button/button_display/_button_display.test.tsx
@@ -27,21 +27,19 @@ describe('EuiButtonDisplay', () => {
   });
 
   describe('minWidth', () => {
-    it('applies a `defaultMinWidth` class and no inline styles by default', () => {
+    it('does not apply a min-width by default', () => {
       const { container } = render(<EuiButtonDisplay />);
 
-      expect(container.innerHTML).toContain('defaultMinWidth');
       expect(container.innerHTML).not.toContain('style');
     });
 
-    it('applies an inline style & not the `defaultMinWidth` class if a custom minWidth is passed', () => {
+    it('applies an inline style if a custom minWidth is passed', () => {
       const { container } = render(<EuiButtonDisplay minWidth={200} />);
 
-      expect(container.innerHTML).not.toContain('defaultMinWidth');
       expect(container.innerHTML).toContain('style="min-inline-size: 200px;"');
     });
 
-    it('does not apply an inline style or `defaultMinWidth` if set to 0 or false', () => {
+    it('does not apply an inline style if set to 0 or false', () => {
       const { container } = render(
         <>
           <EuiButtonDisplay minWidth={0} />
@@ -49,7 +47,6 @@ describe('EuiButtonDisplay', () => {
         </>
       );
 
-      expect(container.innerHTML).not.toContain('defaultMinWidth');
       expect(container.innerHTML).not.toContain('style');
     });
   });

--- a/packages/eui/src/components/button/button_display/_button_display.tsx
+++ b/packages/eui/src/components/button/button_display/_button_display.tsx
@@ -63,7 +63,8 @@ export interface EuiButtonDisplayCommonProps
    */
   fullWidth?: boolean;
   /**
-   * Override the default minimum width
+   * Applies a minimum width. Useful for keeping the button width
+   * stable when its label changes between states
    */
   minWidth?: CSSProperties['minWidth'] | false;
   /**
@@ -161,10 +162,6 @@ export const EuiButtonDisplay = forwardRef<HTMLElement, EuiButtonDisplayProps>(
       styles.euiButtonDisplay,
       styles[size],
       fullWidth && styles.fullWidth,
-      minWidth == null && [
-        styles.defaultMinWidth.defaultMinWidth,
-        styles.defaultMinWidth[size],
-      ],
       buttonIsDisabled && styles.isDisabled,
     ];
 

--- a/packages/eui/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
+++ b/packages/eui/src/components/button/button_group/__snapshots__/button_group.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for multi
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -35,7 +35,7 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for multi
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -56,7 +56,7 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for multi
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-compressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-compressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -92,7 +92,7 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for singl
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -114,7 +114,7 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for singl
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -136,7 +136,7 @@ exports[`EuiButtonGroup button props buttonSize compressed is rendered for singl
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-compressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-compressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -171,7 +171,7 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-m-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-m-euiButtonGroupButton-m-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -192,7 +192,7 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-m-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-m-euiButtonGroupButton-m-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -213,7 +213,7 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-m-defaultMinWidth-isDisabled-euiButtonGroupButton-m-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-m-isDisabled-euiButtonGroupButton-m-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -249,7 +249,7 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for single 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-m-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-m-euiButtonGroupButton-m-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -271,7 +271,7 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-m-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-m-euiButtonGroupButton-m-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -293,7 +293,7 @@ exports[`EuiButtonGroup button props buttonSize m is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-m-defaultMinWidth-isDisabled-euiButtonGroupButton-m-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-m-isDisabled-euiButtonGroupButton-m-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -328,7 +328,7 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -349,7 +349,7 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -370,7 +370,7 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -406,7 +406,7 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for single 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -428,7 +428,7 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -450,7 +450,7 @@ exports[`EuiButtonGroup button props buttonSize s is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -485,7 +485,7 @@ exports[`EuiButtonGroup button props color accent is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-accent-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-accent-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -506,7 +506,7 @@ exports[`EuiButtonGroup button props color accent is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-accent"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-accent"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -527,7 +527,7 @@ exports[`EuiButtonGroup button props color accent is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -563,7 +563,7 @@ exports[`EuiButtonGroup button props color accent is rendered for single 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-accent-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-accent-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -585,7 +585,7 @@ exports[`EuiButtonGroup button props color accent is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-accent"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-accent"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -607,7 +607,7 @@ exports[`EuiButtonGroup button props color accent is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -642,7 +642,7 @@ exports[`EuiButtonGroup button props color accentSecondary is rendered for multi
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-accentSecondary-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-accentSecondary-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -663,7 +663,7 @@ exports[`EuiButtonGroup button props color accentSecondary is rendered for multi
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-accentSecondary"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-accentSecondary"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -684,7 +684,7 @@ exports[`EuiButtonGroup button props color accentSecondary is rendered for multi
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -720,7 +720,7 @@ exports[`EuiButtonGroup button props color accentSecondary is rendered for singl
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-accentSecondary-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-accentSecondary-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -742,7 +742,7 @@ exports[`EuiButtonGroup button props color accentSecondary is rendered for singl
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-accentSecondary"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-accentSecondary"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -764,7 +764,7 @@ exports[`EuiButtonGroup button props color accentSecondary is rendered for singl
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -799,7 +799,7 @@ exports[`EuiButtonGroup button props color danger is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-danger-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-danger-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -820,7 +820,7 @@ exports[`EuiButtonGroup button props color danger is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-danger"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-danger"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -841,7 +841,7 @@ exports[`EuiButtonGroup button props color danger is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -877,7 +877,7 @@ exports[`EuiButtonGroup button props color danger is rendered for single 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-danger-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-danger-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -899,7 +899,7 @@ exports[`EuiButtonGroup button props color danger is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-danger"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-danger"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -921,7 +921,7 @@ exports[`EuiButtonGroup button props color danger is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -956,7 +956,7 @@ exports[`EuiButtonGroup button props color primary is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-primary-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-primary-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -977,7 +977,7 @@ exports[`EuiButtonGroup button props color primary is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-primary"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-primary"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -998,7 +998,7 @@ exports[`EuiButtonGroup button props color primary is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1034,7 +1034,7 @@ exports[`EuiButtonGroup button props color primary is rendered for single 1`] = 
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-primary-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-primary-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1056,7 +1056,7 @@ exports[`EuiButtonGroup button props color primary is rendered for single 1`] = 
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-primary"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-primary"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1078,7 +1078,7 @@ exports[`EuiButtonGroup button props color primary is rendered for single 1`] = 
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1113,7 +1113,7 @@ exports[`EuiButtonGroup button props color success is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-success-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-success-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1134,7 +1134,7 @@ exports[`EuiButtonGroup button props color success is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-success"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-success"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1155,7 +1155,7 @@ exports[`EuiButtonGroup button props color success is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1191,7 +1191,7 @@ exports[`EuiButtonGroup button props color success is rendered for single 1`] = 
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-success-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-success-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1213,7 +1213,7 @@ exports[`EuiButtonGroup button props color success is rendered for single 1`] = 
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-success"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-success"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1235,7 +1235,7 @@ exports[`EuiButtonGroup button props color success is rendered for single 1`] = 
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1270,7 +1270,7 @@ exports[`EuiButtonGroup button props color text is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1291,7 +1291,7 @@ exports[`EuiButtonGroup button props color text is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1312,7 +1312,7 @@ exports[`EuiButtonGroup button props color text is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1348,7 +1348,7 @@ exports[`EuiButtonGroup button props color text is rendered for single 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1370,7 +1370,7 @@ exports[`EuiButtonGroup button props color text is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1392,7 +1392,7 @@ exports[`EuiButtonGroup button props color text is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1427,7 +1427,7 @@ exports[`EuiButtonGroup button props color warning is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-warning-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-warning-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1448,7 +1448,7 @@ exports[`EuiButtonGroup button props color warning is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-warning"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-warning"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1469,7 +1469,7 @@ exports[`EuiButtonGroup button props color warning is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1505,7 +1505,7 @@ exports[`EuiButtonGroup button props color warning is rendered for single 1`] = 
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-warning-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-warning-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1527,7 +1527,7 @@ exports[`EuiButtonGroup button props color warning is rendered for single 1`] = 
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-empty-warning"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-empty-warning"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1549,7 +1549,7 @@ exports[`EuiButtonGroup button props color warning is rendered for single 1`] = 
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1585,7 +1585,7 @@ exports[`EuiButtonGroup button props isDisabled is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled-euiTestCss"
       data-test-subj="test subject string"
       disabled=""
       title="Option one"
@@ -1607,7 +1607,7 @@ exports[`EuiButtonGroup button props isDisabled is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button01"
       disabled=""
       title="Option two"
@@ -1629,7 +1629,7 @@ exports[`EuiButtonGroup button props isDisabled is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1666,7 +1666,7 @@ exports[`EuiButtonGroup button props isDisabled is rendered for single 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled-euiTestCss"
       data-test-subj="test subject string"
       disabled=""
       title="Option one"
@@ -1689,7 +1689,7 @@ exports[`EuiButtonGroup button props isDisabled is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button01"
       disabled=""
       title="Option two"
@@ -1712,7 +1712,7 @@ exports[`EuiButtonGroup button props isDisabled is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1747,7 +1747,7 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1768,7 +1768,7 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1789,7 +1789,7 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1825,7 +1825,7 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for single 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1847,7 +1847,7 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1869,7 +1869,7 @@ exports[`EuiButtonGroup button props isFullWidth is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1904,7 +1904,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-iconOnly-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-iconOnly-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -1925,7 +1925,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-iconOnly-s-uncompressed-base-text"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-euiButtonGroupButton-iconOnly-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -1946,7 +1946,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for multi 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-iconOnly-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-iconOnly-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -1982,7 +1982,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-iconOnly-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-iconOnly-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -2004,7 +2004,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-iconOnly-s-uncompressed-base-text"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-euiButtonGroupButton-iconOnly-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -2026,7 +2026,7 @@ exports[`EuiButtonGroup button props isIconOnly is rendered for single 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-iconOnly-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-iconOnly-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -2062,7 +2062,7 @@ exports[`EuiButtonGroup type="multi" idToSelectedMap 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="true"
-      class="euiButtonGroupButton euiButtonGroupButton-isSelected testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-fill-text-euiTestCss"
+      class="euiButtonGroupButton euiButtonGroupButton-isSelected testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-fill-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -2084,7 +2084,7 @@ exports[`EuiButtonGroup type="multi" idToSelectedMap 1`] = `
     </button>
     <button
       aria-pressed="true"
-      class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-fill-text"
+      class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-fill-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -2105,7 +2105,7 @@ exports[`EuiButtonGroup type="multi" idToSelectedMap 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -2142,7 +2142,7 @@ exports[`EuiButtonGroup type="multi" renders 1`] = `
   >
     <button
       aria-label="aria-label"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -2163,7 +2163,7 @@ exports[`EuiButtonGroup type="multi" renders 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -2184,7 +2184,7 @@ exports[`EuiButtonGroup type="multi" renders 1`] = `
       </span>
     </button>
     <button
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -2220,7 +2220,7 @@ exports[`EuiButtonGroup type="single" idSelected 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="true"
-      class="euiButtonGroupButton euiButtonGroupButton-isSelected testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-fill-text-euiTestCss"
+      class="euiButtonGroupButton euiButtonGroupButton-isSelected testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-fill-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -2242,7 +2242,7 @@ exports[`EuiButtonGroup type="single" idSelected 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -2264,7 +2264,7 @@ exports[`EuiButtonGroup type="single" idSelected 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"
@@ -2302,7 +2302,7 @@ exports[`EuiButtonGroup type="single" renders 1`] = `
     <button
       aria-label="aria-label"
       aria-pressed="false"
-      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
+      class="euiButtonGroupButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text-euiTestCss"
       data-test-subj="test subject string"
       title="Option one"
       type="button"
@@ -2324,7 +2324,7 @@ exports[`EuiButtonGroup type="single" renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-s-uncompressed-base-text"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-s-uncompressed-base-text"
       data-test-subj="button01"
       title="Option two"
       type="button"
@@ -2346,7 +2346,7 @@ exports[`EuiButtonGroup type="single" renders 1`] = `
     </button>
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
+      class="euiButtonGroupButton emotion-euiButtonDisplay-s-isDisabled-euiButtonGroupButton-s-uncompressed-empty-disabled"
       data-test-subj="button02"
       disabled=""
       title="Option three"

--- a/packages/eui/src/components/button/split_button/__snapshots__/split_button.test.tsx.snap
+++ b/packages/eui/src/components/button/split_button/__snapshots__/split_button.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`EuiSplitButton renders 1`] = `
   style="--euiSplitButtonBorderColor: #BFDBFF;"
 >
   <button
-    class="euiButton euiSplitButtonActionPrimary emotion-euiButtonDisplay-m-defaultMinWidth-base-primary-euiSplitButtonActionPrimary"
+    class="euiButton euiSplitButtonActionPrimary emotion-euiButtonDisplay-m-base-primary-euiSplitButtonActionPrimary"
     data-test-subj="primary-action"
     type="button"
   >

--- a/packages/eui/src/components/button/split_button/split_button.styles.ts
+++ b/packages/eui/src/components/button/split_button/split_button.styles.ts
@@ -100,8 +100,6 @@ export const euiSplitButtonActionStyles = (
   // uses smaller sizes due to the buttons being inset into the parent container
   const buttonSize =
     size === 's' ? buttonSizeMap.xs.height : buttonSizeMap.s.height;
-  const buttonMinWidth =
-    size === 's' ? buttonSizeMap.xs.minWidth : buttonSizeMap.s.minWidth;
   const buttonRadius =
     size === 's' ? buttonSizeMap.xs.radiusInset : buttonSizeMap.s.radiusInset;
 
@@ -128,10 +126,6 @@ export const euiSplitButtonActionStyles = (
     euiSplitButtonActionPrimary: css`
       ${commonStyles}
       z-index: ${euiTheme.levels.content};
-
-      &:not(.euiButtonIcon) {
-        min-inline-size: ${buttonMinWidth}px;
-      }
 
       &.euiButtonIcon {
         inline-size: ${buttonSize};

--- a/packages/eui/src/components/card/__snapshots__/card.test.tsx.snap
+++ b/packages/eui/src/components/card/__snapshots__/card.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`EuiCard horizontal selectable 1`] = `
   <button
     aria-checked="false"
     aria-describedby="generated-idTitle generated-idDescription"
-    class="euiButton emotion-euiButtonDisplay-m-fullWidth-defaultMinWidth-base-text-euiCardSelect"
+    class="euiButton emotion-euiButtonDisplay-m-fullWidth-base-text-euiCardSelect"
     role="switch"
     type="button"
   >
@@ -1213,7 +1213,7 @@ exports[`EuiCard props selectable 1`] = `
   <button
     aria-checked="false"
     aria-describedby="generated-idTitle generated-idDescription"
-    class="euiButton emotion-euiButtonDisplay-m-fullWidth-defaultMinWidth-base-text-euiCardSelect"
+    class="euiButton emotion-euiButtonDisplay-m-fullWidth-base-text-euiCardSelect"
     role="switch"
     type="button"
   >

--- a/packages/eui/src/components/card/card_select/__snapshots__/card_select.test.tsx.snap
+++ b/packages/eui/src/components/card/card_select/__snapshots__/card_select.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`EuiCardSelect is rendered 1`] = `
 <button
   aria-checked="false"
   aria-label="aria-label"
-  class="euiButton testClass1 testClass2 emotion-euiButtonDisplay-m-fullWidth-defaultMinWidth-base-text-euiCardSelect-euiTestCss"
+  class="euiButton testClass1 testClass2 emotion-euiButtonDisplay-m-fullWidth-base-text-euiCardSelect-euiTestCss"
   data-test-subj="test subject string"
   role="switch"
   type="button"
@@ -20,7 +20,7 @@ exports[`EuiCardSelect is rendered 1`] = `
 exports[`EuiCardSelect props can override color 1`] = `
 <button
   aria-checked="false"
-  class="euiButton emotion-euiButtonDisplay-m-fullWidth-defaultMinWidth-base-danger-euiCardSelect"
+  class="euiButton emotion-euiButtonDisplay-m-fullWidth-base-danger-euiCardSelect"
   role="switch"
   type="button"
 >
@@ -35,7 +35,7 @@ exports[`EuiCardSelect props can override color 1`] = `
 exports[`EuiCardSelect props can override text 1`] = `
 <button
   aria-checked="false"
-  class="euiButton emotion-euiButtonDisplay-m-fullWidth-defaultMinWidth-base-text-euiCardSelect"
+  class="euiButton emotion-euiButtonDisplay-m-fullWidth-base-text-euiCardSelect"
   role="switch"
   type="button"
 >
@@ -54,7 +54,7 @@ exports[`EuiCardSelect props can override text 1`] = `
 exports[`EuiCardSelect props isDisabled 1`] = `
 <button
   aria-checked="false"
-  class="euiButton emotion-euiButtonDisplay-m-fullWidth-defaultMinWidth-isDisabled-base-disabled-euiCardSelect"
+  class="euiButton emotion-euiButtonDisplay-m-fullWidth-isDisabled-base-disabled-euiCardSelect"
   disabled=""
   role="switch"
   type="button"
@@ -70,7 +70,7 @@ exports[`EuiCardSelect props isDisabled 1`] = `
 exports[`EuiCardSelect props isSelected 1`] = `
 <button
   aria-checked="true"
-  class="euiButton emotion-euiButtonDisplay-m-fullWidth-defaultMinWidth-base-success-euiCardSelect"
+  class="euiButton emotion-euiButtonDisplay-m-fullWidth-base-success-euiCardSelect"
   role="switch"
   type="button"
 >

--- a/packages/eui/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
+++ b/packages/eui/src/components/datagrid/controls/__snapshots__/column_sorting.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`DataGridSortingControl renders a toolbar button/popover allowing users 
                     >
                       <button
                         aria-pressed="true"
-                        class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
+                        class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text"
                         data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
                         title="Low-High"
                         type="button"
@@ -174,7 +174,7 @@ exports[`DataGridSortingControl renders a toolbar button/popover allowing users 
                       </button>
                       <button
                         aria-pressed="false"
-                        class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+                        class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
                         data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
                         title="High-Low"
                         type="button"

--- a/packages/eui/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
+++ b/packages/eui/src/components/datagrid/controls/__snapshots__/column_sorting_draggable.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`EuiDataGridColumnSortingDraggable [React 17] renders an EuiDraggable co
         >
           <button
             aria-pressed="true"
-            class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
+            class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text"
             data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
             title="Low-High"
             type="button"
@@ -102,7 +102,7 @@ exports[`EuiDataGridColumnSortingDraggable [React 17] renders an EuiDraggable co
           </button>
           <button
             aria-pressed="false"
-            class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+            class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
             data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
             title="High-Low"
             type="button"
@@ -224,7 +224,7 @@ exports[`EuiDataGridColumnSortingDraggable [React 18] renders an EuiDraggable co
         >
           <button
             aria-pressed="true"
-            class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
+            class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text"
             data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-asc"
             title="Low-High"
             type="button"
@@ -242,7 +242,7 @@ exports[`EuiDataGridColumnSortingDraggable [React 18] renders an EuiDraggable co
           </button>
           <button
             aria-pressed="false"
-            class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+            class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
             data-test-subj="euiDataGridColumnSorting-sortColumn-columnA-desc"
             title="High-Low"
             type="button"

--- a/packages/eui/src/components/datagrid/controls/__snapshots__/display_selector.test.tsx.snap
+++ b/packages/eui/src/components/datagrid/controls/__snapshots__/display_selector.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`useDataGridDisplaySelector displaySelector allows consumers to customiz
         >
           <button
             aria-pressed="false"
-            class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+            class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
             data-test-subj="compact"
             title="Compact"
             type="button"
@@ -58,7 +58,7 @@ exports[`useDataGridDisplaySelector displaySelector allows consumers to customiz
           </button>
           <button
             aria-pressed="false"
-            class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+            class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
             data-test-subj="normal"
             title="Normal"
             type="button"
@@ -76,7 +76,7 @@ exports[`useDataGridDisplaySelector displaySelector allows consumers to customiz
           </button>
           <button
             aria-pressed="false"
-            class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+            class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
             data-test-subj="expanded"
             title="Expanded"
             type="button"
@@ -135,7 +135,7 @@ exports[`useDataGridDisplaySelector displaySelector allows consumers to customiz
           >
             <button
               aria-pressed="false"
-              class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+              class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
               data-test-subj="auto"
               title="Auto"
               type="button"
@@ -153,7 +153,7 @@ exports[`useDataGridDisplaySelector displaySelector allows consumers to customiz
             </button>
             <button
               aria-pressed="true"
-              class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
+              class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text"
               data-test-subj="static"
               title="Static"
               type="button"
@@ -287,7 +287,7 @@ exports[`useDataGridDisplaySelector displaySelector renders a toolbar button/pop
                 >
                   <button
                     aria-pressed="false"
-                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
                     data-test-subj="compact"
                     title="Compact"
                     type="button"
@@ -305,7 +305,7 @@ exports[`useDataGridDisplaySelector displaySelector renders a toolbar button/pop
                   </button>
                   <button
                     aria-pressed="false"
-                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
                     data-test-subj="normal"
                     title="Normal"
                     type="button"
@@ -323,7 +323,7 @@ exports[`useDataGridDisplaySelector displaySelector renders a toolbar button/pop
                   </button>
                   <button
                     aria-pressed="false"
-                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+                    class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
                     data-test-subj="expanded"
                     title="Expanded"
                     type="button"
@@ -379,7 +379,7 @@ exports[`useDataGridDisplaySelector displaySelector renders a toolbar button/pop
                   >
                     <button
                       aria-pressed="false"
-                      class="euiButtonGroupButton emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text"
+                      class="euiButtonGroupButton emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text"
                       data-test-subj="auto"
                       title="Auto"
                       type="button"
@@ -397,7 +397,7 @@ exports[`useDataGridDisplaySelector displaySelector renders a toolbar button/pop
                     </button>
                     <button
                       aria-pressed="true"
-                      class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text"
+                      class="euiButtonGroupButton euiButtonGroupButton-isSelected emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text"
                       data-test-subj="static"
                       title="Static"
                       type="button"

--- a/packages/eui/src/components/date_picker/super_date_picker/__snapshots__/time_window_buttons.test.tsx.snap
+++ b/packages/eui/src/components/date_picker/super_date_picker/__snapshots__/time_window_buttons.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`EuiTimeWindowButtons renders 1`] = `
     id="generated-id-wrapper"
   >
     <button
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-iconOnly-hasToolTip-uncompressed-base-text"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-m-euiButtonGroupButton-iconOnly-hasToolTip-uncompressed-base-text"
       data-test-subj="timeWindowButtonsPrevious"
       title=""
       type="button"
@@ -36,7 +36,7 @@ exports[`EuiTimeWindowButtons renders 1`] = `
     id="generated-id_euiToolTipAnchor"
   >
     <button
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-iconOnly-hasToolTip-uncompressed-base-text"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-m-euiButtonGroupButton-iconOnly-hasToolTip-uncompressed-base-text"
       data-test-subj="timeWindowButtonsZoomOut"
       title=""
       type="button"
@@ -62,7 +62,7 @@ exports[`EuiTimeWindowButtons renders 1`] = `
     id="generated-id-wrapper"
   >
     <button
-      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-m-defaultMinWidth-euiButtonGroupButton-iconOnly-hasToolTip-uncompressed-base-text"
+      class="euiButtonGroupButton euiButtonGroupButton-isIconOnly emotion-euiButtonDisplay-m-euiButtonGroupButton-iconOnly-hasToolTip-uncompressed-base-text"
       data-test-subj="timeWindowButtonsNext"
       title=""
       type="button"

--- a/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.styles.ts
+++ b/packages/eui/src/components/date_picker/super_date_picker/super_date_picker.styles.ts
@@ -30,7 +30,7 @@ export const euiSuperDatePickerStyles = (euiThemeContext: UseEuiTheme) => {
   const forms = euiFormVariables(euiThemeContext);
 
   const inputWidth = euiTheme.base * 30;
-  const buttonWidth = euiTheme.base * 7; // @see _button_display.styles.ts
+  const buttonWidth = euiTheme.base * 7; // @see euiButtonSizeMap
   const gap = euiTheme.size.s;
 
   // Default restricted width

--- a/packages/eui/src/components/facet/__snapshots__/facet_button.test.tsx.snap
+++ b/packages/eui/src/components/facet/__snapshots__/facet_button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EuiFacetButton is rendered 1`] = `
 <button
   aria-label="aria-label"
-  class="euiFacetButton testClass1 testClass2 emotion-euiButtonDisplay-s-defaultMinWidth-euiFacetButton-euiTestCss"
+  class="euiFacetButton testClass1 testClass2 emotion-euiButtonDisplay-s-euiFacetButton-euiTestCss"
   data-test-subj="test subject string"
   title="aria-label"
   type="button"
@@ -23,7 +23,7 @@ exports[`EuiFacetButton is rendered 1`] = `
 
 exports[`EuiFacetButton props icon is rendered 1`] = `
 <button
-  class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-euiFacetButton"
+  class="euiFacetButton emotion-euiButtonDisplay-s-euiFacetButton"
   title="Content"
   type="button"
 >
@@ -46,7 +46,7 @@ exports[`EuiFacetButton props icon is rendered 1`] = `
 
 exports[`EuiFacetButton props isDisabled is rendered 1`] = `
 <button
-  class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiFacetButton"
+  class="euiFacetButton emotion-euiButtonDisplay-s-isDisabled-euiFacetButton"
   disabled=""
   title="Content"
   type="button"
@@ -76,7 +76,7 @@ exports[`EuiFacetButton props isDisabled is rendered 1`] = `
 
 exports[`EuiFacetButton props isLoading is rendered 1`] = `
 <button
-  class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-isDisabled-euiFacetButton"
+  class="euiFacetButton emotion-euiButtonDisplay-s-isDisabled-euiFacetButton"
   disabled=""
   title="Content"
   type="button"
@@ -101,7 +101,7 @@ exports[`EuiFacetButton props isLoading is rendered 1`] = `
 
 exports[`EuiFacetButton props isSelected is rendered 1`] = `
 <button
-  class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-euiFacetButton"
+  class="euiFacetButton emotion-euiButtonDisplay-s-euiFacetButton"
   title="Content"
   type="button"
 >
@@ -120,7 +120,7 @@ exports[`EuiFacetButton props isSelected is rendered 1`] = `
 
 exports[`EuiFacetButton props quantity is rendered 1`] = `
 <button
-  class="euiFacetButton emotion-euiButtonDisplay-s-defaultMinWidth-euiFacetButton"
+  class="euiFacetButton emotion-euiButtonDisplay-s-euiFacetButton"
   title="Content"
   type="button"
 >

--- a/packages/eui/src/components/modal/__snapshots__/confirm_modal.test.tsx.snap
+++ b/packages/eui/src/components/modal/__snapshots__/confirm_modal.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`EuiConfirmModal renders EuiConfirmModal without EuiModalBody, if empty 
             </span>
           </button>
           <button
-            class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-fill-primary"
+            class="euiButton emotion-euiButtonDisplay-m-fill-primary"
             data-test-subj="confirmModalConfirmButton"
             type="button"
           >

--- a/packages/eui/src/components/search_bar/__snapshots__/search_bar.test.tsx.snap
+++ b/packages/eui/src/components/search_bar/__snapshots__/search_bar.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`SearchBar render - provided query, filters 1`] = `
       >
         <button
           aria-pressed="false"
-          class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
+          class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
           data-test-subj="filter-button_generated-id"
           type="button"
         >

--- a/packages/eui/src/components/search_bar/__snapshots__/search_filters.test.tsx.snap
+++ b/packages/eui/src/components/search_bar/__snapshots__/search_filters.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`EuiSearchBarFilters render - with filters 1`] = `
   >
     <button
       aria-pressed="false"
-      class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
+      class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
       data-test-subj="filter-button_generated-id"
       type="button"
     >

--- a/packages/eui/src/components/search_bar/filters/__snapshots__/field_value_toggle_filter.test.tsx.snap
+++ b/packages/eui/src/components/search_bar/filters/__snapshots__/field_value_toggle_filter.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FieldValueToggleFilter render - active 1`] = `
 >
   <button
     aria-pressed="true"
-    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
+    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >
@@ -31,7 +31,7 @@ exports[`FieldValueToggleFilter render - active negated - custom negated name 1`
 >
   <button
     aria-pressed="true"
-    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
+    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >
@@ -56,7 +56,7 @@ exports[`FieldValueToggleFilter render - active negated 1`] = `
 >
   <button
     aria-pressed="true"
-    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
+    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >
@@ -81,7 +81,7 @@ exports[`FieldValueToggleFilter renders 1`] = `
 >
   <button
     aria-pressed="false"
-    class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
+    class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >

--- a/packages/eui/src/components/search_bar/filters/__snapshots__/field_value_toggle_group_filter.test.tsx.snap
+++ b/packages/eui/src/components/search_bar/filters/__snapshots__/field_value_toggle_group_filter.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TermToggleGroupFilter render - active 1`] = `
 >
   <button
     aria-pressed="true"
-    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
+    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >
@@ -31,7 +31,7 @@ exports[`TermToggleGroupFilter render - active negated - custom negated name 1`]
 >
   <button
     aria-pressed="true"
-    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
+    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >
@@ -56,7 +56,7 @@ exports[`TermToggleGroupFilter render - active negated 1`] = `
 >
   <button
     aria-pressed="true"
-    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
+    class="euiButtonGroupButton euiButtonGroupButton-isSelected euiFilterButton euiFilterButton-isSelected euiFilterButton-hasActiveFilters euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-fill-text-euiFilterButton-hasActiveFilters-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >
@@ -81,7 +81,7 @@ exports[`TermToggleGroupFilter renders 1`] = `
 >
   <button
     aria-pressed="false"
-    class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
+    class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >

--- a/packages/eui/src/components/search_bar/filters/__snapshots__/is_filter.test.tsx.snap
+++ b/packages/eui/src/components/search_bar/filters/__snapshots__/is_filter.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`IsFilter render 1`] = `
 >
   <button
     aria-pressed="false"
-    class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-defaultMinWidth-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
+    class="euiButtonGroupButton euiFilterButton euiFilterButton-isToggle emotion-euiButtonDisplay-s-euiButtonGroupButton-compressed-empty-text-euiFilterButton-toggle"
     data-test-subj="filter-button_generated-id"
     type="button"
   >


### PR DESCRIPTION
## Summary

Implements the decision in #9941.

`EuiButton` no longer applies a minimum width by default (previously 96px for `xs`/`s` and 112px for `m`). Buttons now size to their content, and `minWidth` is opt-in for cases that need a stable width. The known example is unified search, where the label cycles through run, search, refresh and cancel. `EuiSuperUpdateButton` already passes `minWidth={118}`, so it keeps a stable width without any changes here.

A few implementation notes:

- The default lived in the internal `EuiButtonDisplay`, which `EuiFacetButton` also uses, so facet buttons lose the default too. `EuiButtonGroup` already overrides min-width to 0 and `EuiButtonEmpty` never had one, so neither changes visually.
- `EuiSplitButton` forced a min-width on its primary action to shrink the nested `EuiButton` default down to the inset size. With the default gone, that rule would only bring back the wasted space this issue calls out, so it was removed as well. Passing `minWidth` to `EuiSplitButton.ActionPrimary` still works.
- The prop type is unchanged. `false` and `0` remain valid and now behave the same as omitting the prop, so nothing breaks at compile time.
- `euiButtonSizeMap` keeps its `minWidth` values since it is public API and the old numbers are handy for opting back in.

On the Kibana side, Discover and Dashboards should be checked separately to confirm their buttons opt into `minWidth` where a stable width matters (tracked in the issue checklist).

<br/>

### API Changes

| component / parent | prop / child | change  | description |
| ------------------ | ------------ | ------- | ----------- |
| EuiButton          | minWidth     | Default | No minimum width is applied by default. Pass a value to keep the width stable when the label changes between states |
| EuiFacetButton     | minWidth     | Default | Same as EuiButton (shared internal display component) |
| EuiSplitButton     |              | Default | Primary actions no longer enforce a minimum width |

## Impact Assessment

- [x] 💅 **Visual changes**: buttons with short labels narrow to fit their content. No markup changes.
- [x] 🧪 **Test impact**: Emotion class names lose the `defaultMinWidth` label, so downstream snapshot tests need regenerating. VRT baselines need updating.

**Impact level:** 🟡 Moderate

---

### QA instructions for reviewer

- Open the EuiButton playground in Storybook.
  - A button with a short label sizes to its content instead of 112px.
  - Passing `minWidth={112}` restores a fixed minimum width.
  - EuiSplitButton primary actions size to their content.
  - The EuiSuperDatePicker update button keeps a stable width across its state changes.
