### PR TITLE
[test-helpers] Fix EuiComboBoxObject clear() on singleSelection combo boxes

### DIFF
--- a/packages/test-helpers/changelogs/upcoming/9998.md
+++ b/packages/test-helpers/changelogs/upcoming/9998.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed `EuiComboBoxObject.clear()` and `setSelectedOptions()` timing out on `singleSelection` combo boxes, whose pills have no close button

--- a/packages/test-helpers/src/playwright/components/combo_box/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.props.spec.ts
@@ -45,7 +45,7 @@ test.describe('EuiComboBoxObject — singleSelection=true', () => {
   let comboBox: EuiComboBoxObject;
 
   test.beforeEach(async ({ page }) => {
-    await page.goto(playgroundUrl('singleSelection:true'));
+    await page.goto(playgroundUrl('singleSelection:!true'));
     await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
     comboBox = new EuiComboBoxObject(page, TEST_SUBJ);
     await comboBox.clear();
@@ -69,6 +69,15 @@ test.describe('EuiComboBoxObject — singleSelection=true', () => {
     await comboBox.clear();
 
     expect(await comboBox.getSelectedOptions()).toEqual([]);
+  });
+
+  // Also catches the story silently falling back to multi-select, whose pills do have one.
+  test('the pill has no close button', async () => {
+    await comboBox.setSelectedOptions(['Item 2']);
+
+    await expect(
+      comboBox.locator.locator(EuiComboBoxSelectors.PILL_SELECTOR).locator('button')
+    ).toHaveCount(0);
   });
 });
 

--- a/packages/test-helpers/src/playwright/components/combo_box/object.ts
+++ b/packages/test-helpers/src/playwright/components/combo_box/object.ts
@@ -128,7 +128,8 @@ export class EuiComboBoxObject extends BaseObject {
    * Clear all selected options. No-op if nothing is selected.
    *
    * Auto-detects the combo box configuration and uses the appropriate strategy:
-   * - Pills present → {@link clickPillClearButtons}
+   * - Pills with a close button → {@link clickPillClearButtons}
+   * - Pills without a close button (`singleSelection`) → {@link clearPillWithoutCloseButton}
    * - `asPlainText` with a confirmed input selection → {@link deleteSearchInput}
    * - Otherwise → {@link deselectAllFromDropdown}
    *
@@ -142,7 +143,11 @@ export class EuiComboBoxObject extends BaseObject {
     }
 
     if (await this.hasPills()) {
-      await this.clickPillClearButtons();
+      if (await this.hasPillCloseButtons()) {
+        await this.clickPillClearButtons();
+      } else {
+        await this.clearPillWithoutCloseButton();
+      }
       return;
     }
 
@@ -176,15 +181,31 @@ export class EuiComboBoxObject extends BaseObject {
     return (await this.pills.count()) > 0;
   }
 
+  private async hasPillCloseButtons(): Promise<boolean> {
+    return (await this.pills.first().locator('button').count()) > 0;
+  }
+
   /**
    * Clicks the `×` button on each selected pill individually.
-   * Works regardless of `isClearable` — pill close buttons are always present.
    * No-op if no pills are rendered.
    */
   private async clickPillClearButtons(): Promise<void> {
     while (await this.hasPills()) {
       const countBefore = await this.pills.count();
       await this.pills.first().locator('button').click();
+      await expect(this.pills).not.toHaveCount(countBefore);
+    }
+  }
+
+  /**
+   * `singleSelection` pills render without a close button, whatever
+   * `isClearable` is. Backspace on an empty search input removes the
+   * selection instead.
+   */
+  private async clearPillWithoutCloseButton(): Promise<void> {
+    while (await this.hasPills()) {
+      const countBefore = await this.pills.count();
+      await this.searchInput.press('Backspace');
       await expect(this.pills).not.toHaveCount(countBefore);
     }
   }

--- a/packages/test-helpers/src/storybook.ts
+++ b/packages/test-helpers/src/storybook.ts
@@ -10,7 +10,7 @@
  * Returns the Storybook iframe URL for a given story ID and optional args.
  *
  * @param id - The Storybook story ID (e.g. `'forms-euicombobox--playground'`)
- * @param args - Optional semicolon-separated Storybook args string (e.g. `'data-test-subj:myCombo;singleSelection:true'`)
+ * @param args - Optional semicolon-separated Storybook args string (e.g. `'data-test-subj:myCombo;singleSelection:!true'`)
  */
 export const storyUrl = (id: string, args?: string): string =>
   `/iframe.html?id=${id}&viewMode=story${args ? `&args=${args}` : ''}`;


### PR DESCRIPTION
## Summary

`EuiComboBoxObject.clear()` (and `setSelectedOptions()`, which calls it) hangs and times out on a `singleSelection` combo box.

EUI never renders a close button on a pill when `singleSelection` is set, regardless of `isClearable`. `clear()` assumed every pill has one and clicked it, so it waited on a locator that never resolves.

## Fix

`clear()` now checks whether the pill actually has a close button. If not (`singleSelection`), it clears via Backspace on the empty search input instead of clicking a button that doesn't exist.

Also fixed the `singleSelection=true` spec: it was passing `singleSelection:true` in the Storybook URL args, which Storybook silently drops (booleans need the `!true`/`!false` encoding), so the block was actually exercising multi-select. Fixed the encoding and added a test asserting the pill has no close button.

## Testing

- Reverted only the `clear()` fix and reran the (now-correctly-encoded) `singleSelection=true` spec: all 4 tests fail with a 10s timeout on the missing button, confirming the bug.
- Restored the fix: all `combo_box` specs (35) pass.
- Full `@elastic/eui-test-helpers` Playwright suite (84 tests) passes.
- `yarn lint` (tsc --noEmit) is clean.