### PR TITLE
[Chore] Fix deploy-docs SIGPIPE on release tags

### DIFF
--- a/.buildkite/scripts/deploy_docs/step_setup.sh
+++ b/.buildkite/scripts/deploy_docs/step_setup.sh
@@ -64,7 +64,7 @@ if is_pipeline_trigger_pull_request; then
   copy_to_root_directory=false
   echo "Detected a PR preview environment configuration. The built files will be copied to ${bucket_directory}"
 elif is_pipeline_trigger_tag; then
-  latest_release_tag_on_main=$(git tag --list --merged main --sort=-version:refname | grep -E "^${release_tag_pattern}$" | head -1)
+  latest_release_tag_on_main=$(set +o pipefail; git tag --list --merged main --sort=-version:refname | grep -E "^${release_tag_pattern}$" | head -1)
   bucket_directory="${BUILDKITE_TAG}/"
   copy_to_root_directory=false
   if [[ "${BUILDKITE_TAG}" == "${latest_release_tag_on_main}" ]]; then


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

**What:** Stop `eui-deploy-docs` _"Setup"_ step from dying on release tag builds (error: `exit 141`).
**Why:** Tag deployed as `v119.1.0` failed to trigger the documentation deployment ([#4991](https://buildkite.com/elastic/eui-deploy-docs/builds/4991), [#4995](https://buildkite.com/elastic/eui-deploy-docs/builds/4995)).
**How:** `git tag | grep | head -1` under `set -eo pipefail` SIGPIPEs when head closes the pipe. Disables pipefail in that command subshell only.