### PR TITLE
[test-helpers] Add EuiFlyoutObject

### DIFF
--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -54,6 +54,7 @@ their own version at runtime.
 | `EuiDraggableObject` | [src/components/drag_and_drop/README.md](src/components/drag_and_drop/README.md) |
 | `EuiFilterButtonObject` | [src/components/filter_button/README.md](src/components/filter_button/README.md) |
 | `EuiRangeObject` | [src/components/form/range/README.md](src/components/form/range/README.md) |
+| `EuiFlyoutObject` | [src/components/flyout/README.md](src/components/flyout/README.md) |
 | `EuiBasicTableObject` | [src/components/basic_table/README.md](src/components/basic_table/README.md) |
 
 ## Contributing

--- a/packages/test-helpers/changelogs/upcoming/9994.md
+++ b/packages/test-helpers/changelogs/upcoming/9994.md
@@ -1,0 +1,1 @@
+- Added `EuiFlyoutObject`, a Playwright Component Object for `EuiFlyout`

--- a/packages/test-helpers/src/components/flyout/README.md
+++ b/packages/test-helpers/src/components/flyout/README.md
@@ -1,0 +1,26 @@
+# EuiFlyoutObject
+
+Playwright Component Object for [EuiFlyout](https://eui.elastic.co/docs/components/containers/flyout/).
+
+## Usage
+
+```ts
+import { EuiFlyoutObject } from '@elastic/eui-test-helpers';
+
+const flyout = new EuiFlyoutObject(page, 'myFlyout');
+await flyout.closeButton.click();
+```
+
+Set `data-test-subj` on the `<EuiFlyout>` itself, which the component-type guard verifies.
+
+## API
+
+| Member | Description |
+|---|---|
+| `closeButton` | `Locator` for this flyout's own close button, scoped to this instance. Absent with `hideCloseButton` or a rendered flyout menu. |
+
+## Deliberately out of scope
+
+- **Multiple/nested flyouts on the page at once**: `closeButton` is already scoped to the instance you constructed, so this is naturally handled without extra API. Each flyout needs its own `data-test-subj`.
+- **A Kibana-specific close button convention** (e.g. a `closeFlyoutButton` test-subj some consumers add on their own footer button instead of using EUI's close button): that is app-owned, not this component's concern.
+- **The flyout menu** (`EuiFlyoutMenu`, including its own back button and pagination): a separate, newer subsystem with no evidenced consumer yet.

--- a/packages/test-helpers/src/components/flyout/selectors.ts
+++ b/packages/test-helpers/src/components/flyout/selectors.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/containers/flyout/|EuiFlyout}.
+ */
+export const EuiFlyoutSelectors = {
+  /** Root element carrying the consumer's `data-test-subj`. CSS. */
+  ROOT_SELECTOR: '.euiFlyout',
+
+  /** `data-test-subj` EUI sets on its own close button. Absent with `hideCloseButton` or a rendered flyout menu. */
+  CLOSE_BUTTON_TEST_SUBJ: 'euiFlyoutCloseButton',
+};

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -15,4 +15,5 @@ export { EuiSelectableObject } from './playwright/components/selectable/object';
 export { EuiDraggableObject } from './playwright/components/drag_and_drop/object';
 export { EuiFilterButtonObject } from './playwright/components/filter_button/object';
 export { EuiRangeObject } from './playwright/components/form/range/object';
+export { EuiFlyoutObject } from './playwright/components/flyout/object';
 export { EuiBasicTableObject } from './playwright/components/basic_table/object';

--- a/packages/test-helpers/src/playwright/components/flyout/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/flyout/object.spec.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiFlyoutObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+const TEST_SUBJ = 'testFlyout';
+
+const PLAYGROUND_URL = storyUrl('layout-euiflyout-euiflyout--playground', `data-test-subj:${TEST_SUBJ}`);
+
+test.describe('EuiFlyoutObject', () => {
+  let flyout: EuiFlyoutObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    flyout = new EuiFlyoutObject(page, TEST_SUBJ);
+  });
+
+  test.describe('closeButton', () => {
+    test('resolves to exactly one element', async () => {
+      await expect(flyout.closeButton).toHaveCount(1);
+    });
+
+    test('closing the flyout removes it', async () => {
+      await flyout.closeButton.click();
+
+      await expect(flyout.locator).toHaveCount(0);
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/flyout/object.ts
+++ b/packages/test-helpers/src/playwright/components/flyout/object.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiFlyoutSelectors } from '../../../components/flyout/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/containers/flyout/ EuiFlyout}.
+ *
+ * `testSubj` must be set on the `<EuiFlyout>` itself. See the package README
+ * for what this does not cover.
+ */
+export class EuiFlyoutObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiFlyoutSelectors.ROOT_SELECTOR);
+  }
+
+  /**
+   * This flyout's own close button, scoped to this instance. Absent with
+   * `hideCloseButton` or a rendered flyout menu.
+   */
+  public get closeButton(): Locator {
+    return this.root.getByTestId(EuiFlyoutSelectors.CLOSE_BUTTON_TEST_SUBJ);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `EuiFlyoutObject`, a Playwright Component Object for [EuiFlyout](https://eui.elastic.co/docs/components/containers/flyout/), following the package's [CONTRIBUTING guide](https://github.com/elastic/eui/blob/main/packages/test-helpers/CONTRIBUTING.md).

No live Scout consumer exists yet, so this is Storybook-validated only, same as the other recent helpers.

## Evidence, and why the scope is small

Kibana's FTR FlyoutService is used by 16 files. It closes a flyout by finding a button whose aria-label contains Close inside the flyout's own test-subj, with retries. That is legacy WebDriver-era fragility, not a real ongoing gap: EUI's close button already carries a stable, first-class `data-test-subj` (`euiFlyoutCloseButton`), so scoping to it needs no label matching, no retry, and no fallback. I did not carry the FTR service's other behavior over: its `ensureAllClosed` page-wide cleanup and its `closeFlyoutButton` fallback for a Kibana-specific footer-button convention are both app-owned or app-test-infrastructure concerns, not EUI's, so a real Kibana consumer should keep handling those itself, with a smaller surface to reimplement now that the close button itself doesn't need custom lookup logic.

## API

- `closeButton`: a `Locator` for this flyout's own close button, scoped to the instance. Absent with `hideCloseButton` or a rendered flyout menu.

## Deliberately excluded from v1

- Multiple/nested flyouts: already handled naturally, since `closeButton` is scoped to whichever instance you constructed.
- The newer flyout menu/session-management subsystem (`EuiFlyoutMenu`, main/child flyouts): no evidenced consumer yet.

## Testing

`tsc --noEmit` clean. 2 Playwright validation specs pass against Storybook (`Layout/EuiFlyout/EuiFlyout`, Playground story), 16/16 on a repeat-8 flake check. Also ran the full package suite (79 specs), all green.