### PR TITLE
[eslint] Update `button-group-no-invalid-children` rule to support selection variant and add `button-group-selection-require-id` rule

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -380,10 +380,11 @@ Enforce that `EuiButtonGroup` children (when using the Children API) are valid b
 Valid direct children depend on the variant:
 - `variant="default"` (or no variant): `EuiButton`, `EuiButtonEmpty`, and `EuiButtonIcon`
 - `variant="segmented"`: `EuiButton` and `EuiButtonIcon` only (`EuiButtonEmpty` is not allowed)
+- `variant="selection"`: `EuiButton` and `EuiButtonIcon` only (`EuiButtonEmpty` is not allowed)
 
-In addition, these wrapper components are allowed for both variants: `EuiPopover`, `EuiToolTip`, and `EuiCopy`.
+In addition, these wrapper components are allowed for all variants: `EuiPopover`, `EuiToolTip`, and `EuiCopy`.
 
-For `variant="segmented"`, all children must also use the **same button type** — either all `EuiButton` or all `EuiButtonIcon`. Mixing both types is reported as an error, including when buttons appear inside `EuiToolTip`, as an `EuiPopover` trigger, or in an `EuiCopy` render prop.
+For `variant="segmented"` and `variant="selection"`, all children must also use the **same button type** — either all `EuiButton` or all `EuiButtonIcon`. Mixing both types is reported as an error, including when buttons appear inside `EuiToolTip`, as an `EuiPopover` trigger, or in an `EuiCopy` render prop.
 
 #### Examples
 
@@ -404,6 +405,17 @@ For `variant="segmented"`, all children must also use the **same button type** �
 <EuiButtonGroup legend="Actions" variant="segmented">
   <EuiButton>Save</EuiButton>
   <EuiButtonIcon iconType="trash" aria-label="Delete" />
+</EuiButtonGroup>
+
+// ✗ Bad - variant="selection" with EuiButtonEmpty (not allowed)
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiButtonEmpty color="text">Bold</EuiButtonEmpty>
+</EuiButtonGroup>
+
+// ✗ Bad - variant="selection" mixing EuiButton and EuiButtonIcon
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiButton id="bold">Bold</EuiButton>
+  <EuiButtonIcon id="italic" iconType="italic" aria-label="Italic" />
 </EuiButtonGroup>
 
 // ✓ Good - direct buttons
@@ -469,6 +481,18 @@ For `variant="segmented"`, all children must also use the **same button type** �
   <EuiButtonIcon iconType="pencil" aria-label="Edit" />
   <EuiButtonIcon iconType="trash" aria-label="Delete" />
 </EuiButtonGroup>
+
+// ✓ Good - variant="selection" with all EuiButton
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiButton id="bold">Bold</EuiButton>
+  <EuiButton id="italic">Italic</EuiButton>
+</EuiButtonGroup>
+
+// ✓ Good - variant="selection" with all EuiButtonIcon
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiButtonIcon id="bold" iconType="bold" aria-label="Bold" />
+  <EuiButtonIcon id="italic" iconType="italic" aria-label="Italic" />
+</EuiButtonGroup>
 ```
 
 #### Custom button wrapper components
@@ -478,6 +502,51 @@ If a project-specific button component (e.g. `<SaveButton />`) is used as a chil
 ```tsx
 // eslint-disable-next-line @elastic/eui/button-group-no-invalid-children -- SaveButton returns EuiButton
 <SaveButton />
