### PR TITLE
[test-helpers] Add EuiColorPickerObject

### DIFF
--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -59,6 +59,7 @@ their own version at runtime.
 | `EuiAccordionObject` | [src/components/accordion/README.md](src/components/accordion/README.md) |
 | `EuiModalObject` | [src/components/modal/README.md](src/components/modal/README.md) |
 | `EuiBasicTableObject` | [src/components/basic_table/README.md](src/components/basic_table/README.md) |
+| `EuiColorPickerObject` | [src/components/color_picker/README.md](src/components/color_picker/README.md) |
 
 ## Contributing
 

--- a/packages/test-helpers/changelogs/upcoming/10020.md
+++ b/packages/test-helpers/changelogs/upcoming/10020.md
@@ -1,0 +1,1 @@
+- Added `EuiColorPickerObject`, a Playwright Component Object for `EuiColorPicker`

--- a/packages/test-helpers/src/components/color_picker/README.md
+++ b/packages/test-helpers/src/components/color_picker/README.md
@@ -1,0 +1,30 @@
+# EuiColorPickerObject
+
+Playwright Component Object for [EuiColorPicker](https://eui.elastic.co/docs/components/forms/color-picker/).
+
+## Usage
+
+```ts
+import { EuiColorPickerObject } from '@elastic/eui-test-helpers';
+
+const colorPicker = new EuiColorPickerObject(page, 'myColorPicker');
+await colorPicker.locator.click();
+await colorPicker.swatches.first().click();
+```
+
+Set `data-test-subj` on `EuiColorPicker` itself. `EuiColorPicker` renders it on its anchor as `euiColorPickerAnchor <yourSubj>`, a compound value the shared root lookup matches by token. Without that, `getByTestId` on your own subj finds nothing.
+
+## API
+
+| Member | Description |
+|---|---|
+| `panel` | `Locator` for the popover panel. Rendered in a portal, so it is found on the page, not under the anchor. Resolves to zero elements while closed, and gets `data-popover-open="true"` once open. |
+| `swatches` | `Locator` for the swatch buttons inside `panel`. |
+
+`locator` is the anchor, a plain text input. Click it to open the picker, and use Playwright's own `inputValue()`/`fill()` to read or set the color.
+
+## Deliberately out of scope
+
+- **A custom `button` prop**: only the default text-input anchor has a class the component-type guard can rely on. A custom button has none, so it is not supported.
+- **`open()`/`close()` methods**: `EuiPopover` only sets `aria-expanded`/`aria-controls` on button-like toggles, and the default anchor is an input, so the signal `EuiPopoverObject` relies on is missing. Click `locator` and assert on `panel` instead.
+- **Several pickers open at once**: `panel` is found by class on the page, so two open pickers would both match. No consumer has needed this.

--- a/packages/test-helpers/src/components/color_picker/selectors.ts
+++ b/packages/test-helpers/src/components/color_picker/selectors.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/forms/color-picker/|EuiColorPicker}.
+ * `*_SELECTOR` values are CSS.
+ */
+export const EuiColorPickerSelectors = {
+  /** The default text-input anchor. A custom `button` prop has no class of its own. */
+  ANCHOR_SELECTOR: '.euiColorPicker__input',
+
+  /** The popover panel, rendered in a portal and only while open. */
+  PANEL_SELECTOR: '[data-popover-panel].euiColorPicker__popoverPanel',
+
+  /** A swatch button inside the panel. */
+  SWATCH_SELECTOR: '.euiColorPickerSwatch',
+};

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -20,3 +20,4 @@ export { EuiFlyoutObject } from './playwright/components/flyout/object';
 export { EuiAccordionObject } from './playwright/components/accordion/object';
 export { EuiModalObject } from './playwright/components/modal/object';
 export { EuiBasicTableObject } from './playwright/components/basic_table/object';
+export { EuiColorPickerObject } from './playwright/components/color_picker/object';

--- a/packages/test-helpers/src/playwright/components/color_picker/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/color_picker/object.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiColorPickerObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+/**
+ * Validates `EuiColorPickerObject` against the live component in EUI
+ * Storybook. `EuiColorPicker` sets its anchor's `data-test-subj` to
+ * `euiColorPickerAnchor <consumerSubj>`, which only the token-matching root
+ * in the base class resolves.
+ */
+
+const TEST_SUBJ = 'testColorPicker';
+
+const PLAYGROUND_URL = storyUrl(
+  'forms-euicolorpicker-euicolorpicker--playground',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiColorPickerObject', () => {
+  let colorPicker: EuiColorPickerObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    colorPicker = new EuiColorPickerObject(page, TEST_SUBJ);
+    await colorPicker.locator.waitFor({ state: 'visible' });
+  });
+
+  test('resolves to exactly one element despite the compound data-test-subj', async () => {
+    await expect(colorPicker.locator).toHaveCount(1);
+  });
+
+  test('panel and swatches resolve only while open', async () => {
+    await expect(colorPicker.panel).toHaveCount(0);
+
+    await colorPicker.locator.click();
+
+    await expect(colorPicker.panel).toHaveAttribute('data-popover-open', 'true');
+    // The Playground story uses the default palette, so at least one swatch renders.
+    await expect(colorPicker.swatches.first()).toBeVisible();
+  });
+});

--- a/packages/test-helpers/src/playwright/components/color_picker/object.ts
+++ b/packages/test-helpers/src/playwright/components/color_picker/object.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiColorPickerSelectors } from '../../../components/color_picker/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/forms/color-picker/ EuiColorPicker}.
+ *
+ * `testSubj` must be set on `EuiColorPicker` itself. Covers only the default
+ * text-input anchor, not a custom `button` prop. See the package README for
+ * what this does not cover.
+ */
+export class EuiColorPickerObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiColorPickerSelectors.ANCHOR_SELECTOR);
+  }
+
+  /**
+   * The popover panel. Rendered in a portal, so it is found on the page, not
+   * under the anchor. Resolves to zero elements while closed.
+   */
+  public get panel(): Locator {
+    return this.root.page().locator(EuiColorPickerSelectors.PANEL_SELECTOR);
+  }
+
+  /** The swatch buttons inside {@link panel}. */
+  public get swatches(): Locator {
+    return this.panel.locator(EuiColorPickerSelectors.SWATCH_SELECTOR);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `EuiColorPickerObject`, a Playwright Component Object for `EuiColorPicker`.

`EuiColorPicker` renders the consumer's `data-test-subj` on its anchor as `euiColorPickerAnchor <subj>`. Until #10015 no Component Object could target it. This object builds on that fix.

## API

- `panel`: the popover panel, found on the page since it renders in a portal. Zero elements while closed.
- `swatches`: the swatch buttons inside `panel`.

`locator` is the anchor input itself, so opening, reading and filling the color go through Playwright's own methods.

## Not covered, and why

- No `open()`/`close()`. `EuiPopover` only sets `aria-expanded`/`aria-controls` on button-like toggles, and the default anchor is an input, so the signal `EuiPopoverObject` relies on is not there. Documented in the README.
- A custom `button` prop. It has no class the component-type guard can check.
- Several pickers open at the same time. `panel` matches by class on the page.

## Validation

Specs run against the existing Playground story, no story changes. Full package suite passes.
