### PR TITLE
[EuiFlyout] Preserve pixel width on container resize when `size` is numeric

### DIFF
--- a/packages/eui/changelogs/upcoming/9976.md
+++ b/packages/eui/changelogs/upcoming/9976.md
@@ -1,0 +1,4 @@
+**Bug fixes**
+
+- Fixed `EuiFlyout` rescaling a resizable flyout on container resize when `size` is a number; the flyout now preserves the user's pixel width and only re-clamps
+- Fixed `EuiFlyout` calling `onResize` for container-driven resizes, which could overwrite a consumer's persisted width

--- a/packages/eui/changelogs/upcoming/9976.md
+++ b/packages/eui/changelogs/upcoming/9976.md
@@ -1,4 +1,4 @@
 **Bug fixes**
 
-- Fixed `EuiFlyout` rescaling a resizable flyout on container resize when `size` is a number; the flyout now preserves the user's pixel width and only re-clamps
+- Fixed `EuiFlyout` rescaling a resizable flyout on container resize when `size` is a number; the flyout now preserves the requested pixel width, re-clamping it only while there is not enough room and restoring it once there is
 - Fixed `EuiFlyout` calling `onResize` for container-driven resizes, which could overwrite a consumer's persisted width

--- a/packages/eui/src/components/flyout/use_flyout_resizable.test.ts
+++ b/packages/eui/src/components/flyout/use_flyout_resizable.test.ts
@@ -342,6 +342,87 @@ describe('useEuiFlyoutResizable', () => {
       expect(toPixels(result.current.size, 600)).toBeCloseTo(540);
     });
 
