### PR TITLE
Harden EuiFilterButtonObject spec against Storybook args reliability

### DIFF
--- a/packages/test-helpers/src/components/filter_button/README.md
+++ b/packages/test-helpers/src/components/filter_button/README.md
@@ -18,7 +18,7 @@ Set `data-test-subj` on the `<EuiFilterButton>` (EUI spreads it onto the button 
 
 | Member | Description |
 |---|---|
-| `locator` | Inherited root `Locator`. Assert the button's active/selected state directly on it, e.g. `toHaveClass(/euiFilterButton-hasActiveFilters/)` or `toHaveClass(/euiFilterButton-isSelected/)` — both are synchronous CSS classes EUI sets, not async state. |
+| `locator` | Inherited root `Locator`. Assert the button's active/selected state directly on it, e.g. `toHaveClass(/euiFilterButton-hasActiveFilters/)` or `toHaveClass(/euiFilterButton-isSelected/)`. Both are synchronous CSS classes EUI sets, not async state. |
 | `notificationBadge` | `Locator` for the filter-count badge. Only present when the consumer passes `numFilters` or `numActiveFilters`. |
 
 ## Deliberately out of scope

--- a/packages/test-helpers/src/playwright/components/filter_button/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/filter_button/object.props.spec.ts
@@ -15,9 +15,13 @@ const TEST_SUBJ = 'testFilterButton';
 
 test.describe('EuiFilterButtonObject', () => {
   test.describe('isSelected (e.g. while its popover is open)', () => {
+    // Use Storybook's `!`-typed arg syntax for the booleans, not plain
+    // `true`/`false` strings. A manually-declared argType with typed options
+    // (as opposed to an auto-inferred boolean) can silently reject a plain
+    // string and fall back to its own default, with no error to flag it.
     const SELECTED_URL = storyUrl(
       'forms-euifilterbutton--playground',
-      `data-test-subj:${TEST_SUBJ};hasActiveFilters:false;isSelected:true`
+      `data-test-subj:${TEST_SUBJ};hasActiveFilters:!false;isSelected:!true`
     );
 
     test('carries the isSelected class, not the hasActiveFilters class', async ({ page }) => {

--- a/packages/test-helpers/src/playwright/components/filter_button/object.ts
+++ b/packages/test-helpers/src/playwright/components/filter_button/object.ts
@@ -17,10 +17,10 @@ import { EuiFilterButtonSelectors } from '../../../components/filter_button/sele
  *
  * `testSubj` must match the `data-test-subj` set by the consumer on the
  * `<EuiFilterButton>` (EUI spreads it onto the button itself). Deliberately
- * does not own opening/closing a popover triggered by the button — `EuiPopover`
+ * does not own opening/closing a popover triggered by the button. `EuiPopover`
  * already sets `aria-expanded`/`aria-controls` on its toggle synchronously
  * itself, so drive that from the test directly. It also does not own reading
- * or selecting options inside that popover — when the popover content is an
+ * or selecting options inside that popover. When the popover content is an
  * `EuiSelectable`, use {@link EuiSelectableObject} scoped to it instead.
  */
 export class EuiFilterButtonObject extends BaseObject {
@@ -32,11 +32,11 @@ export class EuiFilterButtonObject extends BaseObject {
    * The notification badge showing the available/active filter count, as a
    * `Locator` so callers keep Playwright auto-retry for its text
    * (e.g. `expect(filterButton.notificationBadge).toHaveText('2')`). Only
-   * present when the consumer passes `numFilters` or `numActiveFilters` —
+   * present when the consumer passes `numFilters` or `numActiveFilters`,
    * absent otherwise, so assert presence first if that is in question.
    *
    * For the button's own active/selected state, assert directly on
-   * {@link BaseObject.locator} rather than through a dedicated method — both
+   * {@link BaseObject.locator} rather than through a dedicated method. Both
    * are synchronous CSS classes EUI sets on the root
    * (`euiFilterButton-hasActiveFilters`, `euiFilterButton-isSelected`), e.g.
    * `expect(filterButton.locator).toHaveClass(/euiFilterButton-hasActiveFilters/)`.


### PR DESCRIPTION
Follow-up to #9942.

1. Rewrites a few comment/doc sentences that used em dashes, house style avoids them, no behavior change.
2. Hardens the isSelected props spec against a class of Storybook reliability gap: switches its boolean overrides (`hasActiveFilters`, `isSelected`) to Storybook's `!`-typed arg syntax instead of plain `true`/`false` strings. Investigated a CI failure on this exact test (reported separately), could not reproduce locally including a full 69-test run matching CI's worker count against a freshly built static Storybook, but this closes the same class of gap already found and fixed in EuiRangeObject's showInput override: a manually-typed Storybook control can silently reject a plain boolean string and fall back to its own default, with no error.