### PR TITLE
[Chore] Beef up the machine type

### DIFF
--- a/.buildkite/pipelines/deploy_docs.yml
+++ b/.buildkite/pipelines/deploy_docs.yml
@@ -1,8 +1,8 @@
 agents:
   provider: gcp
   image: "family/eui-ubuntu-2204"
-  # 4 AMD Rome / Milan vCPUs, 16GB RAM
-  machineType: 'n2d-standard-4'
+  # 8 AMD Rome / Milan vCPUs, 32GB RAM
+  machineType: 'n2d-standard-8'
   # No spot instances to protect against agent losses during file upload
   preemptible: false
 


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Bump `deploy-docs` agents from `n2d-standard-4` to `n2d-standard-8`. CI VRT does not cap `--maxWorkers` so it should benefit as well.

This should help with the timeouts, see a related PR: https://github.com/elastic/eui/pull/9983.