### PR TITLE
[Chore] Community contributions

### DIFF
--- a/.github/workflows/community_contribution.yml
+++ b/.github/workflows/community_contribution.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     steps:
@@ -46,3 +47,61 @@ jobs:
               repo: context.repo.repo,
               labels: ['community contribution']
             });
+      - name: "Comment on PRs without a help wanted issue"
+        uses: actions/github-script@v6
+        if: ${{ env.IS_ORG_MEMBER != '204' }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const body = context.payload.pull_request.body ?? '';
+
+            const issueNumbers = new Set();
+            const patterns = [
+              /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi,
+              new RegExp(
+                `(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+https://github.com/${owner}/${repo}/issues/(\\d+)`,
+                'gi'
+              ),
+              new RegExp(
+                `(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+${owner}/${repo}#(\\d+)`,
+                'gi'
+              ),
+            ];
+            for (const pattern of patterns) {
+              for (const match of body.matchAll(pattern)) {
+                issueNumbers.add(Number(match[1]));
+              }
+            }
+
+            let hasHelpWanted = false;
+            for (const issueNumber of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                });
+                if (issue.pull_request) continue;
+                if (
+                  (issue.labels ?? []).some(
+                    (label) => label.name === 'help wanted'
+                  )
+                ) {
+                  hasHelpWanted = true;
+                  break;
+                }
+              } catch (error) {
+                // Ignore missing or inaccessible issues.
+              }
+            }
+
+            if (!hasHelpWanted) {
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner,
+                repo,
+                body: 'We don\'t accept community contributions for issues not labelled "help wanted". Please read our [contribution guidelines](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md).',
+              });
+            }

--- a/.github/workflows/community_contribution.yml
+++ b/.github/workflows/community_contribution.yml
@@ -7,31 +7,50 @@ jobs:
   community-pr-message:
     env:
       USER_LOGIN: ${{ github.event.pull_request.user.login }}
-      IS_ORG_MEMBER: "" # https://github.com/github/vscode-github-actions/issues/47
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
     permissions:
+      id-token: write # Required for OIDC (Vault ephemeral token)
       contents: read
       issues: write
       pull-requests: write
     steps:
-      - name: "Check for org membership"
+      - name: Fetch ephemeral GitHub token
+        id: fetch_ephemeral_token
+        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3
+        with:
+          vault-instance: ci-prod
+          vault-role: token-policy-7c76c3b2363a
+      - name: Check for org membership
         # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
-        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-writing-an-environment-variable-to-github_env
+        id: org_membership
+        env:
+          TOKEN: ${{ steps.fetch_ephemeral_token.outputs.token }}
         run: |
-          DATA=$(
-            curl -L -i -g -w "%{http_code}" \
+          set -euo pipefail
+          HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.EUI_COMMUNITY_PR }}" \
+            -H "Authorization: Bearer $TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/orgs/elastic/members/"$USER_LOGIN"
-          )
+            "https://api.github.com/orgs/elastic/members/$USER_LOGIN")
 
-          HTTP_CODE=$(echo "$DATA" | awk '/([0-9]{3})$/{print}')
-          echo "IS_ORG_MEMBER=$HTTP_CODE" >> "$GITHUB_ENV"
+          case "$HTTP_CODE" in
+            204)
+              echo "Elastic org member"
+              echo "is_member=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "Not an Elastic org member"
+              echo "is_member=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unexpected membership API status: ${HTTP_CODE:-empty}"
+              exit 1
+              ;;
+          esac
       - name: "Add comment to community pull requests"
         uses: actions/github-script@v6
-        if: ${{ env.IS_ORG_MEMBER != '204' }}
+        if: ${{ steps.org_membership.outputs.is_member == 'false' }}
         with:
           script: |
             github.rest.issues.createComment({
@@ -49,7 +68,7 @@ jobs:
             });
       - name: "Comment on PRs without a help wanted issue"
         uses: actions/github-script@v6
-        if: ${{ env.IS_ORG_MEMBER != '204' }}
+        if: ${{ steps.org_membership.outputs.is_member == 'false' }}
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/community_contribution.yml
+++ b/.github/workflows/community_contribution.yml
@@ -7,6 +7,7 @@ jobs:
   community-pr-message:
     env:
       USER_LOGIN: ${{ github.event.pull_request.user.login }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
     permissions:
@@ -25,12 +26,12 @@ jobs:
         # https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user
         id: org_membership
         env:
-          TOKEN: ${{ steps.fetch_ephemeral_token.outputs.token }}
+          GH_TOKEN: ${{ steps.fetch_ephemeral_token.outputs.token }}
         run: |
           set -euo pipefail
           HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $TOKEN" \
+            -H "Authorization: Bearer $GH_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/orgs/elastic/members/$USER_LOGIN")
 
@@ -48,79 +49,32 @@ jobs:
               exit 1
               ;;
           esac
-      - name: "Add comment to community pull requests"
-        uses: actions/github-script@v6
+      - name: Comment on community pull requests
         if: ${{ steps.org_membership.outputs.is_member == 'false' }}
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "👋 Since this is a community submitted pull request, a Buildkite build has not been started automatically. Would an Elastic organization member please verify the contents of this pull request and kick off a build manually?",
-            });
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
 
-            github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['community contribution']
-            });
-      - name: "Comment on PRs without a help wanted issue"
-        uses: actions/github-script@v6
-        if: ${{ steps.org_membership.outputs.is_member == 'false' }}
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prNumber = context.payload.pull_request.number;
-            const body = context.payload.pull_request.body ?? '';
+          gh pr comment "$PR_NUMBER" --body "👋 Since this is a community submitted pull request, a Buildkite build has not been started automatically. Would an Elastic organization member please verify the contents of this pull request and kick off a build manually?"
+          gh pr edit "$PR_NUMBER" --add-label "community contribution"
 
