### PR TITLE
[EuiDataGridColumnResizer] Migrate from class to function component

### DIFF
--- a/packages/eui/src/components/datagrid/body/header/column_resizer.test.tsx
+++ b/packages/eui/src/components/datagrid/body/header/column_resizer.test.tsx
@@ -7,18 +7,26 @@
  */
 
 import React from 'react';
-import { act } from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 import { render } from '../../../../test/rtl';
 
 import { EuiDataGridColumnResizer } from './column_resizer';
 
-describe('EuiDataGridHeaderResizer', () => {
+describe('EuiDataGridColumnResizer', () => {
   const props = {
     columnId: 'someColumn',
     columnWidth: 50,
     setColumnWidth: jest.fn(),
     isLastColumn: false,
   };
+
+  // jsdom derives `pageX` from `clientX`
+  const dragTo = (clientX: number) => fireEvent.mouseMove(window, { clientX });
+  const endDrag = () => fireEvent.mouseUp(window);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('renders', () => {
     const { container } = render(<EuiDataGridColumnResizer {...props} />);
@@ -32,82 +40,94 @@ describe('EuiDataGridHeaderResizer', () => {
   });
 
   describe('mouse events', () => {
-    const mouseEvent = {
-      preventDefault: () => {},
-    } as React.MouseEvent<HTMLDivElement>;
+    it('adds mouse move & up listeners on mouse down', () => {
+      const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+      const { getByTestSubject } = render(
+        <EuiDataGridColumnResizer {...props} />
+      );
 
-    // Using a ref to reach into class methods/state directly -
-    // mocking mouse events in jsdom is too much of a headache
-    let classRef: EuiDataGridColumnResizer;
-    const setRef = (ref: EuiDataGridColumnResizer) => {
-      classRef = ref;
-    };
-
-    describe('on mouse down', () => {
-      it('adds mouse move & up listeners', () => {
-        render(<EuiDataGridColumnResizer {...props} ref={setRef} />);
-        const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
-
-        act(() => classRef.onMouseDown({ ...mouseEvent, pageX: 100 }));
-        expect(classRef.state.initialX).toEqual(100);
-
-        const anyFn = expect.any(Function);
-        expect(addEventListenerSpy).toHaveBeenCalledWith('mouseup', anyFn);
-        expect(addEventListenerSpy).toHaveBeenCalledWith('mousemove', anyFn);
-        expect(addEventListenerSpy).toHaveBeenCalledWith('blur', anyFn);
+      fireEvent.mouseDown(getByTestSubject('dataGridColumnResizer'), {
+        clientX: 100,
       });
+
+      const anyFn = expect.any(Function);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('mouseup', anyFn);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('mousemove', anyFn);
+      expect(addEventListenerSpy).toHaveBeenCalledWith('blur', anyFn);
     });
 
-    describe('on mouse move', () => {
-      it('does not allow an offset that would go under the mininum column width', () => {
-        const { getByTestSubject } = render(
-          <EuiDataGridColumnResizer {...props} ref={setRef} />
-        );
+    it('offsets the resizer by the distance moved', () => {
+      const { getByTestSubject } = render(
+        <EuiDataGridColumnResizer {...props} />
+      );
+      const resizer = getByTestSubject('dataGridColumnResizer');
 
-        act(() => classRef.onMouseDown({ ...mouseEvent, pageX: 100 }));
-        act(() => classRef.onMouseMove({ pageX: 0 }));
+      fireEvent.mouseDown(resizer, { clientX: 100 });
+      dragTo(130);
 
-        expect(classRef.state.offset).toEqual(-10);
-        expect(getByTestSubject('dataGridColumnResizer')).toHaveStyle(
-          'margin-inline-end: 10px'
-        );
-      });
-
-      it('sets offset state to the difference of the moved pageX', () => {
-        const { getByTestSubject } = render(
-          <EuiDataGridColumnResizer {...props} ref={setRef} />
-        );
-
-        act(() => classRef.onMouseDown({ ...mouseEvent, pageX: 100 }));
-        act(() => classRef.onMouseMove({ pageX: 200 }));
-
-        expect(classRef.state.offset).toEqual(100);
-        expect(getByTestSubject('dataGridColumnResizer')).toHaveStyle(
-          'margin-inline-end: -100px'
-        );
-      });
+      expect(resizer).toHaveStyle({ marginInlineEnd: '-30px' });
     });
 
-    describe('on mouse up', () => {
-      it('calls setColumnWidth, reset offset, and removes event listeners', () => {
-        render(<EuiDataGridColumnResizer {...props} ref={setRef} />);
-        const removeEventListenerSpy = jest.spyOn(
-          window,
-          'removeEventListener'
-        );
+    it('does not allow an offset that would go under the mininum column width', () => {
+      const { getByTestSubject } = render(
+        <EuiDataGridColumnResizer {...props} />
+      );
+      const resizer = getByTestSubject('dataGridColumnResizer');
 
-        act(() => classRef.onMouseDown({ ...mouseEvent, pageX: 100 }));
-        act(() => classRef.onMouseMove({ pageX: 200 }));
-        act(() => classRef.onMouseUp());
+      fireEvent.mouseDown(resizer, { clientX: 100 });
+      dragTo(0);
 
-        expect(props.setColumnWidth).toHaveBeenCalledWith('someColumn', 150);
-        expect(classRef.state.offset).toEqual(0);
+      expect(resizer).toHaveStyle({ marginInlineEnd: '10px' });
+    });
 
-        const anyFn = expect.any(Function);
-        expect(removeEventListenerSpy).toHaveBeenCalledWith('mouseup', anyFn);
-        expect(removeEventListenerSpy).toHaveBeenCalledWith('mousemove', anyFn);
-        expect(removeEventListenerSpy).toHaveBeenCalledWith('blur', anyFn);
+    it('calls setColumnWidth, resets the offset, and removes listeners on mouse up', () => {
+      const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+      const { getByTestSubject } = render(
+        <EuiDataGridColumnResizer {...props} />
+      );
+      const resizer = getByTestSubject('dataGridColumnResizer');
+
+      fireEvent.mouseDown(resizer, { clientX: 100 });
+      dragTo(130);
+      endDrag();
+
+      expect(props.setColumnWidth).toHaveBeenCalledTimes(1);
+      expect(props.setColumnWidth).toHaveBeenCalledWith('someColumn', 80);
+      expect(resizer).not.toHaveStyle({ marginInlineEnd: '-30px' });
+
+      const anyFn = expect.any(Function);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('mouseup', anyFn);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('mousemove', anyFn);
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('blur', anyFn);
+    });
+
+    it('uses the latest columnWidth instead of the one captured on mouse down', () => {
+      const { getByTestSubject, rerender } = render(
+        <EuiDataGridColumnResizer {...props} />
+      );
+      const resizer = getByTestSubject('dataGridColumnResizer');
+
+      fireEvent.mouseDown(resizer, { clientX: 100 });
+      rerender(<EuiDataGridColumnResizer {...props} columnWidth={200} />);
+      dragTo(130);
+      endDrag();
+
+      expect(props.setColumnWidth).toHaveBeenCalledWith('someColumn', 230);
+    });
+
+    it('removes listeners when unmounted mid-drag', () => {
+      const { getByTestSubject, unmount } = render(
+        <EuiDataGridColumnResizer {...props} />
+      );
+
+      fireEvent.mouseDown(getByTestSubject('dataGridColumnResizer'), {
+        clientX: 100,
       });
+      unmount();
+      dragTo(130);
+      endDrag();
+
+      expect(props.setColumnWidth).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/eui/src/components/datagrid/body/header/column_resizer.test.tsx
+++ b/packages/eui/src/components/datagrid/body/header/column_resizer.test.tsx
@@ -68,7 +68,7 @@ describe('EuiDataGridColumnResizer', () => {
       expect(resizer).toHaveStyle({ marginInlineEnd: '-30px' });
     });
 
-    it('does not allow an offset that would go under the mininum column width', () => {
+    it('does not allow an offset that would go under the minimum column width', () => {
       const { getByTestSubject } = render(
         <EuiDataGridColumnResizer {...props} />
       );

--- a/packages/eui/src/components/datagrid/body/header/column_resizer.tsx
+++ b/packages/eui/src/components/datagrid/body/header/column_resizer.tsx
@@ -6,97 +6,101 @@
  * Side Public License, v 1.
  */
 
-import React, { Component } from 'react';
-import { RenderWithEuiStylesMemoizer } from '../../../../services';
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useEuiMemoizedStyles, useLatest } from '../../../../services';
 import { logicalStyle } from '../../../../global_styling';
-import {
-  EuiDataGridColumnResizerProps,
-  EuiDataGridColumnResizerState,
-} from '../../data_grid_types';
+import { EuiDataGridColumnResizerProps } from '../../data_grid_types';
 import { DragOverlay } from './draggable_columns';
 import { euiDataGridColumnResizerStyles } from './column_resizer.styles';
 
 const MINIMUM_COLUMN_WIDTH = 40;
 
-export class EuiDataGridColumnResizer extends Component<
-  EuiDataGridColumnResizerProps,
-  EuiDataGridColumnResizerState
-> {
-  state = {
-    initialX: 0,
-    offset: 0,
-  };
+export const EuiDataGridColumnResizer: FunctionComponent<
+  EuiDataGridColumnResizerProps
+> = ({ columnId, columnWidth, setColumnWidth, isLastColumn }) => {
+  const styles = useEuiMemoizedStyles(euiDataGridColumnResizerStyles);
 
-  onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    this.setState({
-      initialX: e.pageX,
-    });
+  const [offset, setOffset] = useState(0);
+  const initialX = useRef(0);
 
-    window.addEventListener('mouseup', this.onMouseUp);
-    window.addEventListener('blur', this.onMouseUp);
-    window.addEventListener('mousemove', this.onMouseMove);
+  // Handlers are bound to `window`, so they must stay stable to be removed
+  // and read current values from a ref
+  const latest = useLatest({ columnId, columnWidth, setColumnWidth, offset });
 
-    // don't let this action steal focus
-    e.preventDefault();
-  };
+  const onMouseMove = useCallback(
+    (e: { pageX: number }) => {
+      const { columnWidth } = latest.current!;
 
-  onMouseUp = () => {
-    const { offset } = this.state;
-    const { columnId, columnWidth, setColumnWidth } = this.props;
+      setOffset(
+        Math.max(
+          e.pageX - initialX.current,
+          -(columnWidth - MINIMUM_COLUMN_WIDTH)
+        )
+      );
+    },
+    [latest]
+  );
+
+  const onMouseUp = useCallback(() => {
+    const { columnId, columnWidth, setColumnWidth, offset } = latest.current!;
+
     setColumnWidth(
       columnId,
       Math.max(MINIMUM_COLUMN_WIDTH, columnWidth + offset)
     );
+    setOffset(0);
 
-    this.setState({ offset: 0 });
+    window.removeEventListener('mouseup', onMouseUp);
+    window.removeEventListener('blur', onMouseUp);
+    window.removeEventListener('mousemove', onMouseMove);
+  }, [latest, onMouseMove]);
 
-    window.removeEventListener('mouseup', this.onMouseUp);
-    window.removeEventListener('blur', this.onMouseUp);
-    window.removeEventListener('mousemove', this.onMouseMove);
-  };
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      initialX.current = e.pageX;
 
-  onMouseMove = (e: { pageX: number }) => {
-    const { columnWidth } = this.props;
-    this.setState(({ initialX }) => ({
-      offset: Math.max(
-        e.pageX - initialX,
-        -(columnWidth - MINIMUM_COLUMN_WIDTH)
-      ),
-    }));
-  };
+      window.addEventListener('mouseup', onMouseUp);
+      window.addEventListener('blur', onMouseUp);
+      window.addEventListener('mousemove', onMouseMove);
 
-  render() {
-    const { offset } = this.state;
-    const { isLastColumn } = this.props;
+      // don't let this action steal focus
+      e.preventDefault();
+    },
+    [onMouseUp, onMouseMove]
+  );
 
-    return (
-      <RenderWithEuiStylesMemoizer>
-        {(stylesMemoizer) => {
-          const styles = stylesMemoizer(euiDataGridColumnResizerStyles);
-          const cssStyles = [
-            styles.euiDataGridColumnResizer,
-            isLastColumn && styles.isLastColumn,
-            offset && styles.isDragging,
-          ];
-          return (
-            <div
-              css={cssStyles}
-              className="euiDataGridColumnResizer"
-              data-test-subj="dataGridColumnResizer"
-              style={
-                offset
-                  ? logicalStyle('margin-right', `${-offset}px`)
-                  : undefined
-              }
-              onMouseDown={this.onMouseDown}
-            >
-              {/* UX polish: prevent other hover states from activating when
-                  dragging over other elements + maintain the resize cursor */}
-              <DragOverlay isDragging={!!offset} cursor="ew-resize" />
-            </div>
-          );
-        }}
-      </RenderWithEuiStylesMemoizer>
-    );
-  }
-}
+  // Clean up listeners if unmounted mid-drag
+  useEffect(() => {
+    return () => {
+      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('blur', onMouseUp);
+      window.removeEventListener('mousemove', onMouseMove);
+    };
+  }, [onMouseUp, onMouseMove]);
+
+  const cssStyles = [
+    styles.euiDataGridColumnResizer,
+    isLastColumn && styles.isLastColumn,
+    offset && styles.isDragging,
+  ];
+
+  return (
+    <div
+      css={cssStyles}
+      className="euiDataGridColumnResizer"
+      data-test-subj="dataGridColumnResizer"
+      style={offset ? logicalStyle('margin-right', `${-offset}px`) : undefined}
+      onMouseDown={onMouseDown}
+    >
+      {/* UX polish: prevent other hover states from activating when
+          dragging over other elements + maintain the resize cursor */}
+      <DragOverlay isDragging={!!offset} cursor="ew-resize" />
+    </div>
+  );
+};

--- a/packages/eui/src/components/datagrid/data_grid.test.tsx
+++ b/packages/eui/src/components/datagrid/data_grid.test.tsx
@@ -14,7 +14,6 @@ import { getAllByTestSubject, render } from '../../test/rtl';
 import { shouldRenderCustomStyles } from '../../test/internal';
 import { keys } from '../../services';
 
-import { EuiDataGridColumnResizer } from './body/header/column_resizer';
 import type { EuiDataGridProps, RenderCellValue } from './data_grid_types';
 import { EuiDataGrid } from './';
 
@@ -108,17 +107,23 @@ function resizeColumn(
 
   const firstResizer = datagrid
     .find(`EuiDataGridColumnResizer[columnId="${columnId}"]`)
-    .instance() as EuiDataGridColumnResizer;
+    .find('div.euiDataGridColumnResizer');
 
   act(() => {
-    firstResizer.onMouseDown({
+    firstResizer.simulate('mousedown', {
       pageX: originalWidth,
       stopPropagation: () => {},
       preventDefault: () => {},
-    } as React.MouseEvent<HTMLDivElement>);
+    });
   });
-  act(() => firstResizer.onMouseMove({ pageX: columnWidth }));
-  act(() => firstResizer.onMouseUp());
+  // `mousemove` and `mouseup` are bound to `window`; jsdom derives `pageX`
+  // from `clientX`
+  act(() => {
+    fireEvent.mouseMove(window, { clientX: columnWidth });
+  });
+  act(() => {
+    fireEvent.mouseUp(window);
+  });
 
   datagrid.update();
 }

--- a/packages/eui/src/components/datagrid/data_grid_types.ts
+++ b/packages/eui/src/components/datagrid/data_grid_types.ts
@@ -461,11 +461,6 @@ export interface EuiDataGridColumnResizerProps {
   isLastColumn: boolean;
 }
 
-export interface EuiDataGridColumnResizerState {
-  initialX: number;
-  offset: number;
-}
-
 export interface EuiDataGridColumnSortingDraggableProps {
   id: string;
   direction: string;


### PR DESCRIPTION
## Summary

Migrates `EuiDataGridColumnResizer` from a class to a function component.

Fixes #9470

### Work done

- Converted the class to a function component using `useState`, `useRef` and `useCallback`
- Replaced `RenderWithEuiStylesMemoizer` with `useEuiMemoizedStyles`
- Drag handlers read current props and offset through `useLatest`, since they are bound to `window` on mouse down and must stay referentially stable to be removed again
- Added listener cleanup on unmount
- Rewrote `column_resizer.test.tsx` to drive real DOM events. The previous tests called the class methods through a ref, which is not available on a function component
- Updated the `resizeColumn` helper in `data_grid.test.tsx` for the same reason

### Tests run

- `yarn test-unit datagrid` — 33 suites, 500 passed, 65 snapshots unchanged
- `yarn tsc --noEmit` — clean
- `eslint` on the changed files — clean

Rendered output is unchanged, so no snapshots or VRT baselines needed updating.

### API Changes

None.

## Impact Assessment

- [x] 🧪 **Test impact** — `data_grid.test.tsx` was reaching into this component with `.instance()`, which returns `null` for function components. Consumer tests doing the same will need updating.

**Impact level:** 🟢 Low

### QA instructions for reviewer

- Open any data grid demo in Storybook or the docs.
- [ ] Drag a column header resizer and confirm the column resizes.
- [ ] Confirm a column cannot be dragged below the 40px minimum width.
- [ ] Confirm releasing the mouse outside the grid, or switching windows mid-drag, still commits the resize.
