### PR TITLE
[test-helpers] Add EuiTreeViewObject

### DIFF
--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -61,6 +61,7 @@ their own version at runtime.
 | `EuiModalObject` | [src/components/modal/README.md](src/components/modal/README.md) |
 | `EuiBasicTableObject` | [src/components/basic_table/README.md](src/components/basic_table/README.md) |
 | `EuiColorPickerObject` | [src/components/color_picker/README.md](src/components/color_picker/README.md) |
+| `EuiTreeViewObject` | [src/components/tree_view/README.md](src/components/tree_view/README.md) |
 
 ## Contributing
 

--- a/packages/test-helpers/changelogs/upcoming/10025.md
+++ b/packages/test-helpers/changelogs/upcoming/10025.md
@@ -1,0 +1,1 @@
+- Added `EuiTreeViewObject`, a Playwright Component Object for `EuiTreeView`

--- a/packages/test-helpers/src/components/tree_view/README.md
+++ b/packages/test-helpers/src/components/tree_view/README.md
@@ -1,0 +1,28 @@
+# EuiTreeViewObject
+
+Playwright Component Object for [EuiTreeView](https://eui.elastic.co/docs/components/navigation/tree-view/).
+
+## Usage
+
+```ts
+import { EuiTreeViewObject } from '@elastic/eui-test-helpers';
+
+const treeView = new EuiTreeViewObject(page, 'myTreeView');
+await treeView.items.filter({ hasText: 'Item One' }).click();
+await expect(treeView.items).toHaveCount(2);
+```
+
+Set `data-test-subj` on `EuiTreeView` itself, which the component-type guard verifies.
+
+## API
+
+| Member | Description |
+|---|---|
+| `items` | `Locator` for the node buttons of this level, in order. A node with children carries `aria-expanded`, which reflects open state synchronously. A leaf has no `aria-expanded`. |
+
+`items` reads direct children of the root only. A nested `EuiTreeView` renders its own `.euiTreeView` inside an expanded node, so a plain descendant search would mix levels.
+
+## Deliberately out of scope
+
+- **Nested levels**: `EuiTreeView` gives nested trees no `data-test-subj` of their own, so there is nothing to scope a second object to. Reach nested nodes through a plain locator under the expanded node until a consumer needs more.
+- **Expand and collapse methods**: clicking a node toggles it and `aria-expanded` updates synchronously, so `items.nth(i).click()` plus a retrying assertion is enough.

--- a/packages/test-helpers/src/components/tree_view/selectors.ts
+++ b/packages/test-helpers/src/components/tree_view/selectors.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/navigation/tree-view/|EuiTreeView}.
+ * `*_SELECTOR` values are CSS.
+ */
+export const EuiTreeViewSelectors = {
+  ROOT_SELECTOR: '.euiTreeView',
+
+  /** Node buttons of this level only. A nested tree renders its own `.euiTreeView` inside a node. */
+  ITEM_SELECTOR: '> li > .euiTreeView__nodeInner',
+};

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -22,3 +22,4 @@ export { EuiContextMenuObject } from './playwright/components/context_menu/objec
 export { EuiModalObject } from './playwright/components/modal/object';
 export { EuiBasicTableObject } from './playwright/components/basic_table/object';
 export { EuiColorPickerObject } from './playwright/components/color_picker/object';
+export { EuiTreeViewObject } from './playwright/components/tree_view/object';

--- a/packages/test-helpers/src/playwright/components/tree_view/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/tree_view/object.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiTreeViewObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+/**
+ * Validates `EuiTreeViewObject` against the live component in EUI Storybook.
+ * The Playground story has two top level nodes, the first expanded with
+ * nested children, so it covers the direct child scoping of `items`.
+ */
+
+const TEST_SUBJ = 'testTreeView';
+
+const PLAYGROUND_URL = storyUrl(
+  'navigation-euitreeview-euitreeview--playground',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiTreeViewObject', () => {
+  let treeView: EuiTreeViewObject;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(PLAYGROUND_URL);
+    await page.getByTestId(TEST_SUBJ).waitFor({ state: 'visible' });
+    treeView = new EuiTreeViewObject(page, TEST_SUBJ);
+  });
+
+  test('items returns only this level, not nested nodes', async () => {
+    const allNodes = treeView.locator.locator('.euiTreeView__nodeInner');
+    const topLevel = treeView.items;
+
+    await expect(topLevel).toHaveCount(2);
+    expect(await allNodes.count()).toBeGreaterThan(2);
+  });
+
+  test('items reflect expanded state through aria-expanded', async () => {
+    const first = treeView.items.first();
+
+    await expect(first).toHaveAttribute('aria-expanded', 'true');
+    await first.click();
+    await expect(first).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/packages/test-helpers/src/playwright/components/tree_view/object.ts
+++ b/packages/test-helpers/src/playwright/components/tree_view/object.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Locator } from '@playwright/test';
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiTreeViewSelectors } from '../../../components/tree_view/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/navigation/tree-view/ EuiTreeView}.
+ *
+ * `testSubj` must be set on `EuiTreeView` itself. See the package README for
+ * what this does not cover.
+ */
+export class EuiTreeViewObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiTreeViewSelectors.ROOT_SELECTOR);
+  }
+
+  /**
+   * The node buttons of this level, in order. A node with children carries
+   * `aria-expanded`, a leaf does not.
+   */
+  public get items(): Locator {
+    return this.root.locator(EuiTreeViewSelectors.ITEM_SELECTOR);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `EuiTreeViewObject`, a Playwright Component Object for `EuiTreeView`.

## API

- `items`: the node buttons of this level, in order. A node with children carries `aria-expanded`, a leaf does not.

`items` reads direct children of the root only. A nested `EuiTreeView` renders its own `.euiTreeView` inside an expanded node, so a plain descendant search would mix levels. The spec proves `items` returns the two top level nodes while the tree contains more.

## Not covered, and why

- Nested levels. EUI gives nested trees no `data-test-subj` of their own, so there is nothing to scope a second object to.
- Expand and collapse methods. Clicking a node toggles it and `aria-expanded` updates synchronously, so a click plus a retrying assertion is enough.

## Validation

Specs run against the existing Playground story, no story changes. Full package suite passes.
