### PR TITLE
[eslint] Update `button-group-no-invalid-children` rule to support custom wrappers

### DIFF
--- a/packages/eslint-plugin/changelogs/upcoming/10024.md
+++ b/packages/eslint-plugin/changelogs/upcoming/10024.md
@@ -1,0 +1,1 @@
+- Updated `button-group-no-invalid-children` rule to support `additionalWrappers` option

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.test.ts
@@ -13,6 +13,7 @@ import {
   VALID_BUTTONS,
   SEGMENTED_VALID_BUTTONS,
   SELECTION_VALID_BUTTONS,
+  VALID_WRAPPERS,
 } from '../utils/button_group_constants';
 
 const languageOptions = {
@@ -26,6 +27,7 @@ const languageOptions = {
 const DEFAULT_ALLOWED = Array.from(VALID_BUTTONS).join(', ');
 const SEGMENTED_ALLOWED = Array.from(SEGMENTED_VALID_BUTTONS).join(', ');
 const SELECTION_ALLOWED = Array.from(SELECTION_VALID_BUTTONS).join(', ');
+const DEFAULT_WRAPPERS = Array.from(VALID_WRAPPERS).join(', ');
 
 const ruleTester = new RuleTester();
 
@@ -804,6 +806,91 @@ ruleTester.run(
         `,
         languageOptions,
       },
+
+      // additionalWrappers
+      {
+        name: 'additional wrapper with valid button child is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <MyTooltipWrapper content="tip">
+              <EuiButton>Save</EuiButton>
+            </MyTooltipWrapper>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+      },
+      {
+        name: 'additional wrapper with valid button icon child is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <EuiButton>Normal</EuiButton>
+            <MyTooltipWrapper content="tip">
+              <EuiButtonIcon iconType="trash" aria-label="Delete" />
+            </MyTooltipWrapper>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+      },
+      {
+        name: 'multiple additional wrappers are each accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <WrapperA content="a">
+              <EuiButton>A</EuiButton>
+            </WrapperA>
+            <WrapperB content="b">
+              <EuiButtonIcon iconType="plus" aria-label="Add" />
+            </WrapperB>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['WrapperA', 'WrapperB'] }],
+      },
+      {
+        name: 'variant="segmented" with additional wrapper and valid EuiButton is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <MyTooltipWrapper content="tip">
+              <EuiButton>Delete</EuiButton>
+            </MyTooltipWrapper>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+      },
+      {
+        name: 'configured additional wrapper nested inside EuiToolTip with valid button is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <EuiToolTip content="tip">
+              <MyTooltipWrapper>
+                <EuiButtonIcon iconType="trash" aria-label="Delete" />
+              </MyTooltipWrapper>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+      },
+      {
+        name: 'configured additional wrapper as EuiPopover trigger with valid button is accepted',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <EuiPopover
+              button={<MyTooltipWrapper><EuiButtonIcon iconType="trash" aria-label="Delete" /></MyTooltipWrapper>}
+              isOpen={false}
+              closePopover={() => {}}
+            >
+              Panel content
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+      },
     ],
 
     invalid: [
@@ -819,7 +906,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'div',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -836,7 +927,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiFlexGroup', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiFlexGroup',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -853,11 +948,19 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'span', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'span',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1026,31 +1129,6 @@ ruleTester.run(
         ],
       },
 
-      // Invalid wrapper children
-      {
-        name: 'non-button inside EuiToolTip',
-        code: dedent`
-          <EuiButtonGroup legend="Actions">
-            <EuiToolTip content="tip">
-              <EuiFlexGroup>
-                <EuiButtonIcon iconType="trash" aria-label="Delete" />
-              </EuiFlexGroup>
-            </EuiToolTip>
-          </EuiButtonGroup>
-        `,
-        languageOptions,
-        errors: [
-          {
-            messageId: 'invalidUnresolvableWrapperChild',
-            data: {
-              name: 'EuiFlexGroup',
-              wrapper: 'EuiToolTip',
-              allowed: DEFAULT_ALLOWED,
-            },
-          },
-        ],
-      },
-
       // EuiToolTip
       {
         name: 'conditional inside EuiToolTip with one invalid branch',
@@ -1098,6 +1176,164 @@ ruleTester.run(
         ],
       },
 
+      // Invalid wrapper children
+      {
+        name: 'non-button inside EuiToolTip',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <EuiToolTip content="tip">
+              <EuiFlexGroup>
+                <EuiButtonIcon iconType="trash" aria-label="Delete" />
+              </EuiFlexGroup>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableWrapperChild',
+            data: {
+              name: 'EuiFlexGroup',
+              wrapper: 'EuiToolTip',
+              allowed: DEFAULT_ALLOWED,
+            },
+          },
+        ],
+      },
+
+      // additionalWrappers
+      {
+        name: 'configured additional wrapper as EuiPopover trigger with invalid child is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <EuiPopover
+              button={<MyTooltipWrapper><EuiText>Not a button</EuiText></MyTooltipWrapper>}
+              isOpen={false}
+              closePopover={() => {}}
+            >
+              Panel content
+            </EuiPopover>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableWrapperChild',
+            data: {
+              name: 'EuiText',
+              wrapper: 'MyTooltipWrapper',
+              allowed: DEFAULT_ALLOWED,
+            },
+          },
+        ],
+      },
+      {
+        name: 'configured additional wrapper nested inside EuiToolTip with invalid child is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <EuiToolTip content="tip">
+              <MyTooltipWrapper>
+                <EuiText>Not a button</EuiText>
+              </MyTooltipWrapper>
+            </EuiToolTip>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableWrapperChild',
+            data: {
+              name: 'EuiText',
+              wrapper: 'MyTooltipWrapper',
+              allowed: DEFAULT_ALLOWED,
+            },
+          },
+        ],
+      },
+      {
+        name: 'configured additional wrapper with invalid child is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <MyTooltipWrapper content="tip">
+              <EuiText>Not a button</EuiText>
+            </MyTooltipWrapper>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+        errors: [
+          {
+            messageId: 'invalidUnresolvableWrapperChild',
+            data: {
+              name: 'EuiText',
+              wrapper: 'MyTooltipWrapper',
+              allowed: DEFAULT_ALLOWED,
+            },
+          },
+        ],
+      },
+      {
+        name: 'configured additional wrapper with plain HTML child is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <MyTooltipWrapper content="tip">
+              <div>Not a button</div>
+            </MyTooltipWrapper>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+        errors: [
+          {
+            messageId: 'invalidWrapperChild',
+            data: {
+              name: 'div',
+              wrapper: 'MyTooltipWrapper',
+              allowed: DEFAULT_ALLOWED,
+            },
+          },
+        ],
+      },
+      {
+        name: 'unconfigured wrapper is still rejected as invalidUnresolvableChild',
+        code: dedent`
+          <EuiButtonGroup legend="Actions">
+            <MyTooltipWrapper content="tip">
+              <EuiButton>Save</EuiButton>
+            </MyTooltipWrapper>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        errors: [
+          {
+            messageId: 'invalidUnresolvableChild',
+            data: {
+              name: 'MyTooltipWrapper',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
+          },
+        ],
+      },
+      {
+        name: 'variant="segmented" with configured additional wrapper mixing button types is reported',
+        code: dedent`
+          <EuiButtonGroup legend="Actions" variant="segmented">
+            <EuiButton>Save</EuiButton>
+            <MyTooltipWrapper content="tip">
+              <EuiButtonIcon iconType="trash" aria-label="Delete" />
+            </MyTooltipWrapper>
+          </EuiButtonGroup>
+        `,
+        languageOptions,
+        options: [{ additionalWrappers: ['MyTooltipWrapper'] }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'segmented' } },
+        ],
+      },
+
       // Fragments
       {
         name: 'shorthand fragment wrapping invalid element',
@@ -1113,7 +1349,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1130,7 +1370,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'div',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1147,7 +1391,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1188,7 +1436,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1203,7 +1455,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1218,11 +1474,19 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiBadge', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiBadge',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1238,7 +1502,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1253,7 +1521,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1269,7 +1541,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1331,7 +1607,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1350,7 +1630,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1368,7 +1652,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1384,7 +1672,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1403,7 +1695,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1418,7 +1714,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'SaveButton', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'SaveButton',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1438,7 +1738,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1478,7 +1782,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'div',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1495,7 +1803,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'div',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1513,7 +1825,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1529,7 +1845,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'div', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'div',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1596,7 +1916,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: DEFAULT_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: DEFAULT_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1613,7 +1937,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
+            data: {
+              name: 'EuiButtonEmpty',
+              allowed: SEGMENTED_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1628,7 +1956,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'div', allowed: SEGMENTED_ALLOWED },
+            data: {
+              name: 'div',
+              allowed: SEGMENTED_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1644,7 +1976,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: SEGMENTED_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: SEGMENTED_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1662,7 +1998,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'EuiButtonEmpty', allowed: SEGMENTED_ALLOWED },
+            data: {
+              name: 'EuiButtonEmpty',
+              allowed: SEGMENTED_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1677,7 +2017,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'SaveButton', allowed: SEGMENTED_ALLOWED },
+            data: {
+              name: 'SaveButton',
+              allowed: SEGMENTED_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1808,7 +2152,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'segmented' } },
+        ],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon inside a fragment is reported',
@@ -1821,7 +2167,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'segmented' } },
+        ],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiToolTip is reported',
@@ -1834,7 +2182,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'segmented' } },
+        ],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiPopover trigger is reported',
@@ -1847,7 +2197,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'segmented' } },
+        ],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiPopover with EuiToolTip-wrapped trigger is reported',
@@ -1864,7 +2216,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'segmented' } },
+        ],
       },
       {
         name: 'variant="segmented" mixing EuiButton and EuiButtonIcon via EuiCopy render prop is reported',
@@ -1877,7 +2231,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'segmented' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'segmented' } },
+        ],
       },
 
       // variant="selection"
