### PR TITLE
[Chore] Wait for registry to fix broken CI

### DIFF
--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -241,7 +241,7 @@ jobs:
         # language=bash
         run: |
           set -euo pipefail
-          # Retry a few times, npm can lag behind yarn.
+          # Retry a few times; the npm registry can lag behind a snapshot publish.
           for attempt in 1 2 3 4 5; do
             if yarn kbn bootstrap; then
               break

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -240,7 +240,18 @@ jobs:
       - name: Run Kibana bootstrap script and normalize dependencies
         # language=bash
         run: |
-          yarn kbn bootstrap
+          set -euo pipefail
+          # Retry a few times, npm can lag behind yarn.
+          for attempt in 1 2 3 4 5; do
+            if yarn kbn bootstrap; then
+              break
+            fi
+            if [[ "$attempt" -eq 5 ]]; then
+              exit 1
+            fi
+            echo "bootstrap failed (attempt ${attempt}/5); retrying in 60s"
+            sleep 60
+          done
           node scripts/yarn_deduplicate
           yarn kbn bootstrap --force-install
       - name: Sync EUI i18n tokens


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

**What:** Retry `yarn kbn bootstrap` up to 5 times (60s apart) when preparing the Kibana integration PR.
**Why:** Snapshot publish succeeds, then Kibana bootstrap dies on registry lag (Couldn't find any versions for `@elastic/eui-theme-borealis@…`). No Kibana PR opens.
**How:** Same step, just retry. Happy path still runs once.

### Failing builds

- Regression ([#9954](https://github.com/elastic/eui/pull/9954) label): [Prepare changes #33415941511](https://github.com/elastic/eui/actions/runs/33415941511)
- Snapshot itself was green: [Release packages #33414075377](https://github.com/elastic/eui/actions/runs/33414075377)
- Nightly CI: [Prepare changes #33467524843](https://github.com/elastic/eui/actions/runs/33467524843) (same class of miss, `@elastic/eui-test-helpers`)

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

Cannot be tested before merging to `main`.