+```
+
+### `@elastic/eui/button-group-selection-require-id`
+
+Enforce that every `EuiButton` and `EuiButtonIcon` child of an `EuiButtonGroup` with `variant="selection"` has an `id` prop. The selection variant uses the `id` of each button to track which buttons are selected, so a missing `id` will cause incorrect or broken selection state at runtime.
+
+The rule only fires when `variant="selection"` is set as a static string. Dynamic variants (`variant={myVar}`) are skipped conservatively. It traverses the same nesting depth as `button-group-no-invalid-children`: fragments, conditionals, variable resolution, `.map()`, and the three supported wrappers (`EuiToolTip`, `EuiPopover` trigger, `EuiCopy` render prop). Children with spread props (`{...props}`) are skipped — the `id` may be provided via the spread.
+
+#### Examples
+
+```tsx
+// ✗ Bad - missing id on direct child
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiButton>Bold</EuiButton>
+</EuiButtonGroup>
+
+// ✗ Bad - missing id on button inside EuiToolTip
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiToolTip content="Italic">
+    <EuiButton>Italic</EuiButton>
+  </EuiToolTip>
+</EuiButtonGroup>
+
+// ✗ Bad - missing id on EuiPopover trigger
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiPopover button={<EuiButton>More</EuiButton>} isOpen={false} closePopover={() => {}}>
+    Panel content
+  </EuiPopover>
+</EuiButtonGroup>
+
+// ✓ Good - all children have id
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiButton id="bold">Bold</EuiButton>
+  <EuiToolTip content="Italic">
+    <EuiButton id="italic">Italic</EuiButton>
+  </EuiToolTip>
+  <EuiPopover button={<EuiButton id="more">More</EuiButton>} isOpen={false} closePopover={() => {}}>
+    Panel content
+  </EuiPopover>
+</EuiButtonGroup>
+
+// ✓ Good - spread props are skipped (id may come from the spread)
+<EuiButtonGroup legend="Format" variant="selection">
+  <EuiButton {...buttonProps} />
+</EuiButtonGroup>
 ```
 
 ## Testing

--- a/packages/eslint-plugin/changelogs/upcoming/9950.md
+++ b/packages/eslint-plugin/changelogs/upcoming/9950.md
@@ -1,0 +1,2 @@
+- Updated `button-group-no-invalid-children` rule to support checking button groups with `variant="selection"`
+- Added new `button-group-selection-require-id` rule to enforce a required `id` prop on each child button of `EuiButtonGroup` with `variant="selection"`

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -30,6 +30,7 @@ import { TooltipNoInteractiveContent } from './rules/a11y/tooltip_no_interactive
 import { TooltipButtonIconWrap } from './rules/a11y/tooltip_button_icon_wrap';
 import { NoDeprecatedIconAliases } from './rules/no_deprecated_icon_aliases';
 import { ButtonGroupNoInvalidChildren } from './rules/button_group_no_invalid_children';
+import { ButtonGroupSelectionRequireId } from './rules/button_group_selection_require_id';
 
 const config = {
   rules: {
@@ -58,6 +59,7 @@ const config = {
     'tooltip-no-interactive-content': TooltipNoInteractiveContent,
     'tooltip-button-icon-wrap': TooltipButtonIconWrap,
     'button-group-no-invalid-children': ButtonGroupNoInvalidChildren,
+    'button-group-selection-require-id': ButtonGroupSelectionRequireId,
   },
   configs: {
     recommended: {
@@ -65,6 +67,7 @@ const config = {
       rules: {
         '@elastic/eui/accessible-interactive-element': 'warn',
         '@elastic/eui/button-group-no-invalid-children': 'error',
+        '@elastic/eui/button-group-selection-require-id': 'error',
         '@elastic/eui/callout-announce-on-mount': 'warn',
         '@elastic/eui/callout-prefer-props-for-content': 'warn',
         '@elastic/eui/consistent-is-invalid-props': 'warn',

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
@@ -8,11 +8,12 @@
 
 import dedent from 'dedent';
 import { RuleTester } from '@typescript-eslint/rule-tester';
+import { ButtonGroupNoInvalidChildren } from './button_group_no_invalid_children';
 import {
-  ButtonGroupNoInvalidChildren,
   VALID_BUTTONS,
   SEGMENTED_VALID_BUTTONS,
-} from './button_group_no_invalid_children';
+  SELECTION_VALID_BUTTONS,
+} from '../utils/button_group_constants';
 
 const languageOptions = {
   parserOptions: {
@@ -24,6 +25,7 @@ const languageOptions = {
 
 const DEFAULT_ALLOWED = Array.from(VALID_BUTTONS).join(', ');
 const SEGMENTED_ALLOWED = Array.from(SEGMENTED_VALID_BUTTONS).join(', ');
+const SELECTION_ALLOWED = Array.from(SELECTION_VALID_BUTTONS).join(', ');
 
 const ruleTester = new RuleTester();
 
@@ -597,10 +599,89 @@ ruleTester.run(
         languageOptions,
       },
       {
-        name: 'variant="selection" is not yet validated — invalid children pass through',
+        name: 'variant="selection" with EuiButton children is accepted',
         code: dedent`
           <EuiButtonGroup legend="Actions" variant="selection">
