### PR TITLE
[EuiDelayRender] Migrate from class to function component

### DIFF
--- a/packages/eui/src/components/delay_render/delay_render.test.tsx
+++ b/packages/eui/src/components/delay_render/delay_render.test.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { act } from '@testing-library/react';
+import { render } from '../../test/rtl';
+
+import { EuiDelayRender } from './delay_render';
+
+describe('EuiDelayRender', () => {
+  jest.useFakeTimers();
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('renders its children after the default 500ms delay', () => {
+    const { container, getByText } = render(
+      <EuiDelayRender>
+        <span>content</span>
+      </EuiDelayRender>
+    );
+    expect(container).toBeEmptyDOMElement();
+
+    act(() => {
+      jest.advanceTimersByTime(499);
+    });
+    expect(container).toBeEmptyDOMElement();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(getByText('content')).toBeInTheDocument();
+  });
+
+  it('respects a custom `delay`', () => {
+    const { container, getByText } = render(
+      <EuiDelayRender delay={1000}>
+        <span>content</span>
+      </EuiDelayRender>
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(999);
+    });
+    expect(container).toBeEmptyDOMElement();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(getByText('content')).toBeInTheDocument();
+  });
+
+  it('hides updated children and shows them again after the delay', () => {
+    const { container, getByText, rerender } = render(
+      <EuiDelayRender>
+        <span>first</span>
+      </EuiDelayRender>
+    );
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(getByText('first')).toBeInTheDocument();
+
+    rerender(
+      <EuiDelayRender>
+        <span>second</span>
+      </EuiDelayRender>
+    );
+    expect(container).toBeEmptyDOMElement();
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(getByText('second')).toBeInTheDocument();
+  });
+
+  it('never renders updated children before the delay has passed', () => {
+    // Unlike the DOM assertions above, this catches content being committed
+    // and immediately hidden again within the same act() flush, which would
+    // still trigger aria-live announcements
+    const onRender = jest.fn();
+    const Probe = ({ label }: { label: string }) => {
+      onRender(label);
+      return <span>{label}</span>;
+    };
+
+    const { getByText, rerender } = render(
+      <EuiDelayRender>
+        <Probe label="first" />
+      </EuiDelayRender>
+    );
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(getByText('first')).toBeInTheDocument();
+
+    rerender(
+      <EuiDelayRender>
+        <Probe label="second" />
+      </EuiDelayRender>
+    );
+    expect(onRender).not.toHaveBeenCalledWith('second');
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(getByText('second')).toBeInTheDocument();
+  });
+
+  it('stays hidden until updates stop arriving for the delay duration', () => {
+    const { container, getByText, rerender } = render(
+      <EuiDelayRender>
+        <span>first</span>
+      </EuiDelayRender>
+    );
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    rerender(
+      <EuiDelayRender>
+        <span>second</span>
+      </EuiDelayRender>
+    );
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(container).toBeEmptyDOMElement();
+
+    rerender(
+      <EuiDelayRender>
+        <span>third</span>
+      </EuiDelayRender>
+    );
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(container).toBeEmptyDOMElement();
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(getByText('third')).toBeInTheDocument();
+  });
+
+  it('does not re-delay when re-rendered with unchanged children', () => {
+    const children = <span>stable</span>;
+    const { getByText, rerender } = render(
+      <EuiDelayRender>{children}</EuiDelayRender>
+    );
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(getByText('stable')).toBeInTheDocument();
+
+    rerender(<EuiDelayRender>{children}</EuiDelayRender>);
+    expect(getByText('stable')).toBeInTheDocument();
+  });
+
+  it('clears the pending timeout on unmount', () => {
+    const { unmount } = render(
+      <EuiDelayRender>
+        <span>content</span>
+      </EuiDelayRender>
+    );
+    expect(jest.getTimerCount()).toBe(1);
+
+    unmount();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/eui/src/components/delay_render/delay_render.tsx
+++ b/packages/eui/src/components/delay_render/delay_render.tsx
@@ -6,66 +6,36 @@
  * Side Public License, v 1.
  */
 
-import { Component, PropsWithChildren } from 'react';
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  useEffect,
+  useState,
+} from 'react';
 
 export interface EuiDelayRenderProps extends PropsWithChildren {
-  delay: number;
+  delay?: number;
 }
 
-interface EuiDelayRenderState {
-  toggle: boolean;
-}
+export const EuiDelayRender: FunctionComponent<EuiDelayRenderProps> = ({
+  delay = 500,
+  children,
+}) => {
+  const [shouldRender, setShouldRender] = useState(false);
+  const [prevProps, setPrevProps] = useState({ children, delay });
 
-export class EuiDelayRender extends Component<
-  EuiDelayRenderProps,
-  EuiDelayRenderState
-> {
-  static defaultProps = {
-    delay: 500,
-  };
-
-  private delayID: number | undefined;
-  private toBeDelayed: boolean = true;
-
-  constructor(props: EuiDelayRenderProps) {
-    super(props);
-    this.state = {
-      toggle: false,
-    };
+  // Hiding must happen during the render phase: waiting for an effect would
+  // briefly commit updated children before hiding them again, flashing the
+  // content and triggering any aria-live announcements it may contain
+  if (children !== prevProps.children || delay !== prevProps.delay) {
+    setPrevProps({ children, delay });
+    setShouldRender(false);
   }
 
-  shouldUpdate() {
-    this.setState(({ toggle }) => ({ toggle: !toggle }));
-  }
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setShouldRender(true), delay);
+    return () => window.clearTimeout(timeoutId);
+  }, [children, delay]);
 
-  startDelaying = () => {
-    window.clearTimeout(this.delayID);
-    this.toBeDelayed = true;
-    this.delayID = window.setTimeout(this.stopDelaying, this.props.delay);
-  };
-  stopDelaying = () => {
-    window.clearTimeout(this.delayID);
-    this.toBeDelayed = false;
-    this.shouldUpdate();
-  };
-
-  componentDidMount() {
-    this.startDelaying();
-  }
-  shouldComponentUpdate() {
-    if (this.toBeDelayed) {
-      this.startDelaying();
-    }
-    return true;
-  }
-  componentWillUnmount() {
-    this.stopDelaying();
-  }
-  componentDidUpdate() {
-    this.toBeDelayed = true;
-  }
-
-  render() {
-    return !this.toBeDelayed ? this.props.children : null;
-  }
-}
+  return shouldRender ? children : null;
+};


