### PR TITLE
[test-helpers] Add EuiToolTipObject

### DIFF
--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -61,6 +61,7 @@ their own version at runtime.
 | `EuiModalObject` | [src/components/modal/README.md](src/components/modal/README.md) |
 | `EuiBasicTableObject` | [src/components/basic_table/README.md](src/components/basic_table/README.md) |
 | `EuiColorPickerObject` | [src/components/color_picker/README.md](src/components/color_picker/README.md) |
+| `EuiToolTipObject` | [src/components/tool_tip/README.md](src/components/tool_tip/README.md) |
 
 ## Contributing
 

--- a/packages/test-helpers/changelogs/upcoming/10026.md
+++ b/packages/test-helpers/changelogs/upcoming/10026.md
@@ -1,0 +1,1 @@
+- Added `EuiToolTipObject`, a Playwright Component Object for `EuiToolTip`

--- a/packages/test-helpers/src/components/tool_tip/README.md
+++ b/packages/test-helpers/src/components/tool_tip/README.md
@@ -1,0 +1,24 @@
+# EuiToolTipObject
+
+Playwright Component Object for [EuiToolTip](https://eui.elastic.co/docs/components/display/tooltip/).
+
+## Usage
+
+```ts
+import { EuiToolTipObject } from '@elastic/eui-test-helpers';
+
+const toolTip = new EuiToolTipObject(page, 'myToolTip');
+await page.getByRole('button', { name: 'Save' }).hover();
+await expect(toolTip.locator).toHaveText('Saves the dashboard');
+```
+
+Set `data-test-subj` on `EuiToolTip` itself. EUI forwards it to the tooltip popover, not the trigger. The popover renders in a portal and is only mounted while shown, so `locator` resolves to zero elements until the trigger is hovered or focused, and again once it is not. Retrying assertions on `locator` cover both without a wait.
+
+## API
+
+This object exposes no members beyond `locator`. Showing and hiding go through the trigger with Playwright's own `hover()`, `focus()` and `blur()`.
+
+## Deliberately out of scope
+
+- **The trigger**: it is the consumer's own element, so target it directly. `EuiToolTip` only wraps it in a plain `span`.
+- **Hiding with Escape**: it bubbles to page level handlers such as modals and flyouts. Blur or move the mouse off the trigger instead.

--- a/packages/test-helpers/src/components/tool_tip/selectors.ts
+++ b/packages/test-helpers/src/components/tool_tip/selectors.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Stable selectors for
+ * {@link https://eui.elastic.co/docs/components/display/tooltip/|EuiToolTip}.
+ * `*_SELECTOR` values are CSS.
+ */
+export const EuiToolTipSelectors = {
+  /** The portaled tooltip. Only mounted while shown. */
+  ROOT_SELECTOR: '.euiToolTip[role="tooltip"]',
+};

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -22,3 +22,4 @@ export { EuiContextMenuObject } from './playwright/components/context_menu/objec
 export { EuiModalObject } from './playwright/components/modal/object';
 export { EuiBasicTableObject } from './playwright/components/basic_table/object';
 export { EuiColorPickerObject } from './playwright/components/color_picker/object';
+export { EuiToolTipObject } from './playwright/components/tool_tip/object';

--- a/packages/test-helpers/src/playwright/components/tool_tip/object.spec.ts
+++ b/packages/test-helpers/src/playwright/components/tool_tip/object.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { EuiToolTipObject } from './object';
+import { storyUrl } from '../../../storybook';
+
+/**
+ * Validates `EuiToolTipObject` against the live component in EUI Storybook.
+ * The Playground story gives the trigger `autoFocus`, so the tooltip is shown
+ * on load without an interaction.
+ */
+
+const TEST_SUBJ = 'testToolTip';
+
+const PLAYGROUND_URL = storyUrl(
+  'display-euitooltip--playground',
+  `data-test-subj:${TEST_SUBJ}`
+);
+
+test.describe('EuiToolTipObject', () => {
+  test('resolves to the portaled tooltip while shown and to nothing once hidden', async ({
+    page,
+  }) => {
+    await page.goto(PLAYGROUND_URL);
+    const toolTip = new EuiToolTipObject(page, TEST_SUBJ);
+    const trigger = page.getByRole('button', { name: 'Tooltip trigger' });
+
+    await expect(toolTip.locator).toHaveCount(1);
+    await expect(toolTip.locator).toHaveText('tooltip content');
+
+    await trigger.blur();
+    await expect(toolTip.locator).toHaveCount(0);
+
+    await trigger.hover();
+    await expect(toolTip.locator).toHaveCount(1);
+  });
+});

--- a/packages/test-helpers/src/playwright/components/tool_tip/object.ts
+++ b/packages/test-helpers/src/playwright/components/tool_tip/object.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { BaseObject, type ObjectScope } from '../../base_object';
+import { EuiToolTipSelectors } from '../../../components/tool_tip/selectors';
+
+/**
+ * Playwright Component Object for {@link
+ * https://eui.elastic.co/docs/components/display/tooltip/ EuiToolTip}.
+ *
+ * `testSubj` must be set on `EuiToolTip` itself. EUI forwards it to the
+ * tooltip popover, which renders in a portal and only while shown, so
+ * `locator` resolves to zero elements until the trigger is hovered or
+ * focused. See the package README for what this does not cover.
+ */
+export class EuiToolTipObject extends BaseObject {
+  constructor(scope: ObjectScope, testSubj: string) {
+    super(scope, testSubj, EuiToolTipSelectors.ROOT_SELECTOR);
+  }
+}


### PR DESCRIPTION
## Summary

Adds `EuiToolTipObject`, a Playwright Component Object for `EuiToolTip`.

`EuiToolTip` forwards the consumer's `data-test-subj` to the tooltip popover, not the trigger. The popover renders in a portal and is only mounted while shown, so `locator` resolves to zero elements until the trigger is hovered or focused. Retrying assertions on it cover both states without a wait.

## API

No members beyond `locator`. Showing and hiding go through the trigger with Playwright's own `hover()`, `focus()` and `blur()`.

## Not covered, and why

- The trigger. It is the consumer's own element wrapped in a plain `span`, so target it directly.
- Hiding with Escape. It bubbles to page level handlers such as modals and flyouts. The README points to `blur()` instead.

## Validation

Spec runs against the existing Playground story, no story changes. It checks the tooltip is present with its text on load, gone after `blur()`, and back after `hover()`. Full package suite passes.