-            <div>Not a button</div>
+            <EuiButton>Bold</EuiButton>
+            <EuiButton>Italic</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="selection" with EuiButtonIcon children is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButtonIcon iconType="bold" aria-label="Bold" />
+            <EuiButtonIcon iconType="italic" aria-label="Italic" />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="selection" with EuiToolTip wrapping EuiButton is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButton>Bold</EuiButton>
+            <EuiToolTip content="Italic text">
+              <EuiButton>Italic</EuiButton>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="selection" with EuiToolTip wrapping EuiButtonIcon is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiToolTip content="Bold">
+              <EuiButtonIcon iconType="bold" aria-label="Bold" />
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="selection" with EuiPopover wrapping EuiButton trigger is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButton>Bold</EuiButton>
+            <EuiPopover button={<EuiButton>More</EuiButton>} isOpen={false} closePopover={() => {}}>
+              <p>Panel content</p>
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="selection" with EuiCopy wrapping EuiButton is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButton>Bold</EuiButton>
+            <EuiCopy textToCopy="text">
+              {(copy) => <EuiButton onClick={copy}>Copy</EuiButton>}
+            </EuiCopy>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="selection" with EuiButton children inside a fragment is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <>
+              <EuiButton>Bold</EuiButton>
+              <EuiButton>Italic</EuiButton>
+            </>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="selection" with spread props on child — cannot statically be determined',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButton {...buttonProps} />
           </EuiButtonGroup>
         `,
         languageOptions,
@@ -1727,7 +1808,7 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon inside a fragment is reported',
@@ -1740,7 +1821,7 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiToolTip is reported',
@@ -1753,7 +1834,7 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiPopover trigger is reported',
@@ -1766,7 +1847,7 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiPopover with EuiToolTip-wrapped trigger is reported',
@@ -1783,7 +1864,7 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiCopy render prop is reported',
@@ -1796,7 +1877,113 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidSegmentedMixedTypes' }],
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
+      },
+
+      // variant="selection"
+      {
+        name: 'variant="selection" with unsupported button component is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidChild',
+            data: { name: 'EuiButtonEmpty', allowed: SELECTION_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="selection" with plain HTML child is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <div>Not a button</div>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidChild',
+            data: { name: 'div', allowed: SELECTION_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="selection" with unsupported component is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButton>Bold</EuiButton>
+            <EuiText>Not allowed</EuiText>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: { name: 'EuiText', allowed: SELECTION_ALLOWED },
+          },
+        ],
+      },
+      {
+        name: 'variant="selection" with unsupported component inside EuiToolTip is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiToolTip content="Cancel">
+              <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidWrapperChild',
+            data: {
+              name: 'EuiButtonEmpty',
+              wrapper: 'EuiToolTip',
+              allowed: SELECTION_ALLOWED,
+            },
+          },
+        ],
+      },
+      {
+        name: 'variant="selection" mixing EuiButton and EuiButtonIcon children is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButton>Bold</EuiButton>
+            <EuiButtonIcon iconType="italic" aria-label="Italic" />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'selection' } }],
+      },
+      {
+        name: 'variant="selection" mixing EuiButton and EuiButtonIcon inside a fragment is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <>
+              <EuiButton>Bold</EuiButton>
+              <EuiButtonIcon iconType="italic" aria-label="Italic" />
+            </>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'selection' } }],
+      },
+      {
+        name: 'variant="selection" mixing EuiButton and EuiButtonIcon via EuiToolTip is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="selection">
+            <EuiButton>Bold</EuiButton>
+            <EuiToolTip content="Italic">
+              <EuiButtonIcon iconType="italic" aria-label="Italic" />
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'selection' } }],
       },
     ],
   }

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
@@ -14,39 +14,20 @@ import {
 import { hasSpread } from '../utils/has_spread';
 import { flatMap } from '../utils/flat_map';
 import { getElementName } from '../utils/get_element_name';
-import { walkJsxChildren } from '../utils/walk_jsx_children';
 import { findAttrValue } from '../utils/get_attr_value';
-
-const BUTTON_GROUP = 'EuiButtonGroup';
-export const VALID_BUTTONS = new Set([
-  'EuiButton',
-  'EuiButtonEmpty',
-  'EuiButtonIcon',
-]);
-export const SEGMENTED_VALID_BUTTONS = new Set(['EuiButton', 'EuiButtonIcon']);
-const VALID_WRAPPERS = new Set(['EuiToolTip', 'EuiPopover', 'EuiCopy']);
+import { collectJsxChildren } from '../utils/collect_jsx_children';
+import {
+  BUTTON_GROUP,
+  VALID_BUTTONS,
+  SEGMENTED_VALID_BUTTONS,
+  SELECTION_VALID_BUTTONS,
+  VALID_WRAPPERS,
+} from '../utils/button_group_constants';
 
 const VALID_WRAPPERS_LIST = Array.from(VALID_WRAPPERS).join(', ');
 
 function isCustomComponent(name: string): boolean {
   return name[0] === name[0].toUpperCase();
-}
-
-function collectJsxChildren(
-  node: TSESTree.Node,
-  sourceCode: TSESLint.SourceCode
-): TSESTree.JSXElement[] {
-  const results: TSESTree.JSXElement[] = [];
-  walkJsxChildren(
-    node,
-    (leaf) => {
-      if (leaf.type === 'JSXElement') {
-        results.push(leaf as TSESTree.JSXElement);
-      }
-    },
-    { sourceCode }
-  );
-  return results;
 }
 
 function reportInvalidWrapperChildren<
@@ -97,7 +78,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
             return;
           }
 
-          // Validate "default" and "segmented" variants.
+          // Validate "default", "segmented", and "selection" variants.
           // Dynamic variant values (variables) are conservatively skipped.
           const variant = findAttrValue(
             context,
@@ -107,14 +88,17 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
           if (
             variant !== undefined &&
             variant !== 'default' &&
-            variant !== 'segmented'
+            variant !== 'segmented' &&
+            variant !== 'selection'
           )
             return;
 
           const isSegmented = variant === 'segmented';
-          const validButtons = isSegmented
-            ? SEGMENTED_VALID_BUTTONS
-            : VALID_BUTTONS;
+          const isSelection = variant === 'selection';
+          const validButtons =
+            isSegmented || isSelection
+              ? SEGMENTED_VALID_BUTTONS
+              : VALID_BUTTONS;
           const allowed = Array.from(validButtons).join(', ');
 
           const children = flatMap(node.children, (c) =>
@@ -122,9 +106,10 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
           );
           if (children.length === 0) return;
 
-          // Collect seen button types for the segmented mixed-type check.
+          // Collect seen button types for the segmented/selection mixed-type check.
           // Populated during the main loop to avoid a second traversal.
-          const seenButtonTypes = isSegmented ? new Set<string>() : null;
+          const seenButtonTypes =
+            isSegmented || isSelection ? new Set<string>() : null;
 
           for (const child of children) {
             const name = getElementName(child.openingElement);
@@ -251,16 +236,17 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
             });
           }
 
-          // For segmented, all children must be the same button type — either
-          // all EuiButton or all EuiButtonIcon. Types are collected during the
-          // main loop above, including from EuiToolTip, EuiPopover, and EuiCopy.
+          // For segmented/selection, all children must be the same button type —
+          // either all EuiButton or all EuiButtonIcon. Types are collected during
+          // the main loop above, including from EuiToolTip, EuiPopover, and EuiCopy.
           if (
             seenButtonTypes?.has('EuiButton') &&
             seenButtonTypes.has('EuiButtonIcon')
           ) {
             context.report({
               node: openingElement,
-              messageId: 'invalidSegmentedMixedTypes',
+              messageId: 'invalidMixedTypes',
+              data: { variant: isSelection ? 'selection' : 'segmented' },
             });
           }
         },
@@ -310,8 +296,8 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
           `with a comment explaining why it renders valid button children:`,
           `// eslint-disable-next-line @elastic/eui/button-group-no-invalid-children -- SaveButton wraps EuiButton`,
         ].join(' '),
