### PR TITLE
[Chore] Update documentation and CI

### DIFF
--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           set -euo pipefail
           corepack enable
-          pnpm_ver="$(node -pe "require('./package.json').engines.pnpm.replace(/^\D*/, '')")"
+          pnpm_ver="$(node -pe 'require("./package.json").engines.pnpm.replace(/^[^0-9]*/, "")')"
           corepack prepare "pnpm@${pnpm_ver}" --activate
       - name: Fetch ephemeral GitHub token
         id: fetch_ephemeral_token

--- a/.github/workflows/update_kibana_dependencies__prepare_changes.yml
+++ b/.github/workflows/update_kibana_dependencies__prepare_changes.yml
@@ -82,6 +82,13 @@ jobs:
         with:
           node-version-file: .nvmrc
           package-manager-cache: false # Don't cache anything as it's a different repository
+      - name: Enable pnpm via corepack
+        # language=bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          pnpm_ver="$(node -pe "require('./package.json').engines.pnpm.replace(/^\D*/, '')")"
+          corepack prepare "pnpm@${pnpm_ver}" --activate
       - name: Fetch ephemeral GitHub token
         id: fetch_ephemeral_token
         uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3
@@ -252,7 +259,7 @@ jobs:
             echo "bootstrap failed (attempt ${attempt}/5); retrying in 60s"
             sleep 60
           done
-          node scripts/yarn_deduplicate
+          node scripts/deduplicate_dependencies
           yarn kbn bootstrap --force-install
       - name: Sync EUI i18n tokens
         env:
@@ -298,7 +305,7 @@ jobs:
       - name: Commit changed files
         # language=bash
         run: |
-          git add package.json yarn.lock src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
+          git add package.json pnpm-lock.yaml src/platform/packages/private/kbn-ui-shared-deps-npm/version_dependencies.txt
           git commit -m "chore: update dependencies"
       - name: Push branch to elastic/eui-kibana
         env:

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -570,7 +570,7 @@ To test the local changes to the plugin, you must:
 3. Build the package: `yarn build`
 4. Run `yalc publish` in the plugin's directory to publish it locally.
 5. In your project's directory, run `yalc add @elastic/eslint-plugin-eui` to link the locally published package.