### PR DESCRIPTION
## Summary

Closes #9501

Converts `EuiDelayRender` from a class to a function component. The `shouldComponentUpdate` render gating becomes conditional rendering in the function body, and timer management moves to `useEffect`, as suggested in the issue's migration notes.

Behavior is preserved: children stay hidden on mount and are hidden again whenever they update, with repeated updates restarting the timer, so content only appears once updates have stopped for the configured delay. Two details worth calling out for review:

- Hiding updated children happens during the render phase (the documented [storing information from previous renders](https://react.dev/reference/react/useState#storing-information-from-previous-renders) pattern) rather than in the effect. Waiting for an effect would briefly commit updated children before hiding them again, flashing the content and triggering any aria-live announcements it may contain. That matters because the main internal consumer is the screen reader caption in `EuiBasicTable`. A dedicated test guards this and fails if the hide is moved into the effect.
- One intentional refinement: re-renders with referentially unchanged children no longer restart the delay, matching the `React.memo` semantics the issue suggests. The old class re-hid on every parent re-render because its `shouldComponentUpdate` never inspected props. All in-repo consumers pass fresh JSX children on every render, so nothing changes for them.

The component had no unit tests, so this adds a suite locking in the timing behavior. It was written against the class implementation first, and everything passes on the old class too except the unchanged children case described above.

`delay` becomes optional in the props type now that `static defaultProps` is gone. The runtime default of 500ms is unchanged.

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| EuiDelayRender     | delay        | Type   | Now optional in `EuiDelayRenderProps` (was required and filled by `defaultProps`). Runtime default of 500ms is unchanged |

## Impact Assessment

Internal refactor with no markup, class name, or styling changes. The only behavior difference is the unchanged children case above, which no known consumer relies on.

**Impact level:** 🟢 Low

Like the other migrations in this effort (#9860, #9879, #9831) this skips a changelog entry, so it needs the `skip-changelog` label from a maintainer.

### QA instructions for reviewer

- Open the `EuiDelayRender` playground in Storybook.
  - The spinner appears only after the configured delay.
  - Changing args re-runs the delay before the spinner reappears.
  - The Cypress a11y spec (`delay_render.a11y.tsx`) passes.