@@ -1892,7 +2248,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'EuiButtonEmpty', allowed: SELECTION_ALLOWED },
+            data: {
+              name: 'EuiButtonEmpty',
+              allowed: SELECTION_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1907,7 +2267,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidChild',
-            data: { name: 'div', allowed: SELECTION_ALLOWED },
+            data: {
+              name: 'div',
+              allowed: SELECTION_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1923,7 +2287,11 @@ ruleTester.run(
         errors: [
           {
             messageId: 'invalidUnresolvableChild',
-            data: { name: 'EuiText', allowed: SELECTION_ALLOWED },
+            data: {
+              name: 'EuiText',
+              allowed: SELECTION_ALLOWED,
+              wrappers: DEFAULT_WRAPPERS,
+            },
           },
         ],
       },
@@ -1957,7 +2325,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'selection' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'selection' } },
+        ],
       },
       {
         name: 'variant="selection" mixing EuiButton and EuiButtonIcon inside a fragment is reported',
@@ -1970,7 +2340,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'selection' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'selection' } },
+        ],
       },
       {
         name: 'variant="selection" mixing EuiButton and EuiButtonIcon via EuiToolTip is reported',
@@ -1983,7 +2355,9 @@ ruleTester.run(
           </EuiButtonGroup>
         `,
         languageOptions,
-        errors: [{ messageId: 'invalidMixedTypes', data: { variant: 'selection' } }],
+        errors: [
+          { messageId: 'invalidMixedTypes', data: { variant: 'selection' } },
+        ],
       },
     ],
   }

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
@@ -38,6 +38,7 @@ function reportInvalidWrapperChildren<
   context: TContext,
   validButtons: Set<string>,
   allowed: string,
+  allowedWrappers: Set<string>,
   seenButtonTypes?: Set<string>
 ): void {
   const children = flatMap(wrapper.children, (c) =>
@@ -54,6 +55,24 @@ function reportInvalidWrapperChildren<
       seenButtonTypes?.add(wrapperChildName);
       continue;
     }
+
+    // Recurse into configured additional wrappers
+    if (
+      allowedWrappers.has(wrapperChildName) &&
+      !VALID_WRAPPERS.has(wrapperChildName)
+    ) {
+      reportInvalidWrapperChildren(
+        wrapperChild,
+        wrapperChildName,
+        context,
+        validButtons,
+        allowed,
+        allowedWrappers,
+        seenButtonTypes
+      );
+      continue;
+    }
+
     context.report({
       node: wrapperChild.openingElement,
       messageId:
@@ -68,7 +87,12 @@ function reportInvalidWrapperChildren<
 
 export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
   {
-    create(context) {
+    create(context, [{ additionalWrappers }]) {
+      const allowedWrappers =
+        additionalWrappers.length > 0
+          ? new Set(Array.from(VALID_WRAPPERS).concat(additionalWrappers))
+          : VALID_WRAPPERS;
+
       return {
         JSXElement(node) {
           const { openingElement } = node;
@@ -123,7 +147,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
               continue;
             }
 
-            if (VALID_WRAPPERS.has(name)) {
+            if (allowedWrappers.has(name)) {
               if (name === 'EuiToolTip') {
                 // Validate JSX children (expanding fragments/conditionals).
                 // Also collects button types for the segmented mixed-type check.
@@ -133,6 +157,7 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                   context,
                   validButtons,
                   allowed,
+                  allowedWrappers,
                   seenButtonTypes ?? undefined
                 );
               } else if (name === 'EuiPopover') {
@@ -202,6 +227,24 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                       }
                       continue;
                     }
+
+                    if (
+                      allowedWrappers.has(triggerElementName) &&
+                      !VALID_WRAPPERS.has(triggerElementName)
+                    ) {
+                      // Additional wrappers as popover triggers
+                      reportInvalidWrapperChildren(
+                        triggerElement,
+                        triggerElementName,
+                        context,
+                        validButtons,
+                        allowed,
+                        allowedWrappers,
+                        seenButtonTypes ?? undefined
+                      );
+                      continue;
+                    }
+
                     context.report({
                       node: triggerElement.openingElement,
                       messageId:
@@ -224,6 +267,18 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                   context,
                   validButtons,
                   allowed,
+                  allowedWrappers,
+                  seenButtonTypes ?? undefined
+                );
+              } else {
+                // Consumer-configured additional wrapper
+                reportInvalidWrapperChildren(
+                  child,
+                  name,
+                  context,
+                  validButtons,
+                  allowed,
+                  allowedWrappers,
                   seenButtonTypes ?? undefined
                 );
               }
@@ -240,7 +295,11 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
                 isCustomComponent(name) && !VALID_BUTTONS.has(name)
                   ? 'invalidUnresolvableChild'
                   : 'invalidChild',
-              data: { name, allowed },
+              data: {
+                name,
+                allowed,
+                wrappers: Array.from(allowedWrappers).join(', '),
+              },
             });
           }
 
@@ -263,19 +322,31 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
     meta: {
       type: 'problem',
       docs: {
-        description: `Enforce that EuiButtonGroup children are valid button components, or a supported wrapper (${VALID_WRAPPERS_LIST})`,
+        description: `Enforce that EuiButtonGroup children are valid button components, or a supported wrapper (${VALID_WRAPPERS_LIST}). Additional wrappers can be configured via the additionalWrappers option.`,
       },
-      schema: [],
+      schema: [
+        {
+          type: 'object',
+          properties: {
+            additionalWrappers: {
+              type: 'array',
+              items: { type: 'string' },
+              uniqueItems: true,
+            },
+          },
+          additionalProperties: false,
+        },
+      ],
       messages: {
         invalidChild: [
           `{{ name }} is not a valid child of EuiButtonGroup.`,
           `Allowed children: {{ allowed }}.`,
-          `Allowed wrappers: ${VALID_WRAPPERS_LIST}.`,
+          `Allowed wrappers: {{ wrappers }}.`,
         ].join(' '),
         invalidUnresolvableChild: [
           `{{ name }} cannot be verified as a valid child of EuiButtonGroup.`,
           `Allowed children: {{ allowed }}.`,
-          `Allowed wrappers: ${VALID_WRAPPERS_LIST}.`,
+          `Allowed wrappers: {{ wrappers }}.`,
           `If {{ name }} is a shared button wrapper component only containing`,
           `valid button children, suppress this rule inline with a comment`,
           `explaining why it's valid.`,
@@ -310,6 +381,6 @@ export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
         ].join(' '),
       },
     },