+    it('restores a numeric `size` when the referenceWidth grows back', async () => {
+      // Clamping must not be destructive: shrinking below the requested width
+      // and growing back again has to return the flyout to `size`
+      const props = {
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        size: 800,
+      };
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        { initialProps: { ...props, referenceWidth: 1200 } }
+      );
+
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(800);
+      });
+
+      // Shrink: 800 no longer fits within 90% of 600, so it clamps to 540
+      rerender({ ...props, referenceWidth: 600 });
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 600)).toBeCloseTo(540);
+      });
+
+      // Grow back: there is room for 800 again, so it must return to 800
+      rerender({ ...props, referenceWidth: 1200 });
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(800);
+      });
+    });
+
+    it('restores the user-dragged width, not `size`, when the referenceWidth grows back', async () => {
+      const props = {
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        size: 800,
+      };
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        { initialProps: { ...props, referenceWidth: 1200 } }
+      );
+
+      const mockElement = createMockElement(800);
+      act(() => {
+        result.current.setFlyoutRef(mockElement);
+      });
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(800);
+      });
+
+      // User drags to 700px
+      act(() => {
+        result.current.onMouseDown({ clientX: 800 } as ReactMouseEvent);
+      });
+      act(() => {
+        window.dispatchEvent(new MouseEvent('mousemove', { clientX: 900 }));
+      });
+      act(() => {
+        window.dispatchEvent(new MouseEvent('mouseup'));
+      });
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(700);
+      });
+
+      // Shrink so even 700 does not fit, then grow back
+      rerender({ ...props, referenceWidth: 600 });
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 600)).toBeCloseTo(540);
+      });
+
+      rerender({ ...props, referenceWidth: 1200 });
+
+      // Back to the width the user chose, *not* the coded `size` of 800
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(700);
+      });
+    });
+
     it('re-clamps a numeric `size` to `maxWidth`', async () => {
       const { result, rerender } = renderHook(
         (props) => useEuiFlyoutResizable(props),

--- a/packages/eui/src/components/flyout/use_flyout_resizable.test.ts
+++ b/packages/eui/src/components/flyout/use_flyout_resizable.test.ts
@@ -6,6 +6,10 @@
  * Side Public License, v 1.
  */
 
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+} from 'react';
 import { waitFor } from '@testing-library/react';
 import { renderHook, renderHookAct as act } from '../../test/rtl/render_hook';
 import { useEuiFlyoutResizable } from './use_flyout_resizable';
@@ -242,6 +246,275 @@ describe('useEuiFlyoutResizable', () => {
       await waitFor(() => {
         expect(result.current.size).toBe('50%');
       });
+    });
+  });
+
+  describe('referenceWidth changes', () => {
+    // The emitted size is a percentage of the reference width, which
+    // `flyout.component.tsx` converts back with `containerRect.width * (pct / 100)`
+    const toPixels = (size: string | number, referenceWidth: number) =>
+      (parseFloat(size as string) / 100) * referenceWidth;
+
+    it('preserves the pixel width for a numeric `size`', async () => {
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        {
+          initialProps: {
+            ...mockProps,
+            enabled: true,
+            minWidth: 0,
+            maxWidth: undefined,
+            referenceWidth: 1200,
+            size: 400,
+          },
+        }
+      );
+
+      // 400 / 1200 * 100 = 33.33...%
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(400);
+      });
+
+      // The container shrinks. The flyout still fits, so it should stay at 400px
+      // rather than scaling down to 400 * (1000 / 1200) = 333.33px
+      rerender({
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        referenceWidth: 1000,
+        size: 400,
+      });
+
+      await waitFor(() => {
+        expect(result.current.size).toBe('40%');
+      });
+      expect(toPixels(result.current.size, 1000)).toBeCloseTo(400);
+
+      // ...and the same on grow
+      rerender({
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        referenceWidth: 1600,
+        size: 400,
+      });
+
+      await waitFor(() => {
+        expect(result.current.size).toBe('25%');
+      });
+      expect(toPixels(result.current.size, 1600)).toBeCloseTo(400);
+    });
+
+    it('re-clamps a numeric `size` when it no longer fits', async () => {
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        {
+          initialProps: {
+            ...mockProps,
+            enabled: true,
+            minWidth: 0,
+            maxWidth: undefined,
+            referenceWidth: 1200,
+            size: 800,
+          },
+        }
+      );
+
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(800);
+      });
+
+      // 800px no longer fits within 90% of 600px, so it clamps to 540px
+      rerender({
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        referenceWidth: 600,
+        size: 800,
+      });
+
+      await waitFor(() => {
+        expect(result.current.size).toBe('90%');
+      });
+      expect(toPixels(result.current.size, 600)).toBeCloseTo(540);
+    });
+
+    it('re-clamps a numeric `size` to `maxWidth`', async () => {
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        {
+          initialProps: {
+            ...mockProps,
+            enabled: true,
+            minWidth: 0,
+            maxWidth: 500,
+            referenceWidth: 1200,
+            size: 800,
+          },
+        }
+      );
+
+      // Already clamped to maxWidth on mount: 500 / 1200 * 100
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(500);
+      });
+
+      rerender({
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: 500,
+        referenceWidth: 1000,
+        size: 800,
+      });
+
+      await waitFor(() => {
+        expect(result.current.size).toBe('50%');
+      });
+      expect(toPixels(result.current.size, 1000)).toBeCloseTo(500);
+    });
+
+    it('preserves the percentage for a named `size`', async () => {
+      // Named sizes are defined as percentages in `flyout.styles.ts`, so they
+      // should keep scaling with the reference width
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        {
+          initialProps: {
+            ...mockProps,
+            enabled: true,
+            minWidth: 0,
+            maxWidth: undefined,
+            referenceWidth: 1200,
+            size: 'm',
+          },
+        }
+      );
+
+      const mockElement = createMockElement(600);
+      act(() => {
+        result.current.setFlyoutRef(mockElement);
+      });
+
+      // 600 / 1200 * 100 = 50%
+      await waitFor(() => {
+        expect(result.current.size).toBe('50%');
+      });
+
+      rerender({
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        referenceWidth: 800,
+        size: 'm',
+      });
+
+      // Still 50%, i.e. 400px of the new 800px reference width
+      await waitFor(() => {
+        expect(result.current.size).toBe('50%');
+      });
+      expect(toPixels(result.current.size, 800)).toBeCloseTo(400);
+    });
+
+    it('does not call `onResize` when only the referenceWidth changes', async () => {
+      const onResize = jest.fn();
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        {
+          initialProps: {
+            ...mockProps,
+            enabled: true,
+            minWidth: 0,
+            maxWidth: undefined,
+            referenceWidth: 1200,
+            size: 800,
+            onResize,
+          },
+        }
+      );
+
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(800);
+      });
+
+      // A user resize, which should call `onResize` and leave the hook in a
+      // state where subsequent width changes would otherwise call it again
+      act(() => {
+        result.current.onKeyDown({
+          key: 'ArrowRight',
+          preventDefault: () => {},
+        } as ReactKeyboardEvent);
+      });
+      await waitFor(() => {
+        expect(onResize).toHaveBeenCalledWith(790);
+      });
+      onResize.mockClear();
+
+      // A container resize re-clamps 790px down to 540px, but that is not a
+      // user resize and must not be reported back to the consumer
+      rerender({
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        referenceWidth: 600,
+        size: 800,
+        onResize,
+      });
+
+      await waitFor(() => {
+        expect(result.current.size).toBe('90%');
+      });
+      expect(onResize).not.toHaveBeenCalled();
+    });
+
+    it('still calls `onResize` once with the final width after a drag ends', async () => {
+      const onResize = jest.fn();
+      const { result } = renderHook(() =>
+        useEuiFlyoutResizable({
+          ...mockProps,
+          enabled: true,
+          minWidth: 0,
+          maxWidth: undefined,
+          referenceWidth: 1200,
+          size: 400,
+          onResize,
+        })
+      );
+
+      const mockElement = createMockElement(400);
+      act(() => {
+        result.current.setFlyoutRef(mockElement);
+      });
+
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(400);
+      });
+      expect(onResize).not.toHaveBeenCalled();
+
+      act(() => {
+        result.current.onMouseDown({ clientX: 400 } as ReactMouseEvent);
+      });
+      act(() => {
+        window.dispatchEvent(new MouseEvent('mousemove', { clientX: 300 }));
+      });
+
+      // Dragging alone should not call `onResize`
+      expect(onResize).not.toHaveBeenCalled();
+
+      act(() => {
+        window.dispatchEvent(new MouseEvent('mouseup'));
+      });
+
+      // Right-side flyout: dragging 100px left grows it to 500px
+      await waitFor(() => {
+        expect(onResize).toHaveBeenCalledTimes(1);
+      });
+      expect(onResize).toHaveBeenCalledWith(500);
     });
   });
 });

