### PR TITLE
Fix EuiFilterButtonObject isSelected spec

### DIFF
--- a/packages/test-helpers/src/playwright/components/filter_button/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/filter_button/object.props.spec.ts
@@ -15,9 +15,10 @@ const TEST_SUBJ = 'testFilterButton';
 
 test.describe('EuiFilterButtonObject', () => {
   test.describe('isSelected (e.g. while its popover is open)', () => {
+    // Use Storybook's `!`-typed arg syntax for booleans, not plain strings.
     const SELECTED_URL = storyUrl(
       'forms-euifilterbutton--playground',
-      `data-test-subj:${TEST_SUBJ};hasActiveFilters:false;isSelected:true`
+      `data-test-subj:${TEST_SUBJ};hasActiveFilters:!false;isSelected:!true`
     );
 
     test('carries the isSelected class, not the hasActiveFilters class', async ({ page }) => {


### PR DESCRIPTION
Fixes a spec bug found via Weronika's report on chore/storybook-vite-builder. The isSelected spec set hasActiveFilters/isSelected via plain true/false strings in the Storybook args URL, which the Vite builder deserializes wrong (falls back to defaults, no error). Switched to Storybook's typed !true/!false arg syntax. Verified 20/20 against a Storybook build from that branch.