-6. Install dependencies: `yarn` (if you're a Kibana contributor, run `yarn kbn bootstrap --no-validate`).
+6. Install dependencies using your package manager.
 7. After making further changes to the plugin, repeat the steps from 3.
 
 ## Publishing

--- a/packages/illustrations/README.md
+++ b/packages/illustrations/README.md
@@ -109,7 +109,7 @@ yarn release:publish
 
 ## Testing local changes in Kibana
 
-`yarn link` does **not** work between EUI and Kibana because Kibana is on Yarn v1 while this repo is on Yarn v4.
+`yarn link` does **not** work between EUI and Kibana because Kibana isn't on Yarn v4 like this repo. It doesn't benefit from [linking](https://yarnpkg.com/protocol/link) or [portaling](https://yarnpkg.com/protocol/portal).
 
 Instead, build a tarball and point Kibana at it with the `file:` protocol (same flow as `@elastic/eui`, see the EUI wiki: [_Testing EUI features in Kibana_](../../wiki/contributing-to-eui/testing/testing-in-kibana.md)).
 
@@ -132,6 +132,6 @@ Then in Kibana's root `package.json`:
 yarn kbn bootstrap --no-validate && yarn start
 ```
 
-After each change, re-run `yarn build-pack` and **rename** the `.tgz` (e.g. `…-1.0.0-1.tgz`, `…-1.0.0-2.tgz`) so Yarn picks up the new contents, then update the `file:` path and re-bootstrap.
+After each change, re-run `yarn build-pack` and **rename** the `.tgz` (e.g. `…-1.0.0-1.tgz`, `…-1.0.0-2.tgz`) so the package manager picks up the new contents, then update the `file:` path and re-bootstrap.
 
 FUTURE NOTE: there exists "Watch mode" for EUI for live-editing but it doesn't include this new package _yet_.

--- a/wiki/contributing-to-eui/developing/developing-in-kibana.md
+++ b/wiki/contributing-to-eui/developing/developing-in-kibana.md
@@ -19,6 +19,8 @@ This guide explains how to develop EUI library locally while seeing changes refl
   git clone https://github.com/<your-username>/kibana.git
   cd kibana
   nvm use
+  corepack enable
+  corepack prepare pnpm@$(node -pe "require('./package.json').engines.pnpm.replace(/^\D*/, '')") --activate
   yarn kbn bootstrap
   ```
 - (Optional) EUI and Kibana should be sibling directories for simplest DX:

--- a/wiki/contributing-to-eui/testing/testing-in-kibana.md
+++ b/wiki/contributing-to-eui/testing/testing-in-kibana.md
@@ -33,7 +33,7 @@ Keep staged commits atomic to simplify cherry-picking for the upgrader:
 
 ## Testing local EUI in local Kibana
 
-`yarn link` doesn't work between EUI and Kibana — Kibana is on Yarn v1 while EUI is on Yarn v4, and the two are not interoperable. Instead, you have two options depending on your goal:
+`yarn link` doesn't work between EUI and Kibana - EUI is on Yarn v4 and Kibana isn't, and their package manager (and its version) is not interoperable with ours. Instead, you have two options depending on your goal:
 
 - For **local development** against a Kibana instance running on your machine, use the [`yarn watch --kibana`](../developing/developing-in-kibana.md) watcher.
 - For **CI validation** — opening a Kibana draft PR so Kibana's CI runs against your EUI changes — use `yarn build-pack` (described below) to produce a `.tgz` that you commit to the Kibana PR.
@@ -78,7 +78,7 @@ yarn kbn bootstrap --no-validate && yarn start
 ```
 
 * The `--no-validate` flag is required when bootstrapping with a `.tgz`.
-  * Change the name of the `.tgz` after subsequent `yarn build-pack` steps (e.g., `elastic-eui-xx.x.x-1.tgz`, `elastic-eui-xx.x.x-2.tgz`). This is required for `yarn` to recognize new changes to the package.
+  * Change the name of the `.tgz` after subsequent `yarn build-pack` steps (e.g., `elastic-eui-xx.x.x-1.tgz`, `elastic-eui-xx.x.x-2.tgz`). This is required for the package manager to recognize new changes to the package.
 * Running Kibana with `yarn start` ensures it starts in dev mode and doesn't use a previously cached version of EUI.
 
 ### Deploying local EUI in Kibana
@@ -101,8 +101,8 @@ Elastic engineers have the option to deploy a local EUI package in Kibana. To do
 
 ```
 
-- Run `yarn kbn bootstrap`
-- Commit the changed files (`package.json`. `yarn.lock` and EUI `.tgz` package) and push your branch
+- Run `yarn kbn bootstrap` (requires pnpm on PATH — see [Developing EUI locally in Kibana](../developing/developing-in-kibana.md))
+- Commit the changed files (`package.json`, `pnpm-lock.yaml` and EUI `.tgz` package) and push your branch
 - Create a Kibana (draft) pull request
   - Kibana CI will run tests on this instance with your custom EUI package
   - To ensure CI works correctly, you'll need to add `@elastic/eui-theme-common` to `packages/kbn-dependency-ownership/src/rule.ts` ([example](https://github.com/elastic/kibana/pull/227054/files)) and `src/dev/license_checker/config.ts` ([example](https://github.com/elastic/kibana/pull/227054/files#diff-373e937e773b0370ab1d28f3cf90251dcbd3cf95546f8c54b6bb6b1f999999dcR96))


### PR DESCRIPTION
<!--
NOTE:
- If this is your first PR in the EUI repo, please ensure you've fully read through our [contributing to EUI](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/README.md) wiki guide.
- Ask @eui-team if you need help.
-->

## Summary

<!--
- **What:** What changed.
- **Why:** Link to issue (e.g. Fixes #123) and/or briefly explain motivation.
- **How:** Implementation approach and any non-obvious decisions for reviewers.
- Any other context to help reviewers.
-->

- Kibana `main` now installs with pnpm ([elastic/kibana#284611](https://github.com/elastic/kibana/pull/284611)). Yarn 1 still runs scripts; `yarn_deduplicate` / `yarn.lock` are gone.
- Enable pnpm via corepack in the Kibana regression workflow, switch dedupe to `node scripts/deduplicate_dependencies`  and commit `pnpm-lock.yaml`.
- Update Kibana testing/dev docs so local bootstrap matches.

### QA

- [ ] Verify the bootstrap step no longer calls `yarn_deduplicate)` and commits `pnpm-lock.yaml`.
- [ ] Skim `wiki/contributing-to-eui/developing/developing-in-kibana.md` - first Kibana clone includes `corepack enable` / `corepack prepare` before `yarn kbn bootstrap`.
- [ ] Skim `wiki/contributing-to-eui/testing/testing-in-kibana.md` - lockfile is `pnpm-lock.yaml`.