### PR TITLE
[test-helpers] Add EuiContextMenuObject

### DIFF
--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -57,6 +57,7 @@ their own version at runtime.
 | `EuiPopoverObject` | [src/components/popover/README.md](src/components/popover/README.md) |
 | `EuiFlyoutObject` | [src/components/flyout/README.md](src/components/flyout/README.md) |
 | `EuiAccordionObject` | [src/components/accordion/README.md](src/components/accordion/README.md) |
+| `EuiContextMenuObject` | [src/components/context_menu/README.md](src/components/context_menu/README.md) |
 | `EuiModalObject` | [src/components/modal/README.md](src/components/modal/README.md) |
 | `EuiBasicTableObject` | [src/components/basic_table/README.md](src/components/basic_table/README.md) |
 

--- a/packages/test-helpers/changelogs/upcoming/10013.md
+++ b/packages/test-helpers/changelogs/upcoming/10013.md
@@ -1,0 +1,1 @@
+- Added `EuiContextMenuObject`, a Playwright Component Object for `EuiContextMenu`

--- a/packages/test-helpers/src/components/context_menu/README.md
+++ b/packages/test-helpers/src/components/context_menu/README.md
@@ -1,0 +1,26 @@
+# EuiContextMenuObject
+
+Playwright Component Object for [EuiContextMenu](https://eui.elastic.co/docs/components/navigation/context-menu/).
+
+## Usage
+
+```ts
+import { EuiContextMenuObject } from '@elastic/eui-test-helpers';
+
+const contextMenu = new EuiContextMenuObject(page, 'myContextMenu');
+await contextMenu.items.filter({ hasText: 'Delete' }).click();
+```
+
+Set `data-test-subj` on the `<EuiContextMenu>` itself, which the component-type guard verifies.
+
+## API
+
+| Member | Description |
+|---|---|
+| `items` | `Locator` for the items in the current panel. |
+
+`items` resolves to the last `.euiContextMenuPanel` in the DOM. During a panel transition (navigating to a nested panel or back) the outgoing panel can briefly still be in the DOM alongside the incoming one, and the incoming one always renders after it, so this avoids matching stale items from a panel that is on its way out.
+
+## Deliberately out of scope
+
+- **Clicking an item by label**: every real consumer already gives its own items a stable `data-test-subj`, so click those directly. `items` is for the cases where filtering by content is genuinely needed, e.g. `items.filter({ hasText: label })`.

--- a/packages/test-helpers/src/components/context_menu/README.md
+++ b/packages/test-helpers/src/components/context_menu/README.md
@@ -1,6 +1,6 @@
 # EuiContextMenuObject
 
-Playwright Component Object for [EuiContextMenu](https://eui.elastic.co/docs/components/navigation/context-menu/).
+Playwright Component Object for [EuiContextMenu](https://eui.elastic.co/docs/components/navigation/context-menu/), or a standalone `EuiContextMenuPanel`, the more common Kibana pattern (a single panel inside a popover, no multi panel wrapper).
 
 ## Usage
 
@@ -11,7 +11,7 @@ const contextMenu = new EuiContextMenuObject(page, 'myContextMenu');
 await contextMenu.items.filter({ hasText: 'Delete' }).click();
 ```
 
-Set `data-test-subj` on the `<EuiContextMenu>` itself, which the component-type guard verifies.
+Set `data-test-subj` on the `<EuiContextMenu>` or the `<EuiContextMenuPanel>` itself, which the component-type guard verifies.
 
 ## API
 
@@ -19,7 +19,7 @@ Set `data-test-subj` on the `<EuiContextMenu>` itself, which the component-type 
 |---|---|
 | `items` | `Locator` for the items in the current panel. |
 
-`items` resolves to the last `.euiContextMenuPanel` in the DOM. During a panel transition (navigating to a nested panel or back) the outgoing panel can briefly still be in the DOM alongside the incoming one, and the incoming one always renders after it, so this avoids matching stale items from a panel that is on its way out.
+When the root is a standalone panel, `items` is that panel's items. When it is an `EuiContextMenu`, `items` resolves to the last `.euiContextMenuPanel` in the DOM. During a panel transition (navigating to a nested panel or back) the outgoing panel can briefly still be in the DOM alongside the incoming one, and the incoming one always renders after it, so this avoids matching stale items from a panel that is on its way out.
 
 ## Deliberately out of scope
 

--- a/packages/test-helpers/src/components/context_menu/selectors.ts
+++ b/packages/test-helpers/src/components/context_menu/selectors.ts
@@ -12,8 +12,12 @@
  * `*_SELECTOR` values are CSS.
  */
 export const EuiContextMenuSelectors = {
-  /** Root element carrying the consumer's `data-test-subj`. */
-  ROOT_SELECTOR: '.euiContextMenu',
+  /**
+   * Root element carrying the consumer's `data-test-subj`: either a multi
+   * panel `EuiContextMenu`, or a single `EuiContextMenuPanel` used on its
+   * own, which is the more common Kibana pattern.
+   */
+  ROOT_SELECTOR: '.euiContextMenu, .euiContextMenuPanel',
 
   /**
    * Each panel. Two can exist at once during a panel transition (the

--- a/packages/test-helpers/src/components/context_menu/selectors.ts
+++ b/packages/test-helpers/src/components/context_menu/selectors.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/navigation/context-menu/|EuiContextMenu}.
+ * `*_SELECTOR` values are CSS.
+ */
+export const EuiContextMenuSelectors = {
+  /** Root element carrying the consumer's `data-test-subj`. */
+  ROOT_SELECTOR: '.euiContextMenu',
+
+  /**
+   * Each panel. Two can exist at once during a panel transition (the
+   * outgoing one still animating out, plus the incoming one). Both are
+   * rendered outgoing-first in markup, so the last match is always the
+   * current panel.
+   */
+  PANEL_SELECTOR: '.euiContextMenuPanel',
+
+  /** An item inside a panel. */
+  ITEM_SELECTOR: '.euiContextMenuItem',
+};

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -18,5 +18,6 @@ export { EuiRangeObject } from './playwright/components/form/range/object';
 export { EuiPopoverObject } from './playwright/components/popover/object';
 export { EuiFlyoutObject } from './playwright/components/flyout/object';
 export { EuiAccordionObject } from './playwright/components/accordion/object';
+export { EuiContextMenuObject } from './playwright/components/context_menu/object';
 export { EuiModalObject } from './playwright/components/modal/object';
 export { EuiBasicTableObject } from './playwright/components/basic_table/object';

--- a/packages/test-helpers/src/playwright/components/context_menu/object.props.spec.ts
+++ b/packages/test-helpers/src/playwright/components/context_menu/object.props.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiContextMenuObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+const TEST_SUBJ = 'testContextMenuPanel';
+
+test.describe('EuiContextMenuObject', () => {
+  test.describe('standalone EuiContextMenuPanel', () => {
+    // A single panel used without the EuiContextMenu wrapper, validated
+    // against its own story rather than assumed from EuiContextMenu's.
+    const PANEL_URL = storyUrl(
+      'navigation-euicontextmenu-euicontextmenupanel--playground',
+      `data-test-subj:${TEST_SUBJ}`
+    );
+
+    test('items resolves to the panel\'s items', async ({ page }) => {
+      await page.goto(PANEL_URL);
+      await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+      const contextMenu = new EuiContextMenuObject(page, TEST_SUBJ);
+
+      const expected = await page.locator('.euiContextMenuItem').count();
+      expect(expected).toBeGreaterThan(0);
+      await expect(contextMenu.items).toHaveCount(expected);
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/context_menu/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/context_menu/object.spec.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiContextMenuObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+const TEST_SUBJ = 'testContextMenu';
+
+const PLAYGROUND_URL = storyUrl('navigation-euicontextmenu-euicontextmenu--playground', `data-test-subj:${TEST_SUBJ}`);
+
+test.describe('EuiContextMenuObject', () => {
+  let contextMenu: EuiContextMenuObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    contextMenu = new EuiContextMenuObject(page, TEST_SUBJ);
+  });
+
+  test.describe('items', () => {
+    test('resolves to the current panel\'s items', async () => {
+      await expect(contextMenu.items.filter({ hasText: 'Handle an onClick' })).toHaveCount(1);
+    });
+
+    test('resolves to only the new panel\'s items after navigating, not both during the transition', async () => {
+      await contextMenu.items.filter({ hasText: 'Nest panels' }).click();
+
+      await expect(contextMenu.items.filter({ hasText: 'PDF reports' })).toHaveCount(1);
+      await expect(contextMenu.items.filter({ hasText: 'Handle an onClick' })).toHaveCount(0);
+    });
+  });
+});

--- a/packages/test-helpers/src/playwright/components/context_menu/object.ts
+++ b/packages/test-helpers/src/playwright/components/context_menu/object.ts
@@ -13,10 +13,11 @@ import { EuiContextMenuSelectors } from '../../../components/context_menu/select
 
 /**
  * Playwright Component Object for {@link
- * https://eui.elastic.co/docs/components/navigation/context-menu/ EuiContextMenu}.
+ * https://eui.elastic.co/docs/components/navigation/context-menu/ EuiContextMenu},
+ * or a standalone `EuiContextMenuPanel`.
  *
- * `testSubj` must be set on the `<EuiContextMenu>` itself. See the package
- * README for what this does not cover.
+ * `testSubj` must be set on the `<EuiContextMenu>` or `<EuiContextMenuPanel>`
+ * itself. See the package README for what this does not cover.
  */
 export class EuiContextMenuObject extends BaseObject {
   constructor(scope: ObjectScope, testSubj: string) {
@@ -24,14 +25,16 @@ export class EuiContextMenuObject extends BaseObject {
   }
 
   /**
-   * The items in the current panel, as a `Locator`. During a panel
-   * transition two panels briefly exist at once, so this always resolves
-   * to the last one in the DOM, which is the current one.
+   * The items in the current panel, as a `Locator`. Resolves to the root
+   * itself when that is a standalone panel, otherwise to the last panel in
+   * the DOM, which is the current one when two exist during a transition.
    */
   public get items(): Locator {
+    const panel = this.scope.locator(EuiContextMenuSelectors.PANEL_SELECTOR);
     return this.root
       .locator(EuiContextMenuSelectors.PANEL_SELECTOR)
       .last()
+      .or(this.root.and(panel))
       .locator(EuiContextMenuSelectors.ITEM_SELECTOR);
   }
 }

--- a/packages/test-helpers/src/playwright/components/context_menu/object.ts
+++ b/packages/test-helpers/src/playwright/components/context_menu/object.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiContextMenuSelectors } from '../../../components/context_menu/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/navigation/context-menu/ EuiContextMenu}.
+ *
+ * `testSubj` must be set on the `<EuiContextMenu>` itself. See the package
+ * README for what this does not cover.
+ */
+export class EuiContextMenuObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiContextMenuSelectors.ROOT_SELECTOR);
+  }
+
+  /**
+   * The items in the current panel, as a `Locator`. During a panel
+   * transition two panels briefly exist at once, so this always resolves
+   * to the last one in the DOM, which is the current one.
+   */
+  public get items(): Locator {
+    return this.root
+      .locator(EuiContextMenuSelectors.PANEL_SELECTOR)
+      .last()
+      .locator(EuiContextMenuSelectors.ITEM_SELECTOR);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `EuiContextMenuObject`, a Playwright Component Object for [EuiContextMenu](https://eui.elastic.co/docs/components/navigation/context-menu/) and for a standalone `EuiContextMenuPanel`, following the package's [CONTRIBUTING guide](https://github.com/elastic/eui/blob/main/packages/test-helpers/CONTRIBUTING.md).

No live Scout consumer exists yet, so this is Storybook-validated only, same as the other recent helpers.

## Context

Both prior audits (Scout and FTR) found consumers already click items by their own stable test-subj, never by label, so there is no genuine label-lookup gap to fix. This is scoped as a minimal getter-only wrapper as part of moving toward broader EUI component coverage over time, per team direction, rather than a response to a specific audit finding.

## API

- `items`: a `Locator` for the items in the current panel.

The root can be either an `EuiContextMenu` or a standalone `EuiContextMenuPanel`. In Kibana the standalone panel inside a popover is the more common pattern (207 files vs 157 for the wrapper), so the object accepts both, validated against each component's own story.

## A design choice worth flagging

`EuiContextMenu` can render two panels at once during a panel transition (an outgoing one still animating out, plus the incoming one), both matching `.euiContextMenuPanel`. `items` resolves to the last panel in the DOM rather than a plain descendant search off the root, since the outgoing panel always renders first. I could not actually reproduce a stale-item collision in testing (the transition resolves fast enough here that a naive descendant search also passed 20/20), so this is a defensive scoping choice, not a proven bug fix, flagging it as such rather than overstating it.

## Deliberately excluded from v1

- Clicking an item by label: no evidenced need, see Context above.

## Testing

`tsc --noEmit` clean. 2 Playwright validation specs pass against Storybook (`Navigation/EuiContextMenu/EuiContextMenu`, Playground story, which has a real nested-panel item), 10/10 on a repeat-5 flake check. Also ran the full package suite (93 specs), all green.