### PR TITLE
[Chore] Rotate kibana-prep-commits on release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,7 +55,7 @@ Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/
 - [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.
 
 <!--
-If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL to `packages/release-cli/kibana-prep-commits` (one URL per line). The nightly Kibana integration run cherry-picks those commits onto its draft PR. Leave entries until the Kibana upgrade PR that includes them has merged; nightly skips commits already applied.
+If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL under `@next` in `packages/release-cli/kibana-prep-commits` (one URL per line). Nightly cherry-picks `@next` and `@previous`. On release, `@next` moves to `@previous` and `@previous` is cleared. Missing or already-applied commits are skipped.
 -->
 
 **Impact level:** 🟢 None / 🟢 Low / 🟡 Moderate / 🔴 High

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -55,7 +55,7 @@ Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/
 - [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.
 
 <!--
-If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL to `packages/release-cli/kibana-prep-commits` (one URL per line). The nightly Kibana integration run cherry-picks those commits onto its draft PR. Entries are cleared automatically during the EUI release process.
+If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL to `packages/release-cli/kibana-prep-commits` (one URL per line). The nightly Kibana integration run cherry-picks those commits onto its draft PR. Leave entries until the Kibana upgrade PR that includes them has merged; nightly skips commits already applied.
 -->
 
 **Impact level:** 🟢 None / 🟢 Low / 🟡 Moderate / 🔴 High

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -141,10 +141,18 @@ jobs:
 
             echo "Cherry-picking $sha from PR #$pr_number"
             git fetch origin "pull/$pr_number/head"
-            git cherry-pick "$sha"
 
-            short_sha="${sha:0:8}"
-            notes+="- [\`$short_sha\`](https://github.com/elastic/kibana/pull/$pr_number/commits/$sha) from elastic/kibana#$pr_number"$'\n'
+            if git cherry-pick "$sha"; then
+              short_sha="${sha:0:8}"
+              notes+="- [\`$short_sha\`](https://github.com/elastic/kibana/pull/$pr_number/commits/$sha) from elastic/kibana#$pr_number"$'\n'
+            elif git diff --quiet && git diff --cached --quiet; then
+              echo "Skipping $sha: already applied on this branch"
+              git cherry-pick --skip
+            else
+              echo "::error::Cherry-pick of $sha from PR #$pr_number failed"
+              git cherry-pick --abort || true
+              exit 1
+            fi
           done <<< "$prep_commits"
 
           if [[ -n "$notes" ]]; then

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -140,7 +140,15 @@ jobs:
             fi
 
             echo "Cherry-picking $sha from PR #$pr_number"
-            git fetch origin "pull/$pr_number/head"
+            if ! git fetch origin "pull/$pr_number/head"; then
+              echo "::warning::Skipping $sha: could not fetch PR #$pr_number"
+              continue
+            fi
+
+            if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+              echo "::warning::Skipping $sha: commit not on PR #$pr_number (force-pushed?)"
+              continue
+            fi
 
             if git cherry-pick "$sha"; then
               short_sha="${sha:0:8}"

--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -1,10 +1,14 @@
 # List Kibana prep commits to cherry-pick during the nightly Kibana integration run.
-# Add one URL per line in the format:
+# Add URLs under @next, one per line:
 # https://github.com/elastic/kibana/pull/NNNN/commits/COMMIT_SHA
 #
-# Remove entries after the Kibana upgrade PR that includes them has merged.
-# Nightly skips commits that are already applied.
+# On release, @next moves to @previous and @previous is cleared.
+# Nightly cherry-picks both sections, skipping commits that are missing or already applied.
+
+# @next
+https://github.com/elastic/kibana/pull/274656/commits/8ec324da4d10e4a7bfa4a121fb2c391535d17738
+
+# @previous
 https://github.com/elastic/kibana/pull/244898/commits/f3a7f97976213c6f2f5334aafd112455ff94d8f9
 https://github.com/elastic/kibana/pull/235177/commits/63b73732214e2cb2aa82b30bc2762bed8703c428
 https://github.com/elastic/kibana/pull/235177/commits/1d2d213025ef53336a6f366b1b6031e2a96b1817
-https://github.com/elastic/kibana/pull/274656/commits/8ec324da4d10e4a7bfa4a121fb2c391535d17738

--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -2,5 +2,9 @@
 # Add one URL per line in the format:
 # https://github.com/elastic/kibana/pull/NNNN/commits/COMMIT_SHA
 #
-# Entries are cleared as part of the EUI release process.
+# Remove entries after the Kibana upgrade PR that includes them has merged.
+# Nightly skips commits that are already applied.
+https://github.com/elastic/kibana/pull/244898/commits/f3a7f97976213c6f2f5334aafd112455ff94d8f9
+https://github.com/elastic/kibana/pull/235177/commits/63b73732214e2cb2aa82b30bc2762bed8703c428
+https://github.com/elastic/kibana/pull/235177/commits/1d2d213025ef53336a6f366b1b6031e2a96b1817
 https://github.com/elastic/kibana/pull/274656/commits/8ec324da4d10e4a7bfa4a121fb2c391535d17738

--- a/packages/release-cli/src/steps/update_versions.ts
+++ b/packages/release-cli/src/steps/update_versions.ts
@@ -7,7 +7,6 @@
  */
 
 import path from 'node:path';
-import fs from 'node:fs/promises';
 import { type ReleaseOptions } from '../release';
 import { type YarnWorkspace, updateWorkspaceVersion } from '../yarn_utils';
 import {
@@ -32,23 +31,6 @@ import {
   isFileAddedToGit,
   stageFiles,
 } from '../git_utils';
-
-const KIBANA_PREP_COMMITS_FILE = 'packages/release-cli/kibana-prep-commits';
-
-const clearKibanaPrepCommits = async (
-  rootWorkspaceDir: string
-): Promise<string | null> => {
-  const filePath = path.join(rootWorkspaceDir, KIBANA_PREP_COMMITS_FILE);
-  const content = await fs.readFile(filePath, 'utf-8').catch(() => null);
-
-  if (content === null) return null;
-
-  const cleared = content.replace(/^(?!\s*#).*\S.*\n?/gm, '');
-  if (cleared === content) return null;
-
-  await fs.writeFile(filePath, cleared, 'utf-8');
-  return filePath;
-};
 
 /**
  * Update version numbers and yearly changelogs based on workspace
@@ -146,13 +128,6 @@ export const stepUpdateVersions = async (
     const yarnLockPath = path.join(rootWorkspaceDir, 'yarn.lock');
     filesToCommit.push(yarnLockPath);
     await stageFiles([yarnLockPath]);
-
-    // Clear Kibana prep commits and include in the release commit
-    const kibanaPrepCommitsPath =
-      await clearKibanaPrepCommits(rootWorkspaceDir);
-    if (kibanaPrepCommitsPath) {
-      filesToCommit.push(kibanaPrepCommitsPath);
-    }
 
     // Stage updated package.json files
     const uniqueFilesToCommit = [...new Set(filesToCommit)];

--- a/packages/release-cli/src/steps/update_versions.ts
+++ b/packages/release-cli/src/steps/update_versions.ts
@@ -7,6 +7,7 @@
  */
 
 import path from 'node:path';
+import fs from 'node:fs/promises';
 import { type ReleaseOptions } from '../release';
 import { type YarnWorkspace, updateWorkspaceVersion } from '../yarn_utils';
 import {
@@ -31,6 +32,71 @@ import {
   isFileAddedToGit,
   stageFiles,
 } from '../git_utils';
+
+const KIBANA_PREP_COMMITS_FILE = 'packages/release-cli/kibana-prep-commits';
+
+const KIBANA_PREP_COMMITS_HEADER = `# List Kibana prep commits to cherry-pick during the nightly Kibana integration run.
+# Add URLs under @next, one per line:
+# https://github.com/elastic/kibana/pull/NNNN/commits/COMMIT_SHA
+#
+# On release, @next moves to @previous and @previous is cleared.
+# Nightly cherry-picks both sections, skipping commits that are missing or already applied.
+`;
+
+const parseKibanaPrepCommits = (
+  content: string
+): { next: string[]; previous: string[] } => {
+  const next: string[] = [];
+  const previous: string[] = [];
+  let section: 'next' | 'previous' | 'legacy' = 'legacy';
+
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (/^#\s*@next\b/i.test(trimmed)) {
+      section = 'next';
+      continue;
+    }
+    if (/^#\s*@previous\b/i.test(trimmed)) {
+      section = 'previous';
+      continue;
+    }
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    if (section === 'previous') previous.push(trimmed);
+    else next.push(trimmed);
+  }
+
+  return { next, previous };
+};
+
+const serializeKibanaPrepCommits = (
+  next: string[],
+  previous: string[]
+): string => {
+  const nextBlock = next.length ? `${next.join('\n')}\n` : '';
+  const previousBlock = previous.length ? `${previous.join('\n')}\n` : '';
+  return `${KIBANA_PREP_COMMITS_HEADER}
+# @next
+${nextBlock}
+# @previous
+${previousBlock}`;
+};
+
+const rotateKibanaPrepCommits = async (
+  rootWorkspaceDir: string
+): Promise<string | null> => {
+  const filePath = path.join(rootWorkspaceDir, KIBANA_PREP_COMMITS_FILE);
+  const content = await fs.readFile(filePath, 'utf-8').catch(() => null);
+
+  if (content === null) return null;
+
+  const { next } = parseKibanaPrepCommits(content);
+  const rotated = serializeKibanaPrepCommits([], next);
+  if (rotated === content) return null;
+
+  await fs.writeFile(filePath, rotated, 'utf-8');
+  return filePath;
+};
 
 /**
  * Update version numbers and yearly changelogs based on workspace
@@ -128,6 +194,14 @@ export const stepUpdateVersions = async (
     const yarnLockPath = path.join(rootWorkspaceDir, 'yarn.lock');
     filesToCommit.push(yarnLockPath);
     await stageFiles([yarnLockPath]);
+
+    // @next -> @previous, @previous cleared. Nightly still cherry-picks both
+    // until the following release, covering the Kibana upgrade merge window.
+    const kibanaPrepCommitsPath =
+      await rotateKibanaPrepCommits(rootWorkspaceDir);
+    if (kibanaPrepCommitsPath) {
+      filesToCommit.push(kibanaPrepCommitsPath);
+    }
 
     // Stage updated package.json files
     const uniqueFilesToCommit = [...new Set(filesToCommit)];


### PR DESCRIPTION
## Summary

Release wiped prep commits before the Kibana upgrade merged. Nightly went red on known issues. See [Slack thread](https://elastic.slack.com/archives/C04UK0RDL2J/p1787637343126859) for context.

On release, `@next` moves to `@previous`. `@previous` is cleared. Nightly cherry-picks both. Missing or already-applied SHAs are skipped.

Restored the three v119.1.0 SHAs into `@previous` so nightly stays green while [elastic/kibana#286829](https://github.com/elastic/kibana/pull/286829) is open.