-        invalidSegmentedMixedTypes: [
-          `EuiButtonGroup with variant="segmented" must use a single button type throughout.`,
+        invalidMixedTypes: [
+          `EuiButtonGroup with variant="{{ variant }}" must use a single button type throughout.`,
           `Use either all EuiButton or all EuiButtonIcon children — not both.`,
         ].join(' '),
       },

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
@@ -56,9 +56,11 @@ function reportInvalidWrapperChildren<
     }
     context.report({
       node: wrapperChild.openingElement,
-      messageId: isCustomComponent(wrapperChildName) && !VALID_BUTTONS.has(wrapperChildName)
-        ? 'invalidUnresolvableWrapperChild'
-        : 'invalidWrapperChild',
+      messageId:
+        isCustomComponent(wrapperChildName) &&
+        !VALID_BUTTONS.has(wrapperChildName)
+          ? 'invalidUnresolvableWrapperChild'
+          : 'invalidWrapperChild',
       data: { name: wrapperChildName, wrapper: wrapperName, allowed },
     });
   }
@@ -95,9 +97,10 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
 
           const isSegmented = variant === 'segmented';
           const isSelection = variant === 'selection';
-          const validButtons =
-            isSegmented || isSelection
-              ? SEGMENTED_VALID_BUTTONS
+          const validButtons = isSegmented
+            ? SEGMENTED_VALID_BUTTONS
+            : isSelection
+              ? SELECTION_VALID_BUTTONS
               : VALID_BUTTONS;
           const allowed = Array.from(validButtons).join(', ');
 
@@ -189,9 +192,11 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
 
                         context.report({
                           node: tooltipChild.openingElement,
-                          messageId: isCustomComponent(tooltipChildName) && !VALID_BUTTONS.has(tooltipChildName)
-                            ? 'invalidUnresolvablePopoverButton'
-                            : 'invalidPopoverButton',
+                          messageId:
+                            isCustomComponent(tooltipChildName) &&
+                            !VALID_BUTTONS.has(tooltipChildName)
+                              ? 'invalidUnresolvablePopoverButton'
+                              : 'invalidPopoverButton',
                           data: { name: tooltipChildName, allowed },
                         });
                       }
@@ -199,9 +204,11 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                     }
                     context.report({
                       node: triggerElement.openingElement,
-                      messageId: isCustomComponent(triggerElementName) && !VALID_BUTTONS.has(triggerElementName)
-                        ? 'invalidUnresolvablePopoverButton'
-                        : 'invalidPopoverButton',
+                      messageId:
+                        isCustomComponent(triggerElementName) &&
+                        !VALID_BUTTONS.has(triggerElementName)
+                          ? 'invalidUnresolvablePopoverButton'
+                          : 'invalidPopoverButton',
                       data: { name: triggerElementName, allowed },
                     });
                   }
@@ -229,9 +236,10 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
 
             context.report({
               node: child.openingElement,
-              messageId: isCustomComponent(name) && !VALID_BUTTONS.has(name)
-                ? 'invalidUnresolvableChild'
-                : 'invalidChild',
+              messageId:
+                isCustomComponent(name) && !VALID_BUTTONS.has(name)
+                  ? 'invalidUnresolvableChild'
+                  : 'invalidChild',
               data: { name, allowed },
             });
           }