--- a/packages/eui/src/components/flyout/use_flyout_resizable.test.ts
+++ b/packages/eui/src/components/flyout/use_flyout_resizable.test.ts
@@ -472,6 +472,111 @@ describe('useEuiFlyoutResizable', () => {
       expect(onResize).not.toHaveBeenCalled();
     });
 
+    it('does not call `onResize` when the referenceWidth and the `onResize` identity change together', async () => {
+      // A parent rerender can hand down a new inline `onResize` in the same
+      // render that a container resize lands in. The callback effect then
+      // re-runs with the render's pre-update `callOnResize`, so resetting that
+      // state in the constraint effect is not on its own enough to suppress it.
+      const onResize = jest.fn();
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        {
+          initialProps: {
+            ...mockProps,
+            enabled: true,
+            minWidth: 0,
+            maxWidth: undefined,
+            referenceWidth: 1200,
+            size: 800,
+            onResize: (width: number) => onResize(width),
+          },
+        }
+      );
+
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(800);
+      });
+
+      act(() => {
+        result.current.onKeyDown({
+          key: 'ArrowRight',
+          preventDefault: () => {},
+        } as ReactKeyboardEvent);
+      });
+      await waitFor(() => {
+        expect(onResize).toHaveBeenCalledWith(790);
+      });
+      onResize.mockClear();
+
+      // Note the fresh `onResize` identity alongside the new referenceWidth
+      rerender({
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        referenceWidth: 600,
+        size: 800,
+        onResize: (width: number) => onResize(width),
+      });
+
+      await waitFor(() => {
+        expect(result.current.size).toBe('90%');
+      });
+      expect(onResize).not.toHaveBeenCalled();
+    });
+
+    it('still calls `onResize` for a user resize that follows a container resize', async () => {
+      // Guards against the container-resize suppression sticking around and
+      // swallowing the next genuine user resize
+      const onResize = jest.fn();
+      const { result, rerender } = renderHook(
+        (props) => useEuiFlyoutResizable(props),
+        {
+          initialProps: {
+            ...mockProps,
+            enabled: true,
+            minWidth: 0,
+            maxWidth: undefined,
+            referenceWidth: 1200,
+            size: 400,
+            onResize,
+          },
+        }
+      );
+
+      await waitFor(() => {
+        expect(toPixels(result.current.size, 1200)).toBeCloseTo(400);
+      });
+
+      rerender({
+        ...mockProps,
+        enabled: true,
+        minWidth: 0,
+        maxWidth: undefined,
+        referenceWidth: 1000,
+        size: 400,
+        onResize,
+      });
+
+      await waitFor(() => {
+        expect(result.current.size).toBe('40%');
+      });
+      expect(onResize).not.toHaveBeenCalled();
+
+      // Now a real user resize — this one must be reported
+      act(() => {
+        result.current.onKeyDown({
+          key: 'ArrowRight',
+          preventDefault: () => {},
+        } as ReactKeyboardEvent);
+      });
+
+      await waitFor(() => {
+        expect(onResize).toHaveBeenCalledTimes(1);
+      });
+      expect(onResize).toHaveBeenCalledWith(390);
+    });
+
     it('still calls `onResize` once with the final width after a drag ends', async () => {
       const onResize = jest.fn();
       const { result } = renderHook(() =>

--- a/packages/eui/src/components/flyout/use_flyout_resizable.ts
+++ b/packages/eui/src/components/flyout/use_flyout_resizable.ts
@@ -79,7 +79,9 @@ export const useEuiFlyoutResizable = ({
     if (!enabled) return; // Don't measure when resizing is disabled
     if (!flyoutWidth && flyoutRef) {
       setCallOnResize(false); // Don't call `onResize` for non-user width changes
-      setFlyoutWidth(getFlyoutMinMaxWidth(flyoutRef.offsetWidth));
+      const measuredWidth = getFlyoutMinMaxWidth(flyoutRef.offsetWidth);
+      requestedWidthRef.current ??= measuredWidth;
+      setFlyoutWidth(measuredWidth);
     }
   }, [flyoutWidth, flyoutRef, getFlyoutMinMaxWidth, enabled]);
 
@@ -104,6 +106,14 @@ export const useEuiFlyoutResizable = ({
   // `callOnResize` back to `true`.
   const isContainerResizeRef = useRef(false);
 
+  // The pixel width last *asked for* — by the consumer via a numeric `size`, or
+  // by the user via a drag / keyboard resize. This is deliberately kept apart
+  // from `flyoutWidth`, which is that request clamped to the space currently
+  // available. Re-clamping the already-clamped `flyoutWidth` would be lossy:
+  // shrinking the container past the request and growing it back would leave
+  // the flyout stuck at the shrunken width instead of returning to the request.
+  const requestedWidthRef = useRef<number | null>(null);
+
   // Update flyout width when consumers pass in a new `size`, or re-clamp
   // (numeric `size`) / scale proportionally and re-clamp (named `size`) when
   // constraints change (e.g. container resize, sibling width change).
@@ -114,6 +124,7 @@ export const useEuiFlyoutResizable = ({
       // The consumer's `size` prop actually changed — reset so the new size takes effect
       prevSizeRef.current = _size;
       prevReferenceWidthRef.current = _referenceWidth;
+      requestedWidthRef.current = typeof _size === 'number' ? _size : null;
       setCallOnResize(false);
       setFlyoutWidth(
         typeof _size === 'number' ? getFlyoutMinMaxWidth(_size) : 0
@@ -135,12 +146,14 @@ export const useEuiFlyoutResizable = ({
       setFlyoutWidth((currentWidth) => {
         if (currentWidth && prevRefWidth > 0 && _referenceWidth > 0) {
           // A numeric `size` is a pixel contract — the consumer supplied an
-          // exact width and may persist it — so re-clamp rather than rescale.
-          // Named sizes are percentages (see `flyout.styles.ts`) and keep
-          // scaling, preserving their percentage position in both directions
-          // (reference width shrink AND grow).
+          // exact width and may persist it — so re-clamp the requested width
+          // rather than rescaling. Clamping is applied to the request, never to
+          // the previous result, so the flyout returns to the requested width
+          // once there is room for it again. Named sizes are percentages (see
+          // `flyout.styles.ts`) and keep scaling, preserving their percentage
+          // position in both directions (reference width shrink AND grow).
           if (typeof _size === 'number') {
-            return getFlyoutMinMaxWidth(currentWidth);
+            return getFlyoutMinMaxWidth(requestedWidthRef.current ?? _size);
           }
           const scaleFactor = _referenceWidth / prevRefWidth;
           return getFlyoutMinMaxWidth(currentWidth * scaleFactor);
@@ -148,6 +161,7 @@ export const useEuiFlyoutResizable = ({
         // When reference width was 0 (e.g. container not yet measured), now
         // that we have a real width, reset from the size prop instead of scaling.
         if (_referenceWidth > 0) {
+          requestedWidthRef.current = typeof _size === 'number' ? _size : null;
           return typeof _size === 'number' ? getFlyoutMinMaxWidth(_size) : 0;
         }
         return currentWidth;
@@ -178,7 +192,11 @@ export const useEuiFlyoutResizable = ({
       const mouseOffset = getPosition(e, true) - initialMouseX.current;
       const changedFlyoutWidth = initialWidth.current + mouseOffset * direction;
 
-      setFlyoutWidth(getFlyoutMinMaxWidth(changedFlyoutWidth));
+      // The dragged width becomes the new request — the user cannot drag past
+      // the clamp, so what they see is what they asked for
+      const newWidth = getFlyoutMinMaxWidth(changedFlyoutWidth);
+      requestedWidthRef.current = newWidth;
+      setFlyoutWidth(newWidth);
     },
     [getFlyoutMinMaxWidth, direction, enabled]
   );
@@ -231,18 +249,25 @@ export const useEuiFlyoutResizable = ({
 
       const KEYBOARD_OFFSET = 10;
 
+      // Steps from the currently rendered width, and the result becomes the new
+      // request. Assigning the ref from the updater keeps it in step with the
+      // width actually committed; the computation is idempotent, so a
+      // double-invoked updater (StrictMode) resolves to the same value.
+      const resizeBy = (offset: number) =>
+        setFlyoutWidth((flyoutWidth) => {
+          const newWidth = getFlyoutMinMaxWidth(flyoutWidth + offset);
+          requestedWidthRef.current = newWidth;
+          return newWidth;
+        });
+
       switch (e.key) {
         case keys.ARROW_RIGHT:
           e.preventDefault(); // Safari+VO will screen reader navigate off the button otherwise
-          setFlyoutWidth((flyoutWidth) =>
-            getFlyoutMinMaxWidth(flyoutWidth + KEYBOARD_OFFSET * direction)
-          );
+          resizeBy(KEYBOARD_OFFSET * direction);
           break;
         case keys.ARROW_LEFT:
           e.preventDefault(); // Safari+VO will screen reader navigate off the button otherwise
-          setFlyoutWidth((flyoutWidth) =>
-            getFlyoutMinMaxWidth(flyoutWidth - KEYBOARD_OFFSET * direction)
-          );
+          resizeBy(-KEYBOARD_OFFSET * direction);
       }
     },
     [getFlyoutMinMaxWidth, direction, enabled]

--- a/packages/eui/src/components/flyout/use_flyout_resizable.ts
+++ b/packages/eui/src/components/flyout/use_flyout_resizable.ts
@@ -89,13 +89,13 @@ export const useEuiFlyoutResizable = ({
   // Initialized to `null` so the first render always takes the "reset" path.
   const prevSizeRef = useRef<string | number | null>(null);
 
-  // Track the previous reference width so we can scale proportionally when
-  // the container / viewport resizes (both shrink AND grow).
+  // Track the previous reference width so we can detect container / viewport
+  // resizes, and scale proportionally for named (percentage) sizes.
   const prevReferenceWidthRef = useRef(_referenceWidth);
 
-  // Update flyout width when consumers pass in a new `size`, or scale
-  // proportionally and re-clamp when constraints change (e.g. container
-  // resize, sibling width change).
+  // Update flyout width when consumers pass in a new `size`, or re-clamp
+  // (numeric `size`) / scale proportionally and re-clamp (named `size`) when
+  // constraints change (e.g. container resize, sibling width change).
   useEffect(() => {
     if (!enabled) return; // Don't update width when resizing is disabled
 
@@ -108,15 +108,27 @@ export const useEuiFlyoutResizable = ({
         typeof _size === 'number' ? getFlyoutMinMaxWidth(_size) : 0
       );
     } else {
-      // Only constraints changed (referenceWidth, sibling width, etc.) —
-      // scale the pixel width proportionally to the reference width change
-      // and then clamp. This preserves the flyout's percentage position in
-      // both directions (viewport shrink AND grow).
+      // Only constraints changed (referenceWidth, sibling width, etc.).
+      // How the current pixel width is updated depends on the `size` contract:
+      // named sizes are percentages, so they scale proportionally with the
+      // reference width; numeric sizes are pixels, so they are only re-clamped.
       const prevRefWidth = prevReferenceWidthRef.current ?? _referenceWidth;
       prevReferenceWidthRef.current = _referenceWidth;
 
+      if (_referenceWidth !== prevRefWidth) {
+        setCallOnResize(false); // A container resize is not a user resize
+      }
+
       setFlyoutWidth((currentWidth) => {
         if (currentWidth && prevRefWidth > 0 && _referenceWidth > 0) {
+          // A numeric `size` is a pixel contract — the consumer supplied an
+          // exact width and may persist it — so re-clamp rather than rescale.
+          // Named sizes are percentages (see `flyout.styles.ts`) and keep
+          // scaling, preserving their percentage position in both directions
+          // (reference width shrink AND grow).
+          if (typeof _size === 'number') {
+            return getFlyoutMinMaxWidth(currentWidth);
+          }
           const scaleFactor = _referenceWidth / prevRefWidth;
           return getFlyoutMinMaxWidth(currentWidth * scaleFactor);
         }

--- a/packages/eui/src/components/flyout/use_flyout_resizable.ts
+++ b/packages/eui/src/components/flyout/use_flyout_resizable.ts
@@ -93,6 +93,17 @@ export const useEuiFlyoutResizable = ({
   // resizes, and scale proportionally for named (percentage) sizes.
   const prevReferenceWidthRef = useRef(_referenceWidth);
 
+  // Set when the pending width change came from a container / viewport resize
+  // rather than from the user. `setCallOnResize(false)` alone cannot suppress
+  // the `onResize` effect below, because that effect can re-run in the *same*
+  // render the resize arrives in (e.g. a parent rerender also hands down a new
+  // inline `onResize`) and would still read the pre-update `callOnResize`.
+  // A ref is written synchronously by the effect below, which is declared
+  // before the `onResize` effect and so always runs first within a commit.
+  // Cleared by the user interaction handlers — the only callers that set
+  // `callOnResize` back to `true`.
+  const isContainerResizeRef = useRef(false);
+
   // Update flyout width when consumers pass in a new `size`, or re-clamp
   // (numeric `size`) / scale proportionally and re-clamp (named `size`) when
   // constraints change (e.g. container resize, sibling width change).
@@ -116,7 +127,9 @@ export const useEuiFlyoutResizable = ({
       prevReferenceWidthRef.current = _referenceWidth;
 
       if (_referenceWidth !== prevRefWidth) {
-        setCallOnResize(false); // A container resize is not a user resize
+        // A container resize is not a user resize
+        isContainerResizeRef.current = true;
+        setCallOnResize(false);
       }
 
       setFlyoutWidth((currentWidth) => {
@@ -171,6 +184,7 @@ export const useEuiFlyoutResizable = ({
   );
 
   const onMouseUp = useCallback(() => {
+    isContainerResizeRef.current = false;
     setCallOnResize(true);
 
     if (!enabled) {
@@ -208,6 +222,7 @@ export const useEuiFlyoutResizable = ({
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      isContainerResizeRef.current = false;
       setCallOnResize(true);
 
       if (!enabled) {
@@ -236,7 +251,9 @@ export const useEuiFlyoutResizable = ({
   // To reduce unnecessary calls, only fire onResize callback:
   // 1. After initial mount / on user width change events only
   // 2. If not currently mouse dragging
+  // 3. Not for container / viewport driven resizes (see `isContainerResizeRef`)
   useEffect(() => {
+    if (isContainerResizeRef.current) return;
     if (callOnResize && enabled) {
       onResize?.(flyoutWidth);
     }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/eui/issues/9969

**What:** A resizable `EuiFlyout` given a **numeric** `size` no longer rescales when the flyout container's width changes. It keeps the user's pixel width and is only re-clamped. Container-driven resizes also no longer fire `onResize`.

**Why:** When the container width changed, `useEuiFlyoutResizable` multiplied the current pixel width by the reference-width ratio to preserve the flyout's *percentage* of the container. For a `type="push"` flyout this moves **both** panes on a single container resize — the flyout rescales and the pushed content reflows to match.

Separately, `callOnResize` is set to `true` on `onMouseUp`/`onKeyDown` and was never reset on the constraint-change path, so these machine-generated rescales called `onResize`. Consumers that persist the callback value had the user's stored width permanently overwritten by a window resize.

**How:** Branch on the `size` type in the constraint-change path of `use_flyout_resizable.ts`, and reset `callOnResize` when the reference width actually changed.

```ts
setFlyoutWidth((currentWidth) => {
  if (currentWidth && prevRefWidth > 0 && _referenceWidth > 0) {
    // A numeric `size` is a pixel contract — re-clamp rather than rescale.
    if (typeof _size === 'number') {
      return getFlyoutMinMaxWidth(currentWidth);
    }
    const scaleFactor = _referenceWidth / prevRefWidth;
    return getFlyoutMinMaxWidth(currentWidth * scaleFactor);
  }
  ...
```

### Why the fix is conditional, and why it does not conflict with #9683

https://github.com/elastic/eui/issues/9683 fires on the **same trigger** — the flyout container's width changing — but asks for the **opposite** outcome: a manually-resized main+child pair should revert to its coded `s`/`m` size when it goes stacked. Both asks are valid because they describe different consumer contracts, and `typeof size === 'number'` is the discriminator:

| `size` prop | Contract | Behavior on container resize |
| --- | --- | --- |
| `'s'` / `'m'` / `'l'` / `'fill'` | Percentage semantics | Keeps scaling — **unchanged by this PR** |
| numeric (e.g. `544`) | Consumer measured, persisted, and re-supplied pixels | Re-clamp only, preserve pixels |

Scaling is correct for named sizes because EUI literally defines them as percentages in `packages/eui/src/components/flyout/flyout.styles.ts`:

```
s: width 25%
m: width 50%
l: width 75%
   (capped at 90%)
```

An `m` flyout that stays at 50% through a container resize is behaving as designed, and the pre-existing code comment said so explicitly ("preserves the flyout's percentage position in both directions"). **Removing the scale factor unconditionally would be a silent semantic change for every resizable named-size flyout**, and would pre-empt #9683's design space. This PR therefore changes the numeric branch only.

The test `preserves the percentage for a named "size"` in `use_flyout_resizable.test.ts` is the regression guard for that: it asserts an `m` flyout still holds 50% across a reference-width change. It passes both with and without this diff, which is exactly what a guard should do.

### Notes for reviewers

- **`resizeMode` prop deliberately not added.** The issue floats an explicit `resizeMode: 'pixel' | 'percent'` prop as the more discoverable API. This PR implements the inferred (`typeof size === 'number'`) version, which needs no consumer changes and keeps the diff reviewable. Happy to switch to the explicit prop if the team prefers it.
- **The `callOnResize` reset is gated on the reference width having changed** (`if (_referenceWidth !== prevRefWidth)`) rather than firing unconditionally. An unconditional reset in this branch would risk suppressing the legitimate `onResize` at the end of a drag when a sibling width or other clamp input changes around the same tick. There is a test covering that a drag-then-release still fires `onResize` exactly once with the final width.
- **The `%` round-trip is lossless on this path.** `referenceWidth` comes from `useResizeObserver(container, 'width')` (which reports `borderBoxSize.inlineSize`) and `flyout.component.tsx` converts back with `containerRect.width` from `getBoundingClientRect()` — both border-box. This PR does not change the `%` output mechanism.
- **Known separate follow-up:** the `container.clientWidth` fallback in `flyout.component.tsx:365` (used when the ResizeObserver hasn't reported yet) is *content-box* where the rest of the path is border-box, so it is off by the container's padding on the first frame — including the push padding this component applies itself. That's a real but distinct bug and is intentionally not folded in here.

### Reporting consumer

Kibana's Discover document details flyout. Kibana scopes flyouts to the app workspace container (`#app-main-scroll`), so a window resize, a sidebar resize, or opening the AI Assistant all change `referenceWidth`; Discover persists the `onResize` width to `localStorage`, which is the user-visible half of the bug. Kibana tracks its own consumer-side fixes (the ones that do **not** need this change) at https://github.com/elastic/kibana/issues/287943.

### API Changes

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
| EuiFlyout / EuiFlyoutResizable | `size` (numeric) | Behavior | A numeric `size` is now treated as a pixel contract: on container resize the flyout is re-clamped rather than rescaled proportionally |
| EuiFlyout / EuiFlyoutResizable | `onResize` | Behavior | No longer called for container-driven (non-user) resizes |

## Screenshots

No visual change for named sizes. For numeric sizes the change is that the flyout *stops* moving on container resize; see the screenshot in https://github.com/elastic/eui/issues/9969 for the reported behavior.

## Impact Assessment

- [ ] 🔴 **Breaking changes** — None. No API surface changes; the behavior change is scoped to resizable flyouts with a numeric `size`.
- [ ] 💅 **Visual changes** — Only for resizable flyouts with a numeric `size` during a container resize, and in the direction the issue asks for. Named sizes (`s`/`m`/`l`/`fill`) are untouched.
- [x] 🧪 **Test impact** — Added 6 unit tests. No existing test was changed: `use_flyout_resizable.test.ts` had no coverage of scaling on `referenceWidth` change (every prior test uses a static `referenceWidth`), so nothing was weakened to get green.
- [ ] 🔧 **Hard to integrate** — No consumer changes required.

**Impact level:** 🟢 Low

## Release Readiness

- [ ] ~~**Documentation:**~~ no doc-visible API change
- [ ] ~~**Figma:**~~ n/a
- [ ] ~~**Migration guide:**~~ n/a
- [ ] ~~**Adoption plan** (new features):~~ bug fix; the reporting consumer is Discover

### QA instructions for reviewer

1. Render a resizable `EuiFlyout` with `type="push"`, a **numeric** `size` (e.g. `544`), and a `container` element narrower than the viewport.
2. Drag the resize handle to a chosen width and note the pixel value.
3. Change the container's width (resize the window, or toggle a sidebar beside it).
   - [ ] Confirm the flyout **stays at the dragged pixel width** (re-clamped if it no longer fits within 90% of the container / `maxWidth`), and that only the pushed content resizes.
   - [ ] Confirm `onResize` does **not** fire for the container resize.
4. Repeat with `size="m"`.
   - [ ] Confirm the `m` flyout still **scales proportionally**, holding 50% of the container across the resize (pre-existing behavior, deliberately preserved for #9683).
5. Drag-and-release on both.
   - [ ] Confirm `onResize` still fires exactly once with the final width.

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [ ] ~~**QA:** Tested light/dark modes, high contrast, mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader~~ — no rendering or styling change
- [ ] **QA:** Tested in CodeSandbox and Kibana
- [ ] ~~**QA:** Tested docs changes~~ — no docs changes
- [x] **Tests:** Added Jest coverage (verified that the 4 new behavior tests fail against the unfixed hook, and that the 2 regression guards pass either way). **Cypress:** not added — the existing `flyout_resizable.spec.tsx` never passes a `container` and never changes the container width mid-test, so it does not exercise the branch this PR touches and is unaffected. A Cypress case that resizes a real container would be worthwhile, but I could not validate one in my environment (the Cypress binary host is unreachable there), so I left it out rather than push an unverified spec. Happy to add it on request.
- [x] **Changelog:** added
- [ ] ~~**Breaking changes:** Added `breaking change` label~~ — not a breaking change

---
_Generated by [Claude Code](https://claude.ai/code/session_018ETTN39EVo6iTDT7cztt7T)_