### PR TITLE
[EuiToolTip] fix dismissal for mouse-out in aria-disabled anchors

### DIFF
--- a/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
+++ b/packages/eui/src/components/tool_tip/tool_tip.spec.tsx
@@ -57,24 +57,28 @@ describe('EuiToolTip', () => {
   });
 
   it('shows the tooltip on hover and hides it on mouseout for a custom disabled trigger button', () => {
-    cy.mount(
-      <EuiToolTip
-        content="Tooltip text here"
-        data-test-subj="tooltip"
-        anchorProps={{ 'data-test-subj': 'tooltipAnchor' }}
-      >
-        <EuiButton data-test-subj="toggleToolTip" hasAriaDisabled isDisabled>
-          Show tooltip
-        </EuiButton>
-      </EuiToolTip>
+    cy.realMount(
+      <>
+        <EuiToolTip
+          content="Tooltip text here"
+          data-test-subj="tooltip"
+          anchorProps={{ 'data-test-subj': 'tooltipAnchor' }}
+        >
+          <EuiButton data-test-subj="toggleToolTip" hasAriaDisabled isDisabled>
+            Show tooltip
+          </EuiButton>
+        </EuiToolTip>
+        <EuiButton>After</EuiButton>
+      </>
     );
     cy.get('[data-test-subj="tooltip"]').should('not.exist');
 
-    // using the anchor wrapper as the mouse events are added there and the disabled button does't support them
-    cy.get('[data-test-subj="tooltipAnchor"]').trigger('mouseover');
+    // realHover moves the pointer onto the child element itself, which exercises
+    // the pointer-events fix for aria-disabled anchors
+    cy.get('[data-test-subj="toggleToolTip"]').realHover();
     cy.get('[data-test-subj="tooltip"]').should('exist');
 
-    cy.get('[data-test-subj="tooltipAnchor"]').trigger('mouseout');
+    cy.get('body').realHover({ position: 'bottomLeft' });
     cy.get('[data-test-subj="tooltip"]').should('not.exist');
   });
 

--- a/packages/eui/src/components/tool_tip/tool_tip.styles.ts
+++ b/packages/eui/src/components/tool_tip/tool_tip.styles.ts
@@ -91,7 +91,8 @@ export const euiToolTipAnchorStyles = () => ({
        wouldn't trigger the onMouseOut and hide the tooltip. Disabling pointer events
        on disabled elements means any mouse events remain handled by parent elements
        https://jakearchibald.com/2017/events-and-disabled-form-fields/ */
-    *[disabled] {
+    *[disabled],
+    *[aria-disabled='true'] {
       pointer-events: none;
     }
   `,


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

Fixes https://github.com/elastic/eui/issues/9997 

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

### API Changes

<!--
List any change to the public EUI API here.

Example:

| component / parent   | prop / child                 | change     | description                                                             |
| -------------------- | ---------------------------- | ---------- | ----------------------------------------------------------------------- |
| EuiOverlayMask       | hasAnimation                 | Added      | Conditionally add animation                                             |
| EuiBadge             | fill                         | Default    | Default is now "false" -- Makes all badges have a light fill by default |
| Tokens               | colors.severity.someOldColor | Deprecated | Use `colors.severity.someOtherColor` instead                            |
| Global CSS Variables | --my-variable                | Added      | Some reason listed here                                                 |

-->

| component / parent | prop / child | change | description |
| ------------------ | ------------ | ------ | ----------- |
|                    |              |        |             |

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| {Before image} | {After image} |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

<!--
If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL under `@next` in `packages/release-cli/kibana-prep-commits` (one URL per line). Nightly cherry-picks `@next` and `@previous`. On release, `@next` moves to `@previous` and `@previous` is cleared. Missing or already-applied commits are skipped.
-->

**Impact level:** 🟢 None / 🟢 Low / 🟡 Moderate / 🔴 High

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