--- a/packages/eslint-plugin/src/rules/button_group_selection_require_id.test.ts
+++ b/packages/eslint-plugin/src/rules/button_group_selection_require_id.test.ts
@@ -1,0 +1,594 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import dedent from 'dedent';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { ButtonGroupSelectionRequireId } from './button_group_selection_require_id';
+
+const languageOptions = {
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+};
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(
+  'button-group-selection-requires-id',
+  ButtonGroupSelectionRequireId,
+  {
+    valid: [
+      // Direct children with id
+      {
+        name: 'EuiButton child with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton id="bold">Bold</EuiButton>
+            <EuiButton id="italic">Italic</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'EuiButtonIcon child with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButtonIcon id="bold" iconType="bold" aria-label="Bold" />
+            <EuiButtonIcon id="italic" iconType="italic" aria-label="Italic" />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Non-selection variants
+      {
+        name: 'options API (self-closing)',
+        code: dedent`
+          <EuiButtonGroup
+            legend="Format"
+            variant="selection"
+            options={[{ id: '1', label: 'One' }]}
+            idSelected="1"
+            onChange={() => {}}
+          />
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="default"',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="default">
+            <EuiButton>No id needed here</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'variant="segmented"',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="segmented">
+            <EuiButton>No id needed here</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'no variant',
+        code: dedent`
+          <EuiButtonGroup legend="Format">
+            <EuiButton>No id needed here</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'dynamic variant',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant={myVariant}>
+            <EuiButton>No id needed here</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Wrappers
+      {
+        name: 'EuiButton wrapped in EuiToolTip with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton id="bold">Bold</EuiButton>
+            <EuiToolTip content="Italic text">
+              <EuiButton id="italic">Italic</EuiButton>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'EuiButtonIcon wrapped in EuiToolTip with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiToolTip content="Bold">
+              <EuiButtonIcon id="bold" iconType="bold" aria-label="Bold" />
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'EuiPopover with EuiButton trigger with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton id="bold">Bold</EuiButton>
+            <EuiPopover button={<EuiButton id="more">More</EuiButton>} isOpen={false} closePopover={() => {}}>
+              Panel content
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'EuiPopover with EuiToolTip-wrapped trigger with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiPopover
+              button={<EuiToolTip content="More"><EuiButtonIcon id="more" iconType="boxesVertical" aria-label="More" /></EuiToolTip>}
+              isOpen={false}
+              closePopover={() => {}}
+            >
+              Panel content
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'EuiCopy render prop returning EuiButton with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton id="bold">Bold</EuiButton>
+            <EuiCopy textToCopy="text">
+              {(copy) => <EuiButton id="copy" onClick={copy}>Copy</EuiButton>}
+            </EuiCopy>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'EuiCopy block-body render prop with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiCopy textToCopy="text">
+              {(copy) => { return <EuiButton id="copy" onClick={copy}>Copy</EuiButton>; }}
+            </EuiCopy>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Fragments
+      {
+        name: 'shorthand fragment wrapping buttons with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <>
+              <EuiButton id="bold">Bold</EuiButton>
+              <EuiButton id="italic">Italic</EuiButton>
+            </>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: '<Fragment> wrapping buttons with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <Fragment>
+              <EuiButton id="bold">Bold</EuiButton>
+            </Fragment>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: '<React.Fragment> wrapping buttons with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <React.Fragment>
+              <EuiButton id="bold">Bold</EuiButton>
+              <EuiButton id="italic">Italic</EuiButton>
+            </React.Fragment>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Conditional rendering
+      {
+        name: '{condition && <EuiButton id />}',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton id="bold">Bold</EuiButton>
+            {showItalic && <EuiButton id="italic">Italic</EuiButton>}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'ternary with both branches having id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {isIcon
+              ? <EuiButtonIcon id="bold" iconType="bold" aria-label="Bold" />
+              : <EuiButton id="bold">Bold</EuiButton>}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'ternary with null alternate branch',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton id="bold">Bold</EuiButton>
+            {showItalic ? <EuiButton id="italic">Italic</EuiButton> : null}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: '{unresolvable || <EuiButton id />}',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {fallback || <EuiButton id="bold">Bold</EuiButton>}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: '{unresolvable ?? <EuiButton id />}',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {fallback ?? <EuiButton id="bold">Bold</EuiButton>}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Variable resolution
+      {
+        name: 'const variable holding a button with id is resolved and accepted',
+        code: dedent`
+          const button = <EuiButton id="bold">Bold</EuiButton>;
+          <EuiButtonGroup legend="Format" variant="selection">
+            {button}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'const variable holding a button array with id is resolved and accepted',
+        code: dedent`
+          const buttons = [
+            <EuiButton key="bold" id="bold">Bold</EuiButton>,
+            <EuiButton key="italic" id="italic">Italic</EuiButton>,
+          ];
+          <EuiButtonGroup legend="Format" variant="selection">
+            {buttons}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'reassigned variable',
+        code: dedent`
+          let button = <EuiButton>No id</EuiButton>;
+          button = <EuiButton id="bold">Bold</EuiButton>;
+          <EuiButtonGroup legend="Format" variant="selection">
+            {button}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Local arrow-function components
+      {
+        name: 'local arrow-fn returning button with id',
+        code: dedent`
+          const FormatButton = () => <EuiButton id="bold">Bold</EuiButton>;
+          <EuiButtonGroup legend="Format" variant="selection">
+            <FormatButton />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'local block-body arrow-fn returning button with id',
+        code: dedent`
+          const FormatButton = () => { return <EuiButton id="bold">Bold</EuiButton>; };
+          <EuiButtonGroup legend="Format" variant="selection">
+            <FormatButton />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // map()
+      {
+        name: 'map() with expression-body button with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {buttons.map((b) => <EuiButton key={b.id} id={b.id}>{b.label}</EuiButton>)}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'map() with block-body button with id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {buttons.map((b) => {
+              return <EuiButton key={b.id} id={b.id}>{b.label}</EuiButton>;
+            })}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Spread bail-outs
+      {
+        name: 'spread props on child',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton {...buttonProps} />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+      {
+        name: 'spread props on child inside EuiToolTip',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiToolTip content="Bold">
+              <EuiButtonIcon {...iconProps} />
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Function call — not resolvable
+      {
+        name: 'function call child',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {renderButtons()}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+
+      // Non-button children
+      {
+        name: 'non-button children without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <div>Not a button</div>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+      },
+    ],
+
+    invalid: [
+      // Direct children missing id
+      {
+        name: 'EuiButton without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton>Bold</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+      {
+        name: 'EuiButtonIcon without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButtonIcon iconType="bold" aria-label="Bold" />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButtonIcon' } }],
+      },
+      {
+        name: 'multiple children without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton id="bold">Bold</EuiButton>
+            <EuiButton>Italic</EuiButton>
+            <EuiButton>Underline</EuiButton>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          { messageId: 'missingId', data: { name: 'EuiButton' } },
+          { messageId: 'missingId', data: { name: 'EuiButton' } },
+        ],
+      },
+
+      // Wrappers — button inside missing id
+      {
+        name: 'EuiToolTip wrapping button without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiToolTip content="Bold">
+              <EuiButton>Bold</EuiButton>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+      {
+        name: 'EuiToolTip with spread props on wrapper but button inside missing id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiToolTip content="Bold" {...tooltipProps}>
+              <EuiButton>Bold</EuiButton>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+      {
+        name: 'EuiPopover button prop without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiPopover button={<EuiButton>More</EuiButton>} isOpen={false} closePopover={() => {}}>
+              Panel content
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+      {
+        name: 'EuiPopover with EuiToolTip-wrapped trigger without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiPopover
+              button={<EuiToolTip content="More"><EuiButtonIcon iconType="boxesVertical" aria-label="More" /></EuiToolTip>}
+              isOpen={false}
+              closePopover={() => {}}
+            >
+              Panel content
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButtonIcon' } }],
+      },
+      {
+        name: 'EuiCopy render prop returning button without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiCopy textToCopy="text">
+              {(copy) => <EuiButton onClick={copy}>Copy</EuiButton>}
+            </EuiCopy>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+
+      // Fragments
+      {
+        name: 'fragment wrapping button without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <>
+              <EuiButton id="bold">Bold</EuiButton>
+              <EuiButton>Italic</EuiButton>
+            </>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+
+      // Conditional rendering
+      {
+        name: '{condition && <EuiButton />}',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            <EuiButton id="bold">Bold</EuiButton>
+            {showItalic && <EuiButton>Italic</EuiButton>}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+      {
+        name: 'ternary with one branch without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {isIcon
+              ? <EuiButtonIcon id="bold" iconType="bold" aria-label="Bold" />
+              : <EuiButton>Bold</EuiButton>}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+      {
+        name: '{unresolvable || <EuiButton />}',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {fallback || <EuiButton>Bold</EuiButton>}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+
+      // Variable resolution
+      {
+        name: 'const variable holding button without id',
+        code: dedent`
+          const button = <EuiButton>Bold</EuiButton>;
+          <EuiButtonGroup legend="Format" variant="selection">
+            {button}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+
+      // Local arrow-function components
+      {
+        name: 'local arrow-fn returning button without id',
+        code: dedent`
+          const FormatButton = () => <EuiButton>Bold</EuiButton>;
+          <EuiButtonGroup legend="Format" variant="selection">
+            <FormatButton />
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+
+      // map()
+      {
+        name: 'map() with expression-body button without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {buttons.map((b) => <EuiButton key={b.id}>{b.label}</EuiButton>)}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+      {
+        name: 'map() with block-body button without id',
+        code: dedent`
+          <EuiButtonGroup legend="Format" variant="selection">
+            {buttons.map((b) => {
+              return <EuiButton key={b.id}>{b.label}</EuiButton>;
+            })}
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [{ messageId: 'missingId', data: { name: 'EuiButton' } }],
+      },
+    ],
+  }
+);

--- a/packages/eslint-plugin/src/rules/button_group_selection_require_id.test.ts
+++ b/packages/eslint-plugin/src/rules/button_group_selection_require_id.test.ts
@@ -21,7 +21,7 @@ const languageOptions = {
 const ruleTester = new RuleTester();
 
 ruleTester.run(
-  'button-group-selection-requires-id',
+  'button-group-selection-require-id',
   ButtonGroupSelectionRequireId,
   {
     valid: [

--- a/packages/eslint-plugin/src/rules/button_group_selection_require_id.ts
+++ b/packages/eslint-plugin/src/rules/button_group_selection_require_id.ts
@@ -15,23 +15,13 @@ import { hasSpread } from '../utils/has_spread';
 import { flatMap } from '../utils/flat_map';
 import { getElementName } from '../utils/get_element_name';
 import { findAttrValue } from '../utils/get_attr_value';
+import { hasMeaningfulAttr } from '../utils/has_meaningful_attr';
 import { collectJsxChildren } from '../utils/collect_jsx_children';
 import {
   BUTTON_GROUP,
   SELECTION_VALID_BUTTONS,
   VALID_WRAPPERS,
 } from '../utils/button_group_constants';
-
-function hasIdAttr(
-  attributes: TSESTree.JSXOpeningElement['attributes']
-): boolean {
-  return attributes.some(
-    (attr): attr is TSESTree.JSXAttribute =>
-      attr.type === 'JSXAttribute' &&
-      attr.name.type === 'JSXIdentifier' &&
-      attr.name.name === 'id'
-  );
-}
 
 function checkButtonForId<
   TContext extends TSESLint.RuleContext<string, unknown[]>,
@@ -40,7 +30,7 @@ function checkButtonForId<
   if (name === null || !SELECTION_VALID_BUTTONS.has(name)) return;
 
   const { attributes } = element.openingElement;
-  if (hasIdAttr(attributes)) return;
+  if (hasMeaningfulAttr(element.openingElement, 'id')) return;
   if (hasSpread(attributes)) return;
 
   context.report({

--- a/packages/eslint-plugin/src/rules/button_group_selection_require_id.ts
+++ b/packages/eslint-plugin/src/rules/button_group_selection_require_id.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  type TSESTree,
+  type TSESLint,
+  ESLintUtils,
+} from '@typescript-eslint/utils';
+import { hasSpread } from '../utils/has_spread';
+import { flatMap } from '../utils/flat_map';
+import { getElementName } from '../utils/get_element_name';
+import { findAttrValue } from '../utils/get_attr_value';
+import { collectJsxChildren } from '../utils/collect_jsx_children';
+import {
+  BUTTON_GROUP,
+  SELECTION_VALID_BUTTONS,
+  VALID_WRAPPERS,
+} from '../utils/button_group_constants';
+
+function hasIdAttr(
+  attributes: TSESTree.JSXOpeningElement['attributes']
+): boolean {
+  return attributes.some(
+    (attr): attr is TSESTree.JSXAttribute =>
+      attr.type === 'JSXAttribute' &&
+      attr.name.type === 'JSXIdentifier' &&
+      attr.name.name === 'id'
+  );
+}
+
+function checkButtonForId<
+  TContext extends TSESLint.RuleContext<string, unknown[]>,
+>(element: TSESTree.JSXElement, context: TContext): void {
+  const name = getElementName(element.openingElement);
+  if (name === null || !SELECTION_VALID_BUTTONS.has(name)) return;
+
+  const { attributes } = element.openingElement;
+  if (hasIdAttr(attributes)) return;
+  if (hasSpread(attributes)) return;
+
+  context.report({
+    node: element.openingElement,
+    messageId: 'missingId',
+    data: { name },
+  });
+}
+
+export const ButtonGroupSelectionRequireId =
+  ESLintUtils.RuleCreator.withoutDocs({
+    create(context) {
+      return {
+        JSXElement(node) {
+          const { openingElement } = node;
+
+          if (
+            openingElement.name.type !== 'JSXIdentifier' ||
+            openingElement.name.name !== BUTTON_GROUP
+          ) {
+            return;
+          }
+
+          // Only validate variant="selection". Dynamic or other variants are skipped.
+          const variant = findAttrValue(
+            context,
+            openingElement.attributes,
+            'variant'
+          );
+          if (variant !== 'selection') return;
+
+          const children = flatMap(node.children, (c) =>
+            collectJsxChildren(c, context.sourceCode)
+          );
+          if (children.length === 0) return;
+
+          for (const child of children) {
+            const name = getElementName(child.openingElement);
+            if (name === null) continue;
+
+            if (SELECTION_VALID_BUTTONS.has(name)) {
+              checkButtonForId(child, context);
+              continue;
+            }
+
+            if (VALID_WRAPPERS.has(name)) {
+              if (name === 'EuiToolTip') {
+                const wrapperChildren = flatMap(child.children, (c) =>
+                  collectJsxChildren(c, context.sourceCode)
+                );
+                for (const wrapperChild of wrapperChildren) {
+                  checkButtonForId(wrapperChild, context);
+                }
+              } else if (name === 'EuiPopover') {
+                const buttonProp = child.openingElement.attributes.find(
+                  (attr): attr is TSESTree.JSXAttribute =>
+                    attr.type === 'JSXAttribute' &&
+                    attr.name.type === 'JSXIdentifier' &&
+                    attr.name.name === 'button'
+                );
+
+                if (buttonProp?.value != null) {
+                  const triggerElements = collectJsxChildren(
+                    buttonProp.value as TSESTree.Node,
+                    context.sourceCode
+                  );
+
+                  for (const triggerElement of triggerElements) {
+                    const triggerName = getElementName(
+                      triggerElement.openingElement
+                    );
+                    if (triggerName === null) continue;
+
+                    if (SELECTION_VALID_BUTTONS.has(triggerName)) {
+                      checkButtonForId(triggerElement, context);
+                      continue;
+                    }
+
+                    if (triggerName === 'EuiToolTip') {
+                      // EuiToolTip wrapping the popover trigger — check its children.
+                      const tooltipChildren = flatMap(
+                        triggerElement.children,
+                        (c) => collectJsxChildren(c, context.sourceCode)
+                      );
+                      for (const tooltipChild of tooltipChildren) {
+                        checkButtonForId(tooltipChild, context);
+                      }
+                    }
+                  }
+                }
+              } else if (name === 'EuiCopy') {
+                // Children is a render prop; walkJsxChildren expands it.
+                const wrapperChildren = flatMap(child.children, (c) =>
+                  collectJsxChildren(c, context.sourceCode)
+                );
+                for (const wrapperChild of wrapperChildren) {
+                  checkButtonForId(wrapperChild, context);
+                }
+              }
+              continue;
+            }
+
+            // Non-button, non-wrapper children are skipped — the other rule handles those.
+          }
+        },
+      };
+    },
+    meta: {
+      type: 'problem',
+      docs: {
+        description:
+          'Enforce that EuiButtonGroup children have an id prop when variant="selection"',
+      },
+      schema: [],
+      messages: {
+        missingId: [
+          `{{ name }} inside EuiButtonGroup with variant="selection" is missing a required id prop.`,
+          `Each button must have a unique id so the group can track selection state.`,
+        ].join(' '),
+      },
+    },
+    defaultOptions: [],
+  });

--- a/packages/eslint-plugin/src/utils/button_group_constants.ts
+++ b/packages/eslint-plugin/src/utils/button_group_constants.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const BUTTON_GROUP = 'EuiButtonGroup';
+
+export const VALID_BUTTONS = new Set([
+  'EuiButton',
+  'EuiButtonEmpty',
+  'EuiButtonIcon',
+]);
+
+export const SEGMENTED_VALID_BUTTONS = new Set(['EuiButton', 'EuiButtonIcon']);
+
+export const SELECTION_VALID_BUTTONS = new Set(['EuiButton', 'EuiButtonIcon']);
+
+export const VALID_WRAPPERS = new Set(['EuiToolTip', 'EuiPopover', 'EuiCopy']);

--- a/packages/eslint-plugin/src/utils/collect_jsx_children.ts
+++ b/packages/eslint-plugin/src/utils/collect_jsx_children.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { type TSESTree, type TSESLint } from '@typescript-eslint/utils';
+import { walkJsxChildren } from './walk_jsx_children';
+
+export function collectJsxChildren(
+  node: TSESTree.Node,
+  sourceCode: TSESLint.SourceCode
+): TSESTree.JSXElement[] {
+  const results: TSESTree.JSXElement[] = [];
+  walkJsxChildren(
+    node,
+    (leaf) => {
+      if (leaf.type === 'JSXElement') {
+        results.push(leaf as TSESTree.JSXElement);
+      }
+    },
+    { sourceCode }
+  );
+  return results;
+}


### PR DESCRIPTION
## Summary

>[!note]
This PR is related to https://github.com/elastic/eui/pull/9929 which adds `variant="selection"` to `EuiButtonGroup`.
This PR should be rebased after merging the implementation PR.

- **What:** 
  - Extends the existing `button-group-no-invalid-children` ESLint rule with validation for `variant="selection"`
  - Adds a new `button-group-selection-require-id` rule that enforces a required `id` prop on each child button
- **Why:** Part of the button group redesign work. selection variant behaves the same as segmented variants an we want to enforce expected children usage.
- **How:**
  - Extends `button-group-no-invalid-children` to support checks on `variant="selection"`
  - Adds new rule `button-group-selection-require-id` which checks if button group children with `variant="selection" each have an required `id`
- Refactors shared constants and utils for button group rule into a centralized place

**Examples - `button-group-no-invalid-children` for `variant="selection"`**

✅ valid
```jsx
// EuiButton children only
<EuiButtonGroup legend="Format" variant="selection">
  <EuiButton id="bold">Bold</EuiButton>
  <EuiButton id="italic">Italic</EuiButton>
</EuiButtonGroup>

// EuiButtonIcon children only
<EuiButtonGroup legend="Format" variant="selection">
  <EuiButtonIcon id="bold" iconType="bold" aria-label="Bold" />
  <EuiButtonIcon id="italic" iconType="italic" aria-label="Italic" />
</EuiButtonGroup>

// EuiToolTip wrapping a valid button
<EuiButtonGroup legend="Format" variant="selection">
  <EuiButton id="bold">Bold</EuiButton>
  <EuiToolTip content="Italic text">
    <EuiButton id="italic">Italic</EuiButton>
  </EuiToolTip>
</EuiButtonGroup>
```

❌ invalid
```jsx
// EuiButtonEmpty is not valid for selection
<EuiButtonGroup legend="Format" variant="selection">
  <EuiButtonEmpty color="text">Cancel</EuiButtonEmpty>
</EuiButtonGroup>

// mixing EuiButton and EuiButtonIcon is not allowed
<EuiButtonGroup legend="Format" variant="selection">
  <EuiButton id="bold">Bold</EuiButton>
  <EuiButtonIcon id="italic" iconType="italic" aria-label="Italic" />
</EuiButtonGroup>
```

**Examples - `button-group-selection-require-id`**

✅ valid
```jsx
<EuiButtonGroup legend="Format" variant="selection">
  <EuiButton id="bold">Bold</EuiButton>
  <EuiToolTip content="Italic">
    <EuiButton id="italic">Italic</EuiButton>
  </EuiToolTip>
  <EuiPopover button={<EuiButton id="more">More</EuiButton>} isOpen={false} closePopover={() => {}}>
    Panel content
  </EuiPopover>
</EuiButtonGroup>
```

❌ invalid
```jsx
// missing id on direct child
<EuiButtonGroup legend="Format" variant="selection">
  <EuiButton>Bold</EuiButton>
</EuiButtonGroup>

// missing id on button inside EuiToolTip
<EuiButtonGroup legend="Format" variant="selection">
  <EuiToolTip content="Italic">
    <EuiButton>Italic</EuiButton>
  </EuiToolTip>
</EuiButtonGroup>

// missing id on EuiPopover trigger
<EuiButtonGroup legend="Format" variant="selection">
  <EuiPopover button={<EuiButton>More</EuiButton>} isOpen={false} closePopover={() => {}}>
    Panel content
  </EuiPopover>
</EuiButtonGroup>
```

**What the rules validate for `variant="selection"`**

1. `button-group-no-invalid-children`:
- Valid direct children: `EuiButton`, `EuiButtonIcon`
- Valid wrappers: same as other variants (`EuiToolTip`, `EuiPopover`, `EuiCopy`) 
- Mixed types: reports `invalidMixedTypes` when both `EuiButton` and `EuiButtonIcon` appear in the same group

2. `button-group-selection-require-id`:
- Reports `missingId` for any `EuiButton`/`EuiButtonIcon` without an explicit `id` attribute
- Spread props (`{...props}`) are skipped conservatively (`id` may be passed via the spread)
- Only fires for `variant="selection"` (static string); dynamic variants are skipped

### API Changes

⚪ No API changes

## Screenshots

<img width="930" height="350" alt="Screenshot 2026-08-24 at 17 43 55" src="https://github.com/user-attachments/assets/85448ae3-23f3-4564-b32b-8ae6d6c4e40e" />

<img width="959" height="471" alt="Screenshot 2026-08-24 at 17 43 15" src="https://github.com/user-attachments/assets/76ce94fb-58d2-4812-96c6-8cfb104bfd7a" />



## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

<!--
If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL to `packages/release-cli/kibana-prep-commits` (one URL per line). The nightly Kibana integration run cherry-picks those commits onto its draft PR. Entries are cleared automatically during the EUI release process.
-->

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

- [x] CI passes
- [ ] verify locally the rules apply and flag invalid usages
  - checkout the PR
  - run `yarn workspace @elastic/eslint-plugin-eui build` on root
  - run `yarn workspace @elastic/eui build:workspaces` on root
  - add a testing code example (e.g. see above) and run `yarn workspace @elastic/eui lint` on root

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
