### PR TITLE
[test-helpers] Add EuiModalObject

### DIFF
--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -56,6 +56,7 @@ their own version at runtime.
 | `EuiRangeObject` | [src/components/form/range/README.md](src/components/form/range/README.md) |
 | `EuiPopoverObject` | [src/components/popover/README.md](src/components/popover/README.md) |
 | `EuiFlyoutObject` | [src/components/flyout/README.md](src/components/flyout/README.md) |
+| `EuiModalObject` | [src/components/modal/README.md](src/components/modal/README.md) |
 | `EuiBasicTableObject` | [src/components/basic_table/README.md](src/components/basic_table/README.md) |
 
 ## Contributing

--- a/packages/test-helpers/changelogs/upcoming/10002.md
+++ b/packages/test-helpers/changelogs/upcoming/10002.md
@@ -1,0 +1,1 @@
+- Added `EuiModalObject`, a Playwright Component Object for `EuiModal`/`EuiConfirmModal`

--- a/packages/test-helpers/src/components/modal/README.md
+++ b/packages/test-helpers/src/components/modal/README.md
@@ -24,4 +24,4 @@ Set `data-test-subj` on the `<EuiModal>`/`<EuiConfirmModal>` itself, which the c
 ## Deliberately out of scope
 
 - **`EuiConfirmModal`'s cancel/confirm buttons**: already carry their own stable `data-test-subj`s (`confirmModalCancelButton`, `confirmModalConfirmButton`), no ambiguity to solve.
-- **Open/close animation**: unlike `EuiPopover`, `EuiModal` has no internal open/close state or transition to wait for. It is a plain conditionally-mounted component.
+- **Waiting for open/close**: unlike `EuiPopover`, `EuiModal` has no closing state or transition. It is conditionally mounted by the consumer and unmounts immediately on close. Its entrance slide-in is covered by Playwright's actionability wait when clicking `closeButton`.

--- a/packages/test-helpers/src/components/modal/README.md
+++ b/packages/test-helpers/src/components/modal/README.md
@@ -1,0 +1,27 @@
+# EuiModalObject
+
+Playwright Component Object for [EuiModal](https://eui.elastic.co/docs/components/containers/modal/) and `EuiConfirmModal`, which renders `EuiModal` underneath.
+
+## Usage
+
+```ts
+import { EuiModalObject } from '@elastic/eui-test-helpers';
+
+const modal = new EuiModalObject(page, 'myModal');
+await modal.closeButton.click();
+```
+
+Set `data-test-subj` on the `<EuiModal>`/`<EuiConfirmModal>` itself, which the component-type guard verifies.
+
+## API
+
+| Member | Description |
+|---|---|
+| `closeButton` | `Locator` for this modal's own close button, scoped to this instance. |
+
+`closeButton` is read by its stable `euiModal__closeIcon` class rather than a `data-test-subj`, since EUI does not set one on that button, only an i18n `aria-label`.
+
+## Deliberately out of scope
+
+- **`EuiConfirmModal`'s cancel/confirm buttons**: already carry their own stable `data-test-subj`s (`confirmModalCancelButton`, `confirmModalConfirmButton`), no ambiguity to solve.
+- **Open/close animation**: unlike `EuiPopover`, `EuiModal` has no internal open/close state or transition to wait for. It is a plain conditionally-mounted component.

--- a/packages/test-helpers/src/components/modal/selectors.ts
+++ b/packages/test-helpers/src/components/modal/selectors.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/containers/modal/|EuiModal}
+ * and `EuiConfirmModal`. `*_SELECTOR` values are CSS.
+ */
+export const EuiModalSelectors = {
+  /** Root element carrying the consumer's `data-test-subj`. Matches `EuiConfirmModal` too, which renders `EuiModal` underneath. */
+  ROOT_SELECTOR: '.euiModal',
+
+  /** The close button. No `data-test-subj`, only an i18n `aria-label`, so read by this stable class instead. */
+  CLOSE_BUTTON_SELECTOR: '.euiModal__closeIcon',
+};

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -17,4 +17,5 @@ export { EuiFilterButtonObject } from './playwright/components/filter_button/obj
 export { EuiRangeObject } from './playwright/components/form/range/object';
 export { EuiPopoverObject } from './playwright/components/popover/object';
 export { EuiFlyoutObject } from './playwright/components/flyout/object';
+export { EuiModalObject } from './playwright/components/modal/object';
 export { EuiBasicTableObject } from './playwright/components/basic_table/object';

