### PR TITLE
[EuiPopover] Round title and footer corners to match the panel

### DIFF
--- a/packages/eui/changelogs/upcoming/9985.md
+++ b/packages/eui/changelogs/upcoming/9985.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiPopoverTitle` and `EuiPopoverFooter` backgrounds not following the popover panel's corner radius

--- a/packages/eui/src/components/popover/popover_footer.styles.ts
+++ b/packages/eui/src/components/popover/popover_footer.styles.ts
@@ -31,6 +31,10 @@ export const euiPopoverFooterStyles = (euiThemeContext: UseEuiTheme) => {
             : euiTheme.components.popoverFooterBorderColor
         }`
       )}
+      /* Match the panel radius so footer backgrounds don't square off the corners.
+         Avoid overflow: hidden on the panel — it clips the filter shadow and arrow. */
+      ${logicalCSS('border-bottom-left-radius', euiTheme.border.radius.medium)}
+      ${logicalCSS('border-bottom-right-radius', euiTheme.border.radius.medium)}
     `,
     // If the popover's containing panel has padding applied,
     // ensure the title expands to cover that padding via negative margins

--- a/packages/eui/src/components/popover/popover_footer.styles.ts
+++ b/packages/eui/src/components/popover/popover_footer.styles.ts
@@ -37,7 +37,7 @@ export const euiPopoverFooterStyles = (euiThemeContext: UseEuiTheme) => {
       ${logicalCSS('border-bottom-right-radius', euiTheme.border.radius.medium)}
     `,
     // If the popover's containing panel has padding applied,
-    // ensure the title expands to cover that padding via negative margins
+    // ensure the footer expands to cover that padding via negative margins
     panelPaddingSizes: {
       none: css``,
       xs: css`

--- a/packages/eui/src/components/popover/popover_title.styles.ts
+++ b/packages/eui/src/components/popover/popover_title.styles.ts
@@ -24,6 +24,10 @@ export const euiPopoverTitleStyles = (euiThemeContext: UseEuiTheme) => {
     euiPopoverTitle: css`
       ${euiTitle(euiThemeContext, 'xxs')}
       ${logicalCSS('border-bottom', euiTheme.border.thin)}
+      /* Match the panel radius so title backgrounds don't square off the corners.
+         Avoid overflow: hidden on the panel — it clips the filter shadow and arrow. */
+      ${logicalCSS('border-top-left-radius', euiTheme.border.radius.medium)}
+      ${logicalCSS('border-top-right-radius', euiTheme.border.radius.medium)}
     `,
     // If the popover's containing panel has padding applied,
     // ensure the title expands to cover that padding via negative margins


### PR DESCRIPTION
Closes #9970 

## Summary

- **What:** `EuiPopoverTitle` and `EuiPopoverFooter` now use the same corner radius as the popover panel.
- **Why:** Fixes #9970. A title or footer background currently squares off the panel corners. This gets more obvious once panel radius increases.
- **How:** Apply `border.radius.medium` to the title’s top corners and the footer’s bottom corners. Do **not** add `overflow: hidden` on the panel — that clips the filter-based shadow and arrow.

### API Changes

None.

## Screenshots

| Before | After |
| ----- | ----- |
| <img width="300" alt="CleanShot 2026-09-01 at 15 44 06@2x" src="https://github.com/user-attachments/assets/4dfe5f74-cc1a-43a2-bc4e-2f0ed719932e" /> | <img width="300" alt="CleanShot 2026-09-01 at 15 38 52@2x" src="https://github.com/user-attachments/assets/f52f4441-5178-4cd0-b858-c03e009a9279" /> |
| <img width="300" alt="CleanShot 2026-09-01 at 15 37 26@2x" src="https://github.com/user-attachments/assets/2a2e429d-c4e8-40e6-9580-3c3ceedfcb9a" /> | <img width="300" alt="CleanShot 2026-09-01 at 15 38 18@2x" src="https://github.com/user-attachments/assets/c11dd593-72d9-429f-ad03-9efdf528d786" /> |

## Impact Assessment

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [x] 💅 **Visual changes** — Title/footer fills now follow the panel radius. Visible when those regions have a background (e.g. Kibana options list `EuiInputPopover`). No layout or API change.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

**Impact level:** 🟢 Low

## Release Readiness

- [x] **Documentation:** ~~N/A — visual bugfix, no docs change~~
- [x] **Figma:** ~~N/A~~
- [x] **Migration guide:** ~~N/A~~
- [x] **Adoption plan** (new features): ~~N/A~~

### QA instructions for reviewer

- Open Storybook **EuiPopoverFooter** and **EuiPopoverTitle**.
- Give `EuiPopoverFooter` (and `EuiPopoverTitle`) a background color.
- [ ] Bottom corners of the footer follow the panel radius (not square).
- [ ] Top corners of the title follow the panel radius (not square).
- [ ] Filter shadow and arrow still render (no clipping).
- Repeat on **Layout / EuiInputPopover** with a footer background, including `panelPaddingSize="none"`.

### Checklist before marking Ready for Review

- [x] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [x] **QA:** Tested docs changes ~~N/A~~
- [x] **Tests:** Existing Jest snapshots still pass (class names unchanged)
- [x] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable) ~~N/A~~

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.

