### PR TITLE
[Chore] Update the header logo prep commit

### DIFF
--- a/packages/release-cli/kibana-prep-commits
+++ b/packages/release-cli/kibana-prep-commits
@@ -8,7 +8,7 @@
 # @next
 https://github.com/elastic/kibana/pull/287310/commits/2abc1ab916e13cee4972b0bed08344c80456002a
 https://github.com/elastic/kibana/pull/287310/commits/e7d41fe9d83bf889bb68eeb61eca4cab4ad0bd42
-https://github.com/elastic/kibana/pull/288418/changes/d47d6b5c9faf2e718850915d563638c7a933d6a8
+https://github.com/elastic/kibana/pull/288418/commits/8d4de5546332856a17cdb42154527b7f9e93f812
 https://github.com/elastic/kibana/pull/235177/commits/fe98fc4dea683a966f7c723432c28221e2ac8b3c
 https://github.com/elastic/kibana/pull/287310/commits/9cd54800d190fba79a50c2d52be514d1cf217c9a
 https://github.com/elastic/kibana/pull/287310/commits/11a47ae5c05b71b02635c3cb7e924c49d006620d


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

Point `kibana-prep-commits` at the Kibana `EuiHeaderLogo` [prep commit](https://github.com/elastic/kibana/pull/288418/changes/8d4de5546332856a17cdb42154527b7f9e93f812) that now includes the header snapshot fix reported on the [Nightly build](https://buildkite.com/elastic/kibana-pull-request/builds/497426).