### PR TITLE
[Chore] Remove `vrt_passed` fallback and add a new message

### DIFF
--- a/.buildkite/scripts/deploy_docs/step_notify.sh
+++ b/.buildkite/scripts/deploy_docs/step_notify.sh
@@ -12,8 +12,7 @@ source .buildkite/scripts/common/utils.sh
 
 bucket_directory="$(buildkite-agent meta-data get bucket_directory --default "")"
 copy_to_root_directory="$(buildkite-agent meta-data get copy_to_root_directory --default "")"
-# Default to "true" for non-PR builds where VRT never runs
-vrt_passed="$(buildkite-agent meta-data get vrt_passed --default true)"
+vrt_passed="$(buildkite-agent meta-data get vrt_passed --default "")"
 vrt_skip_reason="$(buildkite-agent meta-data get vrt_skip_reason --default "see build log")"
 
 website_links="[Documentation website](https://eui.elastic.co/${bucket_directory})"
@@ -39,6 +38,10 @@ if [[ -n "${BUILDKITE_PULL_REQUEST:-}" ]] && [[ "${BUILDKITE_PULL_REQUEST}" != "
   elif [[ "${vrt_passed}" == "skipped" ]]; then
     vrt_annotation="- :no_entry_sign: Visual regression tests skipped: ${vrt_skip_reason}"
     vrt_pr_comment="\n* :no_entry_sign: Visual regression tests skipped: ${vrt_skip_reason}"
+  elif [[ -z "${vrt_passed}" ]]; then
+    annotation_style="error"
+    vrt_annotation="- :warning: Visual regression tests did not complete ([see build](${BUILDKITE_BUILD_URL}))"
+    vrt_pr_comment="\n* :warning: Visual regression tests did not complete ([see build](${BUILDKITE_BUILD_URL}))"
   else
     annotation_style="error"
     # `vrt_comment_url` is only set when `step_vrt_report.sh` actually found visual differences


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

The comment misreports VRT passing when e.g. one of the variant times out. The issue is that the `vrt_passed` fallbacks to `true` but it should rather be empty. We report a new message "VRT did not complete" which is more truthful.

[Example build](https://buildkite.com/elastic/eui-deploy-docs/builds/5171)

<img width="897" height="606" alt="Screenshot 2026-09-01 at 15 38 20" src="https://github.com/user-attachments/assets/27fe1ed9-ebbd-4a39-bf66-60a8250b3e9d" />
<img width="1484" height="491" alt="Screenshot 2026-09-01 at 15 40 29" src="https://github.com/user-attachments/assets/72862c79-dc46-497a-b4e4-950437e37db9" />

## QA

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

| | Case | Screenshots |
| --- | --- | --- |
| ✅ | `skip-vrt` label | <img width="893" height="384" alt="Screenshot 2026-09-02 at 15 35 14" src="https://github.com/user-attachments/assets/1c184546-9cce-4002-ab7e-e8bd619f435c" /> |
| ✅ | No visual diff | <img width="895" height="515" alt="Screenshot 2026-09-02 at 16 12 34" src="https://github.com/user-attachments/assets/ea6e3565-509e-41b0-8061-98056200ee5a" /> |
| ✅ | Visual diff | <img width="892" height="545" alt="Screenshot 2026-09-02 at 15 35 05" src="https://github.com/user-attachments/assets/52b21108-dc7a-422e-a5ff-7c88952b9081" /> |
| ✅ | Timeout error | <img width="896" height="546" alt="Screenshot 2026-09-02 at 15 55 26" src="https://github.com/user-attachments/assets/af04c2ba-8fb1-4ece-9c97-7c398c525879" /><br><img width="1482" height="138" alt="Screenshot 2026-09-02 at 15 49 40" src="https://github.com/user-attachments/assets/a97d2d48-775f-4a1e-b010-b62304f5ccbf" /> |
| ✅ | Infra error | <img width="892" height="594" alt="Screenshot 2026-09-02 at 16 10 22" src="https://github.com/user-attachments/assets/e0785c55-7c77-4c4b-ab42-819324f7e9a3" /> |