--- a/packages/test-helpers/src/playwright/components/modal/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/modal/object.props.spec.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiModalObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+const TEST_SUBJ = 'testConfirmModal';
+
+test.describe('EuiModalObject', () => {
+  test.describe('against EuiConfirmModal', () => {
+    // EuiConfirmModal renders EuiModal underneath, but is validated against
+    // its own story rather than assumed from EuiModal's.
+    const CONFIRM_MODAL_URL = storyUrl(
+      'layout-euiconfirmmodal--playground',
+      `data-test-subj:${TEST_SUBJ}`
+    );
+
+    test('closeButton resolves to exactly one element', async ({ page }) => {
+      await page.goto(CONFIRM_MODAL_URL);
+      await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+      const modal = new EuiModalObject(page, TEST_SUBJ);
+
+      await expect(modal.closeButton).toHaveCount(1);
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/modal/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/modal/object.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiModalObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+/**
+ * Validates `EuiModalObject` against the live component in EUI Storybook.
+ * The Playground story's own onClose is just a logged action, not real
+ * state, so this uses ToggleExample instead, which actually unmounts on
+ * close.
+ */
+
+const TEST_SUBJ = 'testModal';
+
+const TOGGLE_EXAMPLE_URL = storyUrl(
+  'layout-euimodal-euimodal--toggle-example',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiModalObject', () => {
+  let modal: EuiModalObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(TOGGLE_EXAMPLE_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    modal = new EuiModalObject(page, TEST_SUBJ);
+  });
+
+  test.describe('closeButton', () => {
+    test('resolves to exactly one element', async () => {
+      await expect(modal.closeButton).toHaveCount(1);
+    });
+
+    test('closing the modal removes it', async () => {
+      await modal.closeButton.click();
+
+      await expect(modal.locator).toHaveCount(0);
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/modal/object.ts
+++ b/packages/test-helpers/src/playwright/components/modal/object.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiModalSelectors } from '../../../components/modal/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/containers/modal/ EuiModal} and
+ * `EuiConfirmModal`, which renders `EuiModal` underneath.
+ *
+ * `testSubj` must be set on the `<EuiModal>`/`<EuiConfirmModal>` itself. See
+ * the package README for what this does not cover.
+ */
+export class EuiModalObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiModalSelectors.ROOT_SELECTOR);
+  }
+
+  /** This modal's own close button, scoped to this instance. */
+  public get closeButton(): Locator {
+    return this.root.locator(EuiModalSelectors.CLOSE_BUTTON_SELECTOR);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `EuiModalObject`, a Playwright Component Object for [EuiModal](https://eui.elastic.co/docs/components/containers/modal/) and `EuiConfirmModal`, following the package's [CONTRIBUTING guide](https://github.com/elastic/eui/blob/main/packages/test-helpers/CONTRIBUTING.md).

No live Scout consumer exists yet, so this is Storybook-validated only, same as the other recent helpers.

## Evidence

3 Kibana FTR files independently copy-paste the same CSS selector (`.euiButtonIcon.euiModal__closeIcon`) to reach the modal close button, since EUI sets no `data-test-subj` on it, only an i18n `aria-label`. Rather than adding one, this object reads it by that already-stable class, per the package's own principle of preferring a stable class over an overridable test-subj.

`EuiConfirmModal` renders `EuiModal` underneath (the same relationship as `EuiInMemoryTable`/`EuiBasicTable`), so one object covers both. Validated against `EuiConfirmModal`'s own story rather than assumed from `EuiModal`'s.

Unlike `EuiPopover`, `EuiModal` has no closing state or transition. It is conditionally mounted by the consumer and unmounts immediately on close, so asserting it is gone right after the click is safe. Its entrance slide-in is covered by Playwright's actionability wait when clicking `closeButton`.

## API

- `closeButton`: a `Locator` for this modal's own close button, scoped to the instance.

## Deliberately excluded from v1

- `EuiConfirmModal`'s cancel/confirm buttons: already carry their own stable test-subjs, no ambiguity to solve.

## Testing

`tsc --noEmit` clean. 3 Playwright validation specs pass (`Layout/EuiModal/EuiModal`, ToggleExample story, which actually mounts/unmounts unlike Playground's logged-only `onClose`) plus 1 against `EuiConfirmModal`'s own Playground story, 18/18 on a repeat-6 flake check. Also ran the full package suite (87 specs), all green.