-    defaultOptions: [],
+    defaultOptions: [{ additionalWrappers: [] as string[] }],
   }
 );

--- a/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
+++ b/packages/eslint-plugin/src/rules/button_group_no_invalid_children.ts
@@ -87,7 +87,7 @@ function reportInvalidWrapperChildren<
 
 export const ButtonGroupNoInvalidChildren = ESLintUtils.RuleCreator.withoutDocs(
   {
-    create(context, [{ additionalWrappers }]) {
+    create(context, [{ additionalWrappers = [] }]) {
       const allowedWrappers =
         additionalWrappers.length > 0
           ? new Set(Array.from(VALID_WRAPPERS).concat(additionalWrappers))


### PR DESCRIPTION
## Summary

- **What**: Extends the `button-group-no-invalid-children` ESLint rule with an `additionalWrappers` option, letting consumers declare project-specific wrapper components as valid children of `EuiButtonGroup`
- **Why**: There can be valid custom wrappers on consumer side that only return the children (e.g. like Suspense) or even safe custom wrappers that add DOM elements but don't interfere with the button group. To support general valid cases without consumers having to disable the errors manually via comments, we can provide this additional options.
- **How**: Adds an `additionalWrappers` option that allows consumers to define additional safe wrappers.

Usage
```ts
// eslint.config.js
"@elastic/eui/button-group-no-invalid-children": ["error", {
  additionalWrappers: ["CustomWrapper"]
}]
```

✅ valid
```tsx
<EuiButtonGroup legend="Actions">
  <CustomWrapper content="Delete">
    <EuiButtonIcon iconType="trash" aria-label="Delete" />
  </CustomWrapper>
</EuiButtonGroup>

<EuiButtonGroup legend="Actions">
  <EuiToolTip content="tip">
    <CustomWrapper>
      <EuiText>Not a button</EuiText>
    </CustomWrapper>
  </EuiToolTip>
</EuiButtonGroup>
```

❌ invalid
```tsx
<EuiButtonGroup legend="Actions">
  <CustomWrapper content="Delete">
    <div>Not a button</div>
  </CustomWrapper>
</EuiButtonGroup>

<EuiButtonGroup legend="Actions">
  <EuiToolTip content="tip">
    <CustomWrapper>
      <EuiText>Not a button</EuiText>
    </CustomWrapper>
  </EuiToolTip>
</EuiButtonGroup>
```

Known limitations

- Member-expression component names (<React.Suspense>, <UI.Foo>) cannot be configured — `getElementName` returns `null` are already silently skipped by the rule. Only `JSXIdentifier` names (e.g. Suspense, MyWrapper) work.

### API Changes

⚪ No API changes

## Screenshots

<!-- Useful for review and release notes -- most PRs should provide these. -->


| Before         | After         |
| -------------- | ------------- |
| {Before image} | {After image} |


## Impact Assessment

<!-- Help reviewers understand the consumer impact of merging this PR. -->

Note: Most PRs should be [tested in Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md) to help gauge their **Impact** before merging.

- [ ] 🔴 **Breaking changes** — What will break? How many usages in Kibana/Cloud UI are impacted?
- [ ] 💅 **Visual changes** — May impact style overrides; could require visual testing. Explain and estimate impact.
- [ ] 🧪 **Test impact** — May break functional or snapshot tests (e.g., HTML structure, class names, default values).
- [ ] 🔧 **Hard to integrate** — If changes require substantial updates to Kibana, please [stage the changes](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md#staging-integrations) and link them here.

<!--
If this PR needs an accompanying Kibana change to keep the nightly integration test green, add the Kibana PR commit URL under `@next` in `packages/release-cli/kibana-prep-commits` (one URL per line). Nightly cherry-picks `@next` and `@previous`. On release, `@next` moves to `@previous` and `@previous` is cleared. Missing or already-applied commits are skipped.
-->

**Impact level:** 🟢 None

## Release Readiness

<!-- Ensure this PR is ready to ship. ~~cross out~~ items that don't apply. -->

- [ ] **Documentation:** {link to docs page(s)}
- [ ] **Figma:** {link to Figma or [issue](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/designing)}
- [ ] **Migration guide:** {steps or link, for breaking/visual changes or deprecations}
- [ ] **Adoption plan** (new features): {link to issue/doc or outline who will integrate this and where} <!-- We don't ship features without a plan for adoption. -->

### QA instructions for reviewer

<!-- 
Steps for reviewers to test this PR. Please, try to be as thorough as possible, remembering that the reviewer may not have the same context and knowledge as you have.

Ex.
- Open the table (basic/in-memory) demos in Storybook or docs.
- [ ] Confirm that **action buttons** (default row actions) have a **4px** gap between them.
- [ ] Confirm that **custom actions** (when used) still have an **8px** gap.
  -->

### Checklist before marking Ready for Review

<!-- ~~Cross out~~ items that don't apply. -->

- [ ] Filled out all sections above
- [ ] **QA:** Tested [light/dark modes, high contrast](https://devtoolstips.org/tips/en/emulate-forced-colors/), mobile, Chrome/Safari/Edge/Firefox, keyboard-only, screen reader
- [ ] **QA:** Tested in [CodeSandbox](https://codesandbox.io/) and [Kibana](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/testing-in-kibana.md)
- [ ] **QA:** Tested docs changes
- [ ] **Tests:** Added/updated [Jest](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/unit-testing.md), [Cypress](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/cypress-testing.md), and [VRT](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/testing/visual-regression-testing.md)
- [ ] **Changelog:** Added [changelog entry](https://github.com/elastic/eui/blob/main/wiki/contributing-to-eui/documenting/changelogs.md)
- [ ] **Breaking changes:** Added `breaking change` label (if applicable)

### Reviewer checklist

- [ ] Approved **Impact Assessment** — Acceptable to merge given the consumer impact.
- [ ] Approved **Release Readiness** — Docs, Figma, and migration info are sufficient to ship.
