### PR TITLE
[EuiDatePicker] Remove legacy string refs from react-datepicker dropdowns

### DIFF
--- a/packages/eui/changelogs/upcoming/9960.md
+++ b/packages/eui/changelogs/upcoming/9960.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiDatePicker` throwing an error in React 19 when opening the month or year dropdown

--- a/packages/eui/src/components/date_picker/react-datepicker/src/month_dropdown.jsx
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/month_dropdown.jsx
@@ -164,7 +164,6 @@ export default class MonthDropdown extends React.Component {
   renderDropdown = monthNames => (
     <MonthDropdownOptions
       key="dropdown"
-      ref="options"
       month={this.props.month}
       monthNames={monthNames}
       onChange={this.onChange}

--- a/packages/eui/src/components/date_picker/react-datepicker/src/month_dropdown_options.jsx
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/month_dropdown_options.jsx
@@ -57,7 +57,6 @@ export default class MonthDropdownOptions extends React.Component {
             this.props.accessibleMode && this.state.preSelection === i
         })}
         key={month}
-        ref={month}
         onClick={this.onChange.bind(this, i)}
       >
         {this.props.month === i ? (

--- a/packages/eui/src/components/date_picker/react-datepicker/src/month_year_dropdown.jsx
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/month_year_dropdown.jsx
@@ -166,7 +166,6 @@ export default class MonthYearDropdown extends React.Component {
   renderDropdown = () => (
     <MonthYearDropdownOptions
       key="dropdown"
-      ref="options"
       date={this.props.date}
       dateFormat={this.props.dateFormat}
       onChange={this.onChange}

--- a/packages/eui/src/components/date_picker/react-datepicker/src/year_dropdown.jsx
+++ b/packages/eui/src/components/date_picker/react-datepicker/src/year_dropdown.jsx
@@ -149,7 +149,6 @@ export default class YearDropdown extends React.Component {
   renderDropdown = () => (
     <YearDropdownOptions
       key="dropdown"
-      ref="options"
       year={this.props.year}
       onChange={this.onChange}
       onCancel={this.toggleDropdown}


### PR DESCRIPTION
## Summary

**What:** Removes three legacy string refs (`ref="options"`) from the vendored `react-datepicker` dropdown components.

**Why:** Fixes #9009. On React 19, opening the month, year, or month/year dropdown throws during render:

> Uncaught Error: Expected ref to be a function, an object returned by React.createRef(), or undefined/null.

React 19 [removed legacy string refs](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-string-refs). Because the throw happens in `markRef` during `updateClassComponent`, React unmounts the whole tree — so this takes down the consuming application, not just the date picker.

**How:** The offending props are in `packages/eui/src/components/date_picker/react-datepicker/src/`:

| File | Element |
| --- | --- |
| `month_dropdown.js` | `<MonthDropdownOptions ref="options">` |
| `year_dropdown.js` | `<YearDropdownOptions ref="options">` |
| `month_year_dropdown.js` | `<MonthYearDropdownOptions ref="options">` |

All three are **dead code** rather than something needing migration to callback refs — `this.refs` is not read anywhere in the package:

```
$ grep -rn 'this\.refs' packages/eui/src/
(no matches)
```

They appear to be residue from the upstream fork in #5339. Deleting them is therefore behaviour-preserving, which is why this is a deletion rather than a `useRef`/callback-ref migration.

Worth noting for reviewers: these files match an ESLint ignore pattern, so `react/no-string-refs` never had a chance to flag them. That's likely why they survived this long.

### API Changes

None — no public prop, type, or token changes.

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| —                  | —            | —      | No public API change |

## Screenshots

Not applicable — no visual change. On React 16–18 the rendered output is byte-identical (all 42 existing date_picker snapshots pass unmodified). On React 19 the difference is "throws" vs. "works", which isn't meaningfully screenshottable.

## Impact Assessment

- [ ] 🔴 **Breaking changes** — None. No public API surface is touched.
- [ ] 💅 **Visual changes** — None. Snapshots unchanged.
- [ ] 🧪 **Test impact** — None. No HTML structure, class name, or default value changes.
- [ ] 🔧 **Hard to integrate** — No Kibana changes required.

**Impact level:** 🟢 None

## Release Readiness

- ~~**Documentation**~~ — no documented behaviour changes.
- ~~**Figma**~~ — no design changes.
- ~~**Migration guide**~~ — no breaking or visual changes.
- ~~**Adoption plan**~~ — bug fix, not a new feature.

### QA instructions for reviewer

On React 16–18 (current supported range), this should be a no-op:

- Open the [EuiDatePicker docs](https://eui.elastic.co/docs/components/forms/date-picker/) or Storybook.
- [ ] Confirm the month and year dropdowns still open, scroll, and select correctly (`dropdownMode="scroll"`, the default).
- [ ] Confirm `dropdownMode="select"` is unaffected.
- [ ] Confirm `EuiSuperDatePicker`'s absolute tab still works.

To verify the actual fix, a React 19 environment is required: render `<EuiDatePicker showMonthDropdown showYearDropdown />` and open either dropdown. Before this change it throws; after, it behaves normally.

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [ ] **QA:** Tested light/dark modes, high contrast, mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader — *not done; deletion of an unread ref with no rendered-output change*
- [ ] **QA:** Tested in CodeSandbox and Kibana — *not done, happy to if the team wants it*
- [ ] ~~**QA:** Tested docs changes~~ — no docs changes
- [x] **Tests:** `yarn test-unit src/components/date_picker` — 18/18 suites, 188 passed, 1 skipped, 42 snapshots unchanged

  No new regression test: EUI's Jest environment runs React 18, where string refs still work, so the failure this fixes cannot be reproduced in the current test setup. A meaningful regression test depends on the React 19 test environment tracked in #8720.
- [x] **Changelog:** Added
- [ ] ~~**Breaking changes:** Added `breaking change` label~~ — not applicable

---

Scope note: this does not make EUI React 19 compatible overall (#8720, #7774). It removes one hard crash. `EuiFieldSearch` (#9587) is still open, and the `<StrictMode>` work in #7774 is unaffected by this change.