-            const issueNumbers = new Set();
-            const patterns = [
-              /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi,
-              new RegExp(
-                `(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+https://github.com/${owner}/${repo}/issues/(\\d+)`,
-                'gi'
-              ),
-              new RegExp(
-                `(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+${owner}/${repo}#(\\d+)`,
-                'gi'
-              ),
-            ];
-            for (const pattern of patterns) {
-              for (const match of body.matchAll(pattern)) {
-                issueNumbers.add(Number(match[1]));
-              }
-            }
+          has_help_wanted=false
+          issue_numbers=$(
+            printf '%s\n' "$PR_BODY" \
+              | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+(https://github\.com/elastic/eui/issues/|#|elastic/eui#)[0-9]+' \
+              | grep -oE '[0-9]+$' \
+              | sort -u \
+              || true
+          )
+          for issue_number in $issue_numbers; do
+            labels=$(gh issue view "$issue_number" --json labels --jq '.labels[].name' 2>/dev/null) || continue
+            if printf '%s\n' "$labels" | grep -qx 'help wanted'; then
+              has_help_wanted=true
+              break
+            fi
+          done
 
-            let hasHelpWanted = false;
-            for (const issueNumber of issueNumbers) {
-              try {
-                const { data: issue } = await github.rest.issues.get({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                });
-                if (issue.pull_request) continue;
-                if (
-                  (issue.labels ?? []).some(
-                    (label) => label.name === 'help wanted'
-                  )
-                ) {
-                  hasHelpWanted = true;
-                  break;
-                }
-              } catch (error) {
-                // Ignore missing or inaccessible issues.
-              }
-            }
-
-            if (!hasHelpWanted) {
-              await github.rest.issues.createComment({
-                issue_number: prNumber,
-                owner,
-                repo,
-                body: 'We don\'t accept community contributions for issues not labelled "help wanted". Please read our [contribution guidelines](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md).',
-              });
-            }
+          if [[ "$has_help_wanted" != true ]]; then
+            gh pr comment "$PR_NUMBER" --body 'We don'\''t accept community contributions for issues not labelled "help wanted". Please read our [contribution guidelines](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md).'
+          fi

--- a/.github/workflows/community_contribution.yml
+++ b/.github/workflows/community_contribution.yml
@@ -12,7 +12,6 @@ jobs:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
     permissions:
       id-token: write # Required for OIDC (Vault ephemeral token)
-      contents: read
       issues: write
       pull-requests: write
     steps:
@@ -76,9 +75,9 @@ jobs:
           has_help_wanted=false
           inspected=0
           for issue_number in $issue_numbers; do
-            labels=$(gh issue view "$issue_number" --json labels --jq '.labels[].name' 2>/dev/null) || continue
+            is_help_wanted=$(gh issue view "$issue_number" --json labels --jq 'any(.labels[]; .name == "help wanted")' 2>/dev/null) || continue
             inspected=$((inspected + 1))
-            if printf '%s\n' "$labels" | grep -qx 'help wanted'; then
+            if [[ "$is_help_wanted" == true ]]; then
               has_help_wanted=true
               break
             fi

--- a/.github/workflows/community_contribution.yml
+++ b/.github/workflows/community_contribution.yml
@@ -59,7 +59,7 @@ jobs:
           gh pr comment "$PR_NUMBER" --body "👋 Since this is a community submitted pull request, a Buildkite build has not been started automatically. Would an Elastic organization member please verify the contents of this pull request and kick off a build manually?"
           gh pr edit "$PR_NUMBER" --add-label "community contribution"
 
-          has_help_wanted=false
+          guidelines='https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md'
           issue_numbers=$(
             printf '%s\n' "$PR_BODY" \
               | grep -oiE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+(https://github\.com/elastic/eui/issues/|#|elastic/eui#)[0-9]+' \
@@ -67,14 +67,28 @@ jobs:
               | sort -u \
               || true
           )
+
+          if [[ -z "$issue_numbers" ]]; then
+            gh pr comment "$PR_NUMBER" --body "We don't accept community contributions without a linked issue labelled \"help wanted\". Please file or link one first. See our [contribution guidelines]($guidelines)."
+            exit 0
+          fi
+
+          has_help_wanted=false
+          inspected=0
           for issue_number in $issue_numbers; do
             labels=$(gh issue view "$issue_number" --json labels --jq '.labels[].name' 2>/dev/null) || continue
+            inspected=$((inspected + 1))
             if printf '%s\n' "$labels" | grep -qx 'help wanted'; then
               has_help_wanted=true
               break
             fi
           done
 
+          if [[ "$inspected" -eq 0 ]]; then
+            echo "::warning::Could not read linked issues; skipping help wanted comment."
+            exit 0
+          fi
+
           if [[ "$has_help_wanted" != true ]]; then
-            gh pr comment "$PR_NUMBER" --body 'We don'\''t accept community contributions for issues not labelled "help wanted". Please read our [contribution guidelines](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md).'
+            gh pr comment "$PR_NUMBER" --body "We don't accept community contributions for issues not labelled \"help wanted\". Please read our [contribution guidelines]($guidelines)."
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@ All contributor knowledge lives in the [wiki](./wiki/):
 
 If the wiki disagrees with this file, the wiki wins — open a PR to fix it.
 
+## Contributing
+
+External contributors may only open PRs for issues labelled `help wanted`. If a request is not against such an issue, stop and point them at [Contributing to EUI](./wiki/contributing-to-eui/README.md).
+
 ## Tools
 
 - Use the [`gh` CLI](https://cli.github.com/) when interacting with GitHub.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 Check out our [full documentation site][docs] which contains many examples of components in the EUI framework aesthetic, and how to use them in your products. Our FAQ below covers common usage questions — for other general questions regarding EUI, check out the [Discussions tab](https://github.com/elastic/eui/discussions).
 
-> [!NOTE]
-> We're in the process of migrating this repository to a monorepo structure. You can find `@elastic/eui` files in the [packages/eui](https://github.com/elastic/eui/tree/main/packages/eui) directory.
-
 ## Frequently Asked Questions
 
 ### What is the Elastic UI Framework?
@@ -33,7 +30,7 @@ Traditionally releases are made weekly against whatever is in the `main` branch 
 
 ### Can I contribute to EUI?
 
-We accept external contributions for issues labeled [**help wanted**](https://github.com/elastic/eui/labels/help%20wanted). You can find documentation around creating and submitting new components in [our wiki](wiki/contributing-to-eui/).
+External contributors may only open PRs for issues labeled [**help wanted**](https://github.com/elastic/eui/labels/help%20wanted). See [Contributing to EUI](wiki/contributing-to-eui/) for the full policy.
 
 ### What about reporting bugs and feature requests?
 
@@ -43,7 +40,7 @@ Please note that in order to keep our backlog manageable and focused on tasks we
 
 This activity counter can be soft reset by commenting on the issue directly, but please do so mindfully. We would ask that you proactively let the EUI team know why this request matters to you or how it impacts you or your users, in order to help us prioritize accordingly.
 
-The EUI team, like everyone else, has a finite amount of time and resources, and it is not humanly possible for us to implement every task or feature requested of us. If you are interested in contributing an implementation, keep an eye out for issues labeled [**help wanted**](https://github.com/elastic/eui/labels/help%20wanted).
+The EUI team, like everyone else, has a finite amount of time and resources, and it is not humanly possible for us to implement every task or feature requested of us. If you want to contribute a fix, see [Can I contribute to EUI?](#can-i-contribute-to-eui).
 
 ### I have more questions!
 

--- a/wiki/contributing-to-eui/README.md
+++ b/wiki/contributing-to-eui/README.md
@@ -13,8 +13,11 @@ However, because EUI has a large footprint in Elastic products, we must maintain
 
 ## What to contribute
 
-- **Bug fixes** — Especially clear, scoped fixes for reproducible issues.
-- **[Help wanted](https://github.com/elastic/eui/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)** — Issues with this label are meant for community pickup: we’ve checked that they fit our roadmap and aren’t blocked on private internal planning.
+External contributors may only open PRs for issues labelled [`help wanted`](https://github.com/elastic/eui/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22). We add that label when a task fits our roadmap and it has been prepared with clear instructions.
+
+If you are having a problem with EUI, [file an issue](https://github.com/elastic/eui/issues/new).
+
+If you want to contribute a fix for an issue that affects you, comment on that issue with a proposed solution. We can discuss it there. If we agree, we will add the `help wanted` label.
 
 ## What not to contribute
 
@@ -26,8 +29,7 @@ Unless agreed upon previously:
 
 ## How to contribute
 
-- **Comment before you start** — Note your intent on the issue to avoid duplicate work. We don’t assign issues to community members by policy.
-- **No matching issue yet?** **[Open one](https://github.com/elastic/eui/issues/new)** first so maintainers can scope the change before you invest in a PR.
+We do not assign issues to community members. Comment on the `help wanted` issue before you start so others know you are working on it.
 
 ## Typical change flow
 


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Closes https://github.com/elastic/eui-private/issues/760

We need to migrate our migrate our CC workflow and guidance, especially for agents. `AGENTS.md` redirects to wiki and wiki is ambiguous on community contributions. It states they are accepted for issues labelled "help wanted" AND bugs.

Also, workflow malfunctions and when membership check fails it fallbacks to "community contribution" (as seen on this PR 👀).

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

- [ ] Wiki is the source of truth and is clear about community contributions,
- [ ] `README.md` and `AGENTS.md` mention we only accept CC on issues labelled "help wanted" and redirect to wiki for more guidance.

Unfortunately, the workflow that automatically comments on CC PRs that have an issue linked that doesn't have a "help wanted" label, can only be tested after having been merged to `main`.

- [ ] Make sure the automation steps are correct and the comment is clear.