### PR TITLE
[test-helpers] Add EuiPopoverObject

### DIFF
--- a/packages/eui/src/components/popover/popover.stories.tsx
+++ b/packages/eui/src/components/popover/popover.stories.tsx
@@ -74,6 +74,7 @@ const StatefulPopover = ({
   closePopover,
   isOpen: _isOpen,
   hasArrow,
+  'data-test-subj': dataTestSubj,
   ...rest
 }: EuiPopoverProps) => {
   const [isOpen, setOpen] = useState(_isOpen);
@@ -101,7 +102,7 @@ const StatefulPopover = ({
   };
 
   const trigger = (
-    <EuiButton onClick={() => setOpen(!isOpen)}>
+    <EuiButton data-test-subj={dataTestSubj} onClick={() => setOpen(!isOpen)}>
       {button || 'trigger'}
     </EuiButton>
   );

--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -54,6 +54,7 @@ their own version at runtime.
 | `EuiDraggableObject` | [src/components/drag_and_drop/README.md](src/components/drag_and_drop/README.md) |
 | `EuiFilterButtonObject` | [src/components/filter_button/README.md](src/components/filter_button/README.md) |
 | `EuiRangeObject` | [src/components/form/range/README.md](src/components/form/range/README.md) |
+| `EuiPopoverObject` | [src/components/popover/README.md](src/components/popover/README.md) |
 | `EuiBasicTableObject` | [src/components/basic_table/README.md](src/components/basic_table/README.md) |
 
 ## Contributing

--- a/packages/test-helpers/changelogs/upcoming/9993.md
+++ b/packages/test-helpers/changelogs/upcoming/9993.md
@@ -1,0 +1,1 @@
+- Added `EuiPopoverObject`, a Playwright Component Object for `EuiPopover`

--- a/packages/test-helpers/src/components/popover/README.md
+++ b/packages/test-helpers/src/components/popover/README.md
@@ -1,0 +1,29 @@
+# EuiPopoverObject
+
+Playwright Component Object for [EuiPopover](https://eui.elastic.co/docs/components/containers/popover/).
+
+## Usage
+
+```ts
+import { EuiPopoverObject } from '@elastic/eui-test-helpers';
+
+const popover = new EuiPopoverObject(page, 'myPopoverToggle');
+await popover.open();
+await popover.close();
+```
+
+Set `data-test-subj` on the toggle button (the `button` prop's own element), not on `EuiPopover` itself — `EuiPopover` spreads unrecognized props onto its outer anchor wrapper, not the toggle. `EuiPopover` only manages `aria-expanded`/`aria-controls` on a button-like toggle (a `<button>` or `role="button"`), which the component-type guard also relies on, so a non-button toggle is not supported.
+
+## API
+
+| Member | Description |
+|---|---|
+| `open()` | Opens the popover. A no-op if it is already open. |
+| `close()` | Closes the popover. A no-op if it is already closed. |
+
+Both read `aria-expanded` synchronously, which `EuiPopover` sets on the toggle from mount regardless of open state, so no wait or retry is needed to decide whether to click.
+
+## Deliberately out of scope
+
+- **Reading open state**: assert directly on `locator`, e.g. `expect(popover.locator).toHaveAttribute('aria-expanded', 'true')`.
+- **The popover panel**: not this component's concern. Scope another Component Object (e.g. `EuiSelectableObject`) to the panel's own `data-test-subj` for its contents.

--- a/packages/test-helpers/src/components/popover/README.md
+++ b/packages/test-helpers/src/components/popover/README.md
@@ -12,16 +12,16 @@ await popover.open();
 await popover.close();
 ```
 
-Set `data-test-subj` on the toggle button (the `button` prop's own element), not on `EuiPopover` itself — `EuiPopover` spreads unrecognized props onto its outer anchor wrapper, not the toggle. `EuiPopover` only manages `aria-expanded`/`aria-controls` on a button-like toggle (a `<button>` or `role="button"`), which the component-type guard also relies on, so a non-button toggle is not supported.
+Set `data-test-subj` on the toggle button (the `button` prop's own element), not on `EuiPopover` itself. `EuiPopover` spreads unrecognized props onto its outer anchor wrapper, not the toggle. `EuiPopover` only manages `aria-expanded`/`aria-controls` on a button-like toggle (a `<button>` or `role="button"`), which the component-type guard also relies on, so a non-button toggle is not supported.
 
 ## API
 
 | Member | Description |
 |---|---|
-| `open()` | Opens the popover. A no-op if it is already open. |
-| `close()` | Closes the popover. A no-op if it is already closed. |
+| `open()` | Opens the popover and returns once the panel is open. A no-op if it is already open. |
+| `close()` | Closes the popover and returns once the panel is removed. A no-op if it is already closed. |
 
-Both read `aria-expanded` synchronously, which `EuiPopover` sets on the toggle from mount regardless of open state, so no wait or retry is needed to decide whether to click.
+Both decide whether to click from `aria-expanded`, which `EuiPopover` sets on the toggle synchronously with the open state. The panel itself lags that: it gets `data-popover-open` a frame after opening, and stays mounted for its 250ms closing transition. Both methods wait for the panel, found through the toggle's `aria-controls`, so callers can act on or assert against it right away.
 
 ## Deliberately out of scope
 

--- a/packages/test-helpers/src/components/popover/selectors.ts
+++ b/packages/test-helpers/src/components/popover/selectors.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/containers/popover/|EuiPopover}.
+ * `*_SELECTOR` values are CSS.
+ */
+export const EuiPopoverSelectors = {
+  /** `EuiPopover` sets this on a button-like toggle from mount, regardless of open state. */
+  TOGGLE_SELECTOR: '[aria-expanded]',
+};

--- a/packages/test-helpers/src/components/popover/selectors.ts
+++ b/packages/test-helpers/src/components/popover/selectors.ts
@@ -14,4 +14,7 @@
 export const EuiPopoverSelectors = {
   /** `EuiPopover` sets this on a button-like toggle from mount, regardless of open state. */
   TOGGLE_SELECTOR: '[aria-expanded]',
+
+  /** The portal panel, matched by the id the toggle's `aria-controls` points at. Present while open or closing. */
+  panelFor: (id: string) => `[data-popover-panel][id="${id}"]`,
 };

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -15,4 +15,5 @@ export { EuiSelectableObject } from './playwright/components/selectable/object';
 export { EuiDraggableObject } from './playwright/components/drag_and_drop/object';
 export { EuiFilterButtonObject } from './playwright/components/filter_button/object';
 export { EuiRangeObject } from './playwright/components/form/range/object';
+export { EuiPopoverObject } from './playwright/components/popover/object';
 export { EuiBasicTableObject } from './playwright/components/basic_table/object';

--- a/packages/test-helpers/src/playwright/components/popover/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/popover/object.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiPopoverObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+const TEST_SUBJ = 'testPopover';
+
+const PLAYGROUND_URL = storyUrl(
+  'layout-euipopover-euipopover--playground',
+  `data-test-subj:${TEST_SUBJ};isOpen:!false`
+);
+
+test.describe('EuiPopoverObject', () => {
+  let popover: EuiPopoverObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    popover = new EuiPopoverObject(page, TEST_SUBJ);
+  });
+
+  test.describe('open', () => {
+    test('opens a closed popover', async () => {
+      await expect(popover.locator).toHaveAttribute('aria-expanded', 'false');
+
+      await popover.open();
+
+      await expect(popover.locator).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    test('is a no-op when already open', async () => {
+      await popover.open();
+      await popover.open();
+
+      await expect(popover.locator).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  test.describe('close', () => {
+    test('closes an open popover', async () => {
+      await popover.open();
+
+      await popover.close();
+
+      await expect(popover.locator).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    test('is a no-op when already closed', async () => {
+      await popover.close();
+
+      await expect(popover.locator).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/popover/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/popover/object.spec.ts
@@ -12,6 +12,7 @@ import { EuiPopoverObject } from './object';
 import { storyUrl } from '../../../storybook';
 
 const TEST_SUBJ = 'testPopover';
+const PANEL = '[data-popover-panel]';
 
 const PLAYGROUND_URL = storyUrl(
   'layout-euipopover-euipopover--playground',
@@ -28,35 +29,37 @@ test.describe('EuiPopoverObject', () => {
   });
 
   test.describe('open', () => {
-    test('opens a closed popover', async () => {
-      await expect(popover.locator).toHaveAttribute('aria-expanded', 'false');
+    test('opens a closed popover and returns once the panel is open', async ({ page }) => {
+      await expect(page.locator(PANEL)).toHaveCount(0);
 
       await popover.open();
 
+      expect(await page.locator(PANEL).getAttribute('data-popover-open')).toBe('true');
       await expect(popover.locator).toHaveAttribute('aria-expanded', 'true');
     });
 
-    test('is a no-op when already open', async () => {
+    test('is a no-op when already open', async ({ page }) => {
       await popover.open();
       await popover.open();
 
-      await expect(popover.locator).toHaveAttribute('aria-expanded', 'true');
+      await expect(page.locator(PANEL)).toHaveCount(1);
     });
   });
 
   test.describe('close', () => {
-    test('closes an open popover', async () => {
+    test('closes an open popover and returns once the panel is removed', async ({ page }) => {
       await popover.open();
 
       await popover.close();
 
+      expect(await page.locator(PANEL).count()).toBe(0);
       await expect(popover.locator).toHaveAttribute('aria-expanded', 'false');
     });
 
-    test('is a no-op when already closed', async () => {
+    test('is a no-op when already closed', async ({ page }) => {
       await popover.close();
 
-      await expect(popover.locator).toHaveAttribute('aria-expanded', 'false');
+      await expect(page.locator(PANEL)).toHaveCount(0);
     });
   });
 });

--- a/packages/test-helpers/src/playwright/components/popover/object.ts
+++ b/packages/test-helpers/src/playwright/components/popover/object.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiPopoverSelectors } from '../../../components/popover/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/containers/popover/ EuiPopover}.
+ *
+ * `testSubj` must be set on the toggle button, not the panel — see the
+ * package README for the component-type guard and what this does not cover.
+ */
+export class EuiPopoverObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiPopoverSelectors.TOGGLE_SELECTOR);
+  }
+
+  /** Opens the popover. A no-op if it is already open. */
+  async open(): Promise<void> {
+    if ((await this.root.getAttribute('aria-expanded')) !== 'true') {
+      await this.root.click();
+    }
+  }
+
+  /** Closes the popover. A no-op if it is already closed. */
+  async close(): Promise<void> {
+    if ((await this.root.getAttribute('aria-expanded')) === 'true') {
+      await this.root.click();
+    }
+  }
+}

--- a/packages/test-helpers/src/playwright/components/popover/object.ts
+++ b/packages/test-helpers/src/playwright/components/popover/object.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { expect, type Locator } from '@playwright/test';
+
 import { BaseObject, type ObjectScope } from '../../base_object';
 import { EuiPopoverSelectors } from '../../../components/popover/selectors';
 
@@ -13,7 +15,7 @@ import { EuiPopoverSelectors } from '../../../components/popover/selectors';
  * Playwright Component Object for {@link
  * https://eui.elastic.co/docs/components/containers/popover/ EuiPopover}.
  *
- * `testSubj` must be set on the toggle button, not the panel — see the
+ * `testSubj` must be set on the toggle button, not the panel. See the
  * package README for the component-type guard and what this does not cover.
  */
 export class EuiPopoverObject extends BaseObject {
@@ -21,17 +23,41 @@ export class EuiPopoverObject extends BaseObject {
     super(scope, testSubj, EuiPopoverSelectors.TOGGLE_SELECTOR);
   }
 
-  /** Opens the popover. A no-op if it is already open. */
+  /**
+   * Opens the popover and waits for the panel to be open. A no-op if it is
+   * already open.
+   */
   async open(): Promise<void> {
-    if ((await this.root.getAttribute('aria-expanded')) !== 'true') {
-      await this.root.click();
+    if ((await this.root.getAttribute('aria-expanded')) === 'true') {
+      return;
     }
+    await this.root.click();
+    const panel = await this.panel();
+    await panel.waitFor({ state: 'visible' });
+    await expect(panel).toHaveAttribute('data-popover-open', 'true');
   }
 
-  /** Closes the popover. A no-op if it is already closed. */
+  /**
+   * Closes the popover and waits for the panel to be removed. A no-op if it
+   * is already closed.
+   */
   async close(): Promise<void> {
-    if ((await this.root.getAttribute('aria-expanded')) === 'true') {
-      await this.root.click();
+    if ((await this.root.getAttribute('aria-expanded')) !== 'true') {
+      return;
     }
+    // `aria-controls` is removed on close, so resolve the panel first.
+    const panel = await this.panel();
+    await this.root.click();
+    await panel.waitFor({ state: 'detached' });
+  }
+
+  /**
+   * The panel the toggle's `aria-controls` points at. EUI sets that attribute
+   * synchronously with the open state, before the panel's own transition.
+   */
+  private async panel(): Promise<Locator> {
+    await expect(this.root).toHaveAttribute('aria-controls', /.+/);
+    const id = (await this.root.getAttribute('aria-controls')) as string;
+    return this.root.page().locator(EuiPopoverSelectors.panelFor(id));
   }
 }


### PR DESCRIPTION
## Summary

Adds `EuiPopoverObject`, a Playwright Component Object for [EuiPopover](https://eui.elastic.co/docs/components/containers/popover/), following the package's [CONTRIBUTING guide](https://github.com/elastic/eui/blob/main/packages/test-helpers/CONTRIBUTING.md).

No live Scout consumer exists yet, so this is Storybook-validated only, same as `EuiFilterButtonObject` (#9942) and `EuiRangeObject` (#9957).

## API

- `open()`: opens the popover, a no-op if already open.
- `close()`: closes the popover, a no-op if already closed.

Both decide whether to click from `aria-expanded`, which `EuiPopover` sets on the toggle synchronously with the open state. The panel lags that (`data-popover-open` lands a frame after opening, and the panel stays mounted for its 250ms closing transition), so both methods then wait for the panel, found through the toggle's `aria-controls`, to be open or removed before returning.

## Deliberately excluded from v1

- Reading open state as a dedicated method, assert directly on the inherited `locator` instead.
- The popover panel and its contents, not this component's concern. Scope another Component Object to the panel's own test-subj.

## Also in this PR

Updates the Popover `Playground` story to forward `data-test-subj` onto its trigger button. It previously only spread unrecognized props onto `EuiPopover`'s own outer wrapper, so there was no way to target a consumer-supplied test-subj on the toggle at all, needed to validate this object against Storybook.

## Testing

`tsc --noEmit` clean. 4 Playwright validation specs pass, 20/20 on a repeat-5 flake check. Also ran the full package suite (81 specs) against a from-scratch Vite-built Storybook (this repo has migrated builders since the last helper PRs), all green.