### PR TITLE
[test-helpers] Match root by data-test-subj token, not whole value

### DIFF
--- a/packages/test-helpers/changelogs/upcoming/10015.md
+++ b/packages/test-helpers/changelogs/upcoming/10015.md
@@ -1,0 +1,3 @@
+**Bug fixes**
+
+- Fixed Component Objects not finding components whose `data-test-subj` holds several space-separated tokens, such as `EuiColorPicker`. The root now matches one token, following Kibana's `data-test-subj` convention

--- a/packages/test-helpers/src/playwright/base_object.spec.ts
+++ b/packages/test-helpers/src/playwright/base_object.spec.ts
@@ -72,3 +72,31 @@ test.describe('BaseObject component-type guard', () => {
     expect(object.syncMethod()).toBe('sync');
   });
 });
+
+test.describe('BaseObject root matching', () => {
+  test('matches a testSubj that is one of several space-separated tokens', async ({
+    page,
+  }) => {
+    // EuiColorPicker renders its anchor as `data-test-subj="euiColorPickerAnchor
+    // <consumerSubj>"`, so an exact match on the consumer's subj alone misses it.
+    await page.setContent(
+      '<div class="euiComboBox" data-test-subj="euiColorPickerAnchor target"></div>'
+    );
+
+    const object = new TestObject(page, 'target', '.euiComboBox');
+
+    await expect(object.locator).toHaveCount(1);
+  });
+
+  test('does not match a testSubj that is only a substring of a token', async ({
+    page,
+  }) => {
+    await page.setContent(
+      '<div class="euiComboBox" data-test-subj="targetExtra"></div>'
+    );
+
+    const object = new TestObject(page, 'target', '.euiComboBox');
+
+    await expect(object.locator).toHaveCount(0);
+  });
+});

--- a/packages/test-helpers/src/playwright/base_object.ts
+++ b/packages/test-helpers/src/playwright/base_object.ts
@@ -11,10 +11,21 @@ import type { Locator, Page } from '@playwright/test';
 export type ObjectScope = Page | Locator | BaseObject;
 
 /**
+ * Matches one space-separated token in `data-test-subj`, not the whole
+ * attribute value. `getByTestId` does an exact match and misses components
+ * like `EuiColorPicker` that add their own token to the consumer's subj.
+ */
+const testSubjSelector = (testSubj: string): string =>
+  `[data-test-subj~="${testSubj.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`;
+
+/**
  * Base class for Playwright Component Objects — semantic wrappers around a
  * single root `Locator` resolved from a `data-test-subj` inside the given
  * scope. Subclasses compose: pass another Component Object as `scope` to
  * nest one inside the other's DOM subtree.
+ *
+ * `testSubj` matches one space-separated token of `data-test-subj`, following
+ * Kibana's convention (see `@kbn/test-subj-selector`).
  *
  * Requires `testIdAttribute: 'data-test-subj'` in the Playwright config.
  */
@@ -45,7 +56,7 @@ export abstract class BaseObject {
 
   constructor(scope: ObjectScope, testSubj: string, componentSelector?: string) {
     this.scope = scope instanceof BaseObject ? scope.locator : scope;
-    this.root = this.scope.getByTestId(testSubj);
+    this.root = this.scope.locator(testSubjSelector(testSubj));
     this.testSubj = testSubj;
     this.componentSelector = componentSelector;
 


### PR DESCRIPTION
## Summary

`BaseObject` resolved its root with `getByTestId`, which requires the whole `data-test-subj` value to equal `testSubj`. Kibana's convention allows several space-separated tokens in one `data-test-subj` (this is why `@kbn/test-subj-selector` matches with `~=`), and some EUI components rely on it. `EuiColorPicker` renders its anchor as `data-test-subj="euiColorPickerAnchor <consumerSubj>"`, so `getByTestId(consumerSubj)` finds nothing and no Component Object could target it.

The root now resolves with `[data-test-subj~="<testSubj>"]`, which matches one token of the attribute. Single-token subjs behave exactly as before.

## Scope

Only the root lookup changes. The `getByTestId` calls inside `combo_box`, `datagrid`, `toast` and `flyout` target fixed EUI-owned subjs that are never composed, so they are left as they were.

## Validation

- Full test-helpers suite passes (93 specs) plus two new `BaseObject` specs: one proves a token inside a multi-token value matches, one proves a substring of a token does not.
- Built the package locally and swapped it into a Kibana checkout, then ran Scout specs from three plugins against a live stack: index_management (6 passed, `comboBox`), canvas (1 passed, `comboBox`), triggers_actions_ui (8 passed, `basicTable`).
- Grepped Kibana for every multi-token `data-test-subj` value and confirmed none of their tokens is passed to a Component Object anywhere, so the broader match cannot create a strict-mode collision in current consumers.

This unblocks an `EuiColorPickerObject` as a follow-up.
