### PR TITLE
[Illustrations] Add prefixIds plugin

### DIFF
--- a/packages/illustrations/changelogs/upcoming/9973.md
+++ b/packages/illustrations/changelogs/upcoming/9973.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed illustrations rendering cropped when more than one was inlined on the same page

--- a/packages/illustrations/scripts/generate.js
+++ b/packages/illustrations/scripts/generate.js
@@ -35,6 +35,7 @@ const svgoConfig = {
   plugins: [
     { name: 'preset-default', params: { overrides: { removeViewBox: false } } },
     'removeDimensions',
+    'prefixIds',
   ],
 };
 

--- a/packages/illustrations/src/illustrations.test.ts
+++ b/packages/illustrations/src/illustrations.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { readdirSync } from 'fs';
+import { join } from 'path';
+
+import { illustrations } from './generated';
+
+const SVG_FILE = /^(.+)\.(light|dark)\.svg$/;
+const ID_ATTR = /\bid="([^"]+)"/g;
+const URL_REF = /url\(#([^)]+)\)/g;
+
+const toCamelCase = (name: string) =>
+  name.replace(/[-_](.)/g, (_, char: string) => char.toUpperCase());
+
+const catalog = Object.values(illustrations);
+
+const sourceIds = [
+  ...new Set(
+    readdirSync(join(__dirname, 'svgs'))
+      .map((fileName) => fileName.match(SVG_FILE)?.[1])
+      .filter((id): id is string => Boolean(id))
+  ),
+].sort();
+
+const svgVariants = catalog.flatMap(({ id, light, dark }) => [
+  { source: `${id}.light`, svg: light },
+  { source: `${id}.dark`, svg: dark },
+]);
+
+describe('illustrations catalog', () => {
+  it('exports one entry per src/svgs pair', () => {
+    expect(catalog.map(({ id }) => id).sort()).toEqual(sourceIds);
+  });
+
+  it('exposes each illustration on the camelCase export name', () => {
+    for (const illustration of catalog) {
+      expect(illustrations[toCamelCase(illustration.id)]).toBe(illustration);
+    }
+  });
+
+  it('ships light and dark SVGs with a viewBox', () => {
+    for (const { svg } of svgVariants) {
+      expect(svg).toMatch(/^<svg\b/);
+      expect(svg).toContain('viewBox=');
+    }
+  });
+
+  it('does not reuse SVG ids across the catalog', () => {
+    const seen = new Map<string, string>();
+    const duplicates: string[] = [];
+
+    for (const { source, svg } of svgVariants) {
+      for (const match of svg.matchAll(ID_ATTR)) {
+        const svgId = match[1];
+        const previous = seen.get(svgId);
+        if (previous) {
+          duplicates.push(`"${svgId}" in ${source} and ${previous}`);
+        } else {
+          seen.set(svgId, source);
+        }
+      }
+    }
+
+    expect(duplicates).toEqual([]);
+  });
+
+  it('keeps url() references inside the same SVG', () => {
+    const broken: string[] = [];
+
+    for (const { source, svg } of svgVariants) {
+      const ids = new Set([...svg.matchAll(ID_ATTR)].map((match) => match[1]));
+      for (const match of svg.matchAll(URL_REF)) {
+        if (!ids.has(match[1])) {
+          broken.push(`${source} references #${match[1]}`);
+        }
+      }
+    }
+
+    expect(broken).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

SVGO was minifying every illustration’s clip/mask ids to `a`/`b`/`c`. `EuiIllustration` inlines those SVGs, so the docs gallery (and any page with more than one illustration) applied the wrong clip/mask and cropped assets like `telecom`. See [Slack thread](https://elastic.slack.com/archives/C7QC1JV6F/p1788158019816029) for more context.

**Changes:**

- Enabled SVGO `prefixIds` so ids stay unique per file. Figma source was fine; this is an export/inlining bug.
- Added a catalog unit test covering source pairs, export shape, unique ids and in-SVG `url(#…)` refs.

### API Changes

<!--
List any change to the public EUI API here.

Example:

| component / parent   | prop / child                 | change     | description                                                             |
| -------------------- | ---------------------------- | ---------- | ----------------------------------------------------------------------- |
| EuiOverlayMask       | hasAnimation                 | Added      | Conditionally add animation                                             |
| EuiBadge             | fill                         | Default    | Default is now "false" -- Makes all badges have a light fill by default |
| Tokens               | colors.severity.someOldColor | Deprecated | Use `colors.severity.someOtherColor` instead                            |
| Global CSS Variables | --my-variable                | Added      | Some reason listed here                                                 |

-->

N/A

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->

| Before         | After         |
| -------------- | ------------- |
| <img width="271" height="299" alt="Screenshot 2026-08-31 at 11 32 41" src="https://github.com/user-attachments/assets/c33fa83a-3cfb-47f4-8dba-087481bdf08f" /> | <img width="273" height="298" alt="Screenshot 2026-08-31 at 11 31 39" src="https://github.com/user-attachments/assets/84dd5939-3bac-417b-8446-7457ebb65a43" /> |

## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] ~🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?~
- [ ] ~💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.~
- [ ] ~🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).~
- [ ] ~🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.~

<!--
If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL under `@next` in `packages/release-cli/kibana-prep-commits` (one URL per line). Nightly cherry-picks `@next` and `@previous`. On release, `@next` moves to `@previous` and `@previous` is cleared. Missing or already-applied commits are skipped.
-->

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [x] **Documentation:**
  - [Illustrations](https://eui.elastic.co/pr_9973/docs/components/display/illustrations/)
- [x] **Figma:**
  - [Illustrations](https://www.figma.com/design/TIbEMX3CEpkcPZaFqjIvRq/Illustrations?node-id=3398-15027&p=f&t=wmW2iZKi5D8VFLy2-0)
- [ ] ~**Migration guide:** {steps or link, for breaking/visual changes or deprecations}~
- [ ] ~**Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->~

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

- [ ] Illustrations docs page renders illustrations correctly (e.g. `telecom`).
- [ ] CI passes (runs `yarn workspace @elastic/eui-illustrations test-unit`)

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [x] Filled out all sections above
- [x] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] ~**QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)~
- [ ] ~**QA:** Tested docs changes~
- [x] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] ~**Breaking changes:** Added `breaking change` label (if applicable)~

### Reviewer checklist

- [x] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [x] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
