### PR TITLE
[Chore] Remove commit from nightly release prep list

### DIFF
--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -9,6 +9,5 @@
 https://github.com/elastic/kibana/pull/274656/commits/8ec324da4d10e4a7bfa4a121fb2c391535d17738
 
 # @previous
-https://github.com/elastic/kibana/pull/244898/commits/f3a7f97976213c6f2f5334aafd112455ff94d8f9
 https://github.com/elastic/kibana/pull/235177/commits/63b73732214e2cb2aa82b30bc2762bed8703c428
 https://github.com/elastic/kibana/pull/235177/commits/1d2d213025ef53336a6f366b1b6031e2a96b1817

--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -6,7 +6,6 @@
 # Nightly cherry-picks both sections, skipping commits that are missing or already applied.
 
 # @next
-https://github.com/elastic/kibana/pull/274656/commits/8ec324da4d10e4a7bfa4a121fb2c391535d17738
 
 # @previous
 https://github.com/elastic/kibana/pull/235177/commits/63b73732214e2cb2aa82b30bc2762bed8703c428


### PR DESCRIPTION
## Summary

- **What:** Removes entries from the nightly build cherry-pick commit list.
- **Why:** The commits were removed in the recent merged [eui upgrade PR](https://github.com/elastic/kibana/pull/286829). Keeping it in the nightly build results in CI failures (🔴 [build](https://buildkite.com/elastic/kibana-pull-request/builds/493165)).
- **How:** Removes commit `https://github.com/elastic/kibana/pull/244898/commits/f3a7f97976213c6f2f5334aafd112455ff94d8f9` and `https://github.com/elastic/kibana/pull/274656/commits/8ec324da4d10e4a7bfa4a121fb2c391535d17738` from `packages/release-cli/kibana-prep-